### PR TITLE
fix: firewall routing enforcement and live rule reload

### DIFF
--- a/containers/attack-base/entrypoint.sh
+++ b/containers/attack-base/entrypoint.sh
@@ -67,6 +67,25 @@ except Exception:
 done
 echo ""
 
+# ── Firewall gateway route injection ─────────────────────────────────────────
+# When a firewall container is present on internet-dmz-net, inject static routes
+# for OT, control, and plant-dmz subnets so traffic routes THROUGH the firewall
+# container rather than being blocked. This makes nftables deny rules effective —
+# without these routes, the only path to OT was the extraNetworks bypass which
+# completely bypassed the firewall.
+# FW_GW_IP, OT_SUBNET, CONTROL_SUBNET, PLANT_DMZ_SUBNET are injected by
+# compose-generator.ts from the effective zone subnets.
+if [ -n "${FW_GW_IP}" ]; then
+    echo "[otforge-attack] Injecting routes via firewall gateway ${FW_GW_IP}..."
+    for SUBNET in "${OT_SUBNET}" "${CONTROL_SUBNET}" "${PLANT_DMZ_SUBNET}"; do
+        [ -z "${SUBNET}" ] && continue
+        ip route replace "${SUBNET}" via "${FW_GW_IP}" 2>/dev/null && \
+            echo "[otforge-attack]   Route added: ${SUBNET} via ${FW_GW_IP}" || \
+            echo "[otforge-attack]   Route failed: ${SUBNET} (NET_ADMIN required)"
+    done
+fi
+echo ""
+
 # ── Start TigerVNC server ─────────────────────────────────────────────────────
 echo "[otforge-attack] Starting TigerVNC server on display :1 (port 5901)..."
 

--- a/containers/firewall/entrypoint.sh
+++ b/containers/firewall/entrypoint.sh
@@ -100,7 +100,14 @@ if [ -n "${FW_RULES_JSON}" ] && [ "${FW_RULES_JSON}" != "[]" ]; then
     RULE_COUNT=$(echo "${FW_RULES_JSON}" | jq 'length')
     echo "[ics-firewall] Loading ${RULE_COUNT} ACL rule(s) from scenario..."
 
-    for i in $(seq 0 $((RULE_COUNT - 1))); do
+    # Process deny rules before allow rules so explicit denies always take
+    # precedence over existing allows — students adding a deny rule in the
+    # firewall panel will correctly override a pre-existing allow rule.
+    DENY_INDICES=$(echo "${FW_RULES_JSON}" | jq -r 'to_entries[] | select(.value.action == "deny") | .key')
+    ALLOW_INDICES=$(echo "${FW_RULES_JSON}" | jq -r 'to_entries[] | select(.value.action == "allow") | .key')
+    ORDERED_INDICES="${DENY_INDICES} ${ALLOW_INDICES}"
+
+    for i in ${ORDERED_INDICES}; do
         RULE=$(echo "${FW_RULES_JSON}" | jq ".[$i]")
         SRC_ZONE=$(echo "$RULE"  | jq -r '.sourceZone')
         DST_ZONE=$(echo "$RULE"  | jq -r '.destinationZone')

--- a/containers/firewall/entrypoint.sh
+++ b/containers/firewall/entrypoint.sh
@@ -149,6 +149,17 @@ if [ -n "${FW_RULES_JSON}" ] && [ "${FW_RULES_JSON}" != "[]" ]; then
     done
 fi
 
+# ── NAT masquerade for attacker zone ───────────────────────────────────────────
+# Without masquerade, return traffic from OT devices back to Kali routes through
+# the Docker host kernel, which Docker's isolation rules block between bridges.
+# Masquerade rewrites the source IP to the firewall's ot-net IP (10.200.10.254)
+# so OT devices send replies to the firewall, which reverse-NATs them back to Kali.
+# The FORWARD chain still sees the original attacker source IP, so deny rules
+# for Tutorial 03 defense exercises work correctly.
+nft add table ip nat
+nft add chain ip nat postrouting "{ type nat hook postrouting priority 100; }"
+nft add rule ip nat postrouting ip saddr "${FW_ZONE_ATTACKER}" masquerade
+
 # ── Display final ruleset ───────────────────────────────────────────────────────
 echo "[ics-firewall] Active nftables ruleset:"
 nft list ruleset

--- a/containers/firewall/reload-fw-rules.sh
+++ b/containers/firewall/reload-fw-rules.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# reload-fw-rules.sh — Reference copy of the firewall reload logic.
+#
+# NOT installed into the container image (see Dockerfile — only entrypoint.sh is copied).
+# The actual reload is driven by packages/app/src/main/index.ts: buildNftScript()
+# generates nft commands from the live scenario data and pipes them into the running
+# container via `docker exec -i <container> sh`. No image rebuild required.
+#
+# This file exists as a human-readable reference for the reload sequence and for
+# manual testing: docker exec -i <container> bash < reload-fw-rules.sh
+#
+# Requires env vars set at container startup by compose-generator:
+#   FW_ZONE_OT, FW_ZONE_CONTROL, FW_ZONE_PLANT_DMZ,
+#   FW_ZONE_ENTERPRISE, FW_ZONE_INTERNET_DMZ, FW_ZONE_ATTACKER
+#
+# For manual testing, also set:
+#   FW_RULES_JSON    — ACLRule array JSON (or "" / "[]" for no rules)
+#   FW_DEFAULT_POLICY — "accept" | "drop"
+
+set -e
+
+POLICY="${FW_DEFAULT_POLICY:-drop}"
+echo "[ics-firewall] Reloading rules: default-policy=${POLICY}"
+
+# Flush all rules in the forward chain — keeps the chain structure and the
+# NAT masquerade table/chain intact so existing connections are not killed.
+nft flush chain inet ics_fw forward
+
+# Update default policy on the existing chain without changing hook/priority.
+nft chain inet ics_fw forward "{ policy ${POLICY}; }"
+
+# Baseline: always allow established/related and ICMP (must be re-added after flush).
+nft add rule inet ics_fw forward ct state established,related accept
+nft add rule inet ics_fw forward ip protocol icmp accept
+nft add rule inet ics_fw forward ip6 nexthdr icmpv6 accept
+
+# ── Zone subnet lookup ───────────────────────────────────────────────────────────
+# Mirrors the zone_subnet() function in entrypoint.sh exactly.
+zone_subnet() {
+    case "$1" in
+        ot)           echo "${FW_ZONE_OT}" ;;
+        control)      echo "${FW_ZONE_CONTROL}" ;;
+        plant-dmz)    echo "${FW_ZONE_PLANT_DMZ}" ;;
+        enterprise)   echo "${FW_ZONE_ENTERPRISE}" ;;
+        internet-dmz) echo "${FW_ZONE_INTERNET_DMZ}" ;;
+        attacker)     echo "${FW_ZONE_ATTACKER}" ;;
+        *)            echo "" ;;
+    esac
+}
+
+# ── ACL rules from FW_RULES_JSON ─────────────────────────────────────────────────
+if [ -n "${FW_RULES_JSON}" ] && [ "${FW_RULES_JSON}" != "[]" ]; then
+    RULE_COUNT=$(echo "${FW_RULES_JSON}" | jq 'length')
+    echo "[ics-firewall] Applying ${RULE_COUNT} ACL rule(s)..."
+
+    # Deny rules first so explicit denies override any pre-existing allow.
+    DENY_INDICES=$(echo "${FW_RULES_JSON}" | jq -r 'to_entries[] | select(.value.action == "deny") | .key')
+    ALLOW_INDICES=$(echo "${FW_RULES_JSON}" | jq -r 'to_entries[] | select(.value.action == "allow") | .key')
+    ORDERED_INDICES="${DENY_INDICES} ${ALLOW_INDICES}"
+
+    for i in ${ORDERED_INDICES}; do
+        RULE=$(echo "${FW_RULES_JSON}" | jq ".[$i]")
+        SRC_ZONE=$(echo "$RULE"  | jq -r '.sourceZone')
+        DST_ZONE=$(echo "$RULE"  | jq -r '.destinationZone')
+        PROTO=$(echo "$RULE"     | jq -r '.protocol')
+        PORT=$(echo "$RULE"      | jq -r '.destinationPort | tostring')
+        ACTION=$(echo "$RULE"    | jq -r '.action')
+        COMMENT=$(echo "$RULE"   | jq -r '.comment // ""')
+
+        SRC_SUBNET=$(zone_subnet "$SRC_ZONE")
+        DST_SUBNET=$(zone_subnet "$DST_ZONE")
+
+        PARTS=("inet" "ics_fw" "forward")
+
+        [ -n "$SRC_SUBNET" ] && PARTS+=("ip" "saddr" "$SRC_SUBNET")
+        [ -n "$DST_SUBNET" ] && PARTS+=("ip" "daddr" "$DST_SUBNET")
+
+        case "$PROTO" in
+            tcp)
+                if [ "$PORT" != "any" ] && [ -n "$PORT" ]; then
+                    PARTS+=("tcp" "dport" "$PORT")
+                fi
+                ;;
+            udp)
+                if [ "$PORT" != "any" ] && [ -n "$PORT" ]; then
+                    PARTS+=("udp" "dport" "$PORT")
+                fi
+                ;;
+            icmp)
+                PARTS+=("ip" "protocol" "icmp")
+                ;;
+        esac
+
+        NFT_ACTION=$([ "$ACTION" = "allow" ] && echo "accept" || echo "drop")
+        PARTS+=("$NFT_ACTION")
+
+        nft add rule "${PARTS[@]}"
+        echo "[ics-firewall] Rule[$i]: ${SRC_ZONE}→${DST_ZONE} proto=${PROTO} port=${PORT} action=${ACTION}${COMMENT:+ # ${COMMENT}}"
+    done
+else
+    echo "[ics-firewall] No ACL rules — default policy (${POLICY}) applies to all traffic."
+fi
+
+echo "[ics-firewall] Reload complete."
+nft list chain inet ics_fw forward

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -64,7 +64,7 @@ import {
   findFreeSubnets,
   ZONE_DEFAULTS
 } from '@otforge/orchestrator'
-import type { NetworkZone } from '@otforge/schema'
+import type { NetworkZone, ACLRule } from '@otforge/schema'
 import { initDb, saveActiveScenario, loadActiveScenario, clearActiveScenario } from './db'
 import { parsePlcFile } from './plc-import'
 
@@ -357,6 +357,13 @@ let dockerClient: DockerClient
  * Null when no simulation is active. Used by stop/status IPC handlers.
  */
 let activeProjectName: string | null = null
+
+/**
+ * Zone → CIDR subnet map captured at simulation start.
+ * Needed by firewall:reload to generate nft address-match rules without
+ * re-running zone resolution. Cleared when the simulation stops.
+ */
+let activeZones: Record<NetworkZone, string> | null = null
 
 /**
  * Maps PLC device nodeIds to their published host ports for the OpenPLC web
@@ -836,6 +843,11 @@ function registerIPCHandlers(): void {
 
         const composeYaml = generateCompose(scenario, projectName, scenarioDir, zones)
 
+        // Capture zone subnets so firewall:reload can generate nft rules at runtime.
+        activeZones = Object.fromEntries(
+          Object.entries(zones).map(([z, cfg]) => [z, cfg.subnet])
+        ) as Record<NetworkZone, string>
+
         // Pass a callback that fires if docker image inspect reveals missing images.
         // The renderer listens for simulation:pullStatus { pulling: true } and shows
         // an "Importing Containers" overlay so the user knows why startup is slow.
@@ -902,6 +914,7 @@ function registerIPCHandlers(): void {
     if (result.ok) {
       await clearActiveScenario()
       activeProjectName = null
+      activeZones = null
       activePlcPorts.clear()
       activePlcModbusPorts.clear()
       activeAttackPorts.clear()
@@ -918,6 +931,55 @@ function registerIPCHandlers(): void {
     if (!activeProjectName) return []
     return dockerClient.getStatus(activeProjectName)
   })
+
+  // ── Firewall runtime reload ───────────────────────────────────────────────────
+
+  /**
+   * Rebuilds the nftables forward chain in the running firewall container without
+   * restarting the simulation. Students add/remove rules in the UI then click
+   * "Apply Rules" to push them live.
+   *
+   * How it works — no image rebuild required:
+   *   buildNftScript() converts the typed ACLRule array into a sequence of plain
+   *   `nft` shell commands. That script is piped via stdin to
+   *   `docker exec -i <container> sh` — the container already has sh and nft.
+   *   Zone subnets come from activeZones, captured when the simulation started.
+   *
+   * @param nodeId        - Canvas node ID of the firewall device.
+   * @param rules         - Current ACLRule array from scenario.security.firewallRules.
+   * @param defaultPolicy - "drop" (deny-by-default) or "accept" (allow-by-default).
+   */
+  ipcMain.handle(
+    'firewall:reload',
+    (
+      _e,
+      { nodeId, rules, defaultPolicy }: { nodeId: string; rules: ACLRule[]; defaultPolicy: string }
+    ): Promise<{ ok: boolean; error?: string }> => {
+      if (!activeProjectName || !activeZones) {
+        return Promise.resolve({ ok: false, error: 'No simulation running.' })
+      }
+      const sanitized = nodeId.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+      const containerName = `${activeProjectName}-${sanitized}`
+      const script = buildNftScript(rules, defaultPolicy, activeZones)
+
+      return new Promise(resolve => {
+        const proc = spawn('docker', ['exec', '-i', containerName, 'sh'], {
+          env: buildDockerEnv(),
+          stdio: 'pipe'
+        })
+        let stderr = ''
+        proc.stderr?.on('data', chunk => {
+          stderr += chunk.toString()
+        })
+        proc.stdin?.write(script)
+        proc.stdin?.end()
+        proc.on('close', code =>
+          resolve(code === 0 ? { ok: true } : { ok: false, error: stderr || `exit ${code}` })
+        )
+        proc.on('error', err => resolve({ ok: false, error: err.message }))
+      })
+    }
+  )
 
   // ── Monitoring — Loki log query proxy (Phase 6) ───────────────────────────────
 
@@ -2614,6 +2676,69 @@ async function buildInstalledPack(
   }
 
   return { manifest, installPath: packPath, installedAt, deviceTypes, scenarioMetas }
+}
+
+// ── Firewall nft script generator ─────────────────────────────────────────────
+
+/**
+ * Builds a POSIX sh script that rebuilds the nftables forward chain from the
+ * given ACL rules and default policy. The script is piped via stdin into the
+ * running firewall container — no image change or pre-installed reload script
+ * is required because the container already has `sh` and `nft`.
+ *
+ * All values are inlined from TypeScript data so the script contains no shell
+ * variables and is safe to pipe without any escaping concerns.
+ *
+ * @param rules         - Current ACL rule list (deny rules applied before allow).
+ * @param defaultPolicy - "drop" or "accept".
+ * @param zones         - Zone name → CIDR map captured at simulation start.
+ */
+function buildNftScript(
+  rules: ACLRule[],
+  defaultPolicy: string,
+  zones: Record<string, string>
+): string {
+  const lines: string[] = [
+    'set -e',
+    '# Flush only the forward chain — preserves NAT masquerade and other tables.',
+    'nft flush chain inet ics_fw forward',
+    `nft chain inet ics_fw forward "{ policy ${defaultPolicy}; }"`,
+    '# Baseline: always allow established/related connections and ICMP.',
+    'nft add rule inet ics_fw forward ct state established,related accept',
+    'nft add rule inet ics_fw forward ip protocol icmp accept',
+    'nft add rule inet ics_fw forward ip6 nexthdr icmpv6 accept'
+  ]
+
+  // Deny rules first so explicit denies take precedence over any allow rule.
+  const ordered = [
+    ...rules.filter(r => r.action === 'deny'),
+    ...rules.filter(r => r.action === 'allow')
+  ]
+
+  for (const rule of ordered) {
+    const parts = ['nft', 'add', 'rule', 'inet', 'ics_fw', 'forward']
+
+    const srcSubnet = rule.sourceZone !== 'any' ? zones[rule.sourceZone] : undefined
+    const dstSubnet = rule.destinationZone !== 'any' ? zones[rule.destinationZone] : undefined
+    if (srcSubnet) parts.push('ip', 'saddr', srcSubnet)
+    if (dstSubnet) parts.push('ip', 'daddr', dstSubnet)
+
+    if (rule.protocol === 'tcp') {
+      if (rule.destinationPort !== 'any') parts.push('tcp', 'dport', String(rule.destinationPort))
+    } else if (rule.protocol === 'udp') {
+      if (rule.destinationPort !== 'any') parts.push('udp', 'dport', String(rule.destinationPort))
+    } else if (rule.protocol === 'icmp') {
+      parts.push('ip', 'protocol', 'icmp')
+    }
+
+    parts.push(rule.action === 'allow' ? 'accept' : 'drop')
+    lines.push(parts.join(' '))
+  }
+
+  lines.push(
+    'echo "[ics-firewall] Reload complete — $(nft list chain inet ics_fw forward | grep -c rule) rule(s) active"'
+  )
+  return lines.join('\n') + '\n'
 }
 
 // ── TCP port connectivity helper ──────────────────────────────────────────────

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -40,7 +40,8 @@ import type {
   PlcImportResult,
   PackInstallResult,
   PackListResult,
-  PackUninstallResult
+  PackUninstallResult,
+  ACLRule
 } from '@otforge/schema'
 
 /**
@@ -138,6 +139,25 @@ const api = {
      */
     meminfo: (): Promise<{ totalMb: number; freeMb: number; cpus: number }> =>
       ipcRenderer.invoke('system:meminfo')
+  },
+
+  // ── Firewall runtime reload ───────────────────────────────────────────────────
+  firewall: {
+    /**
+     * Rebuilds the nftables forward chain in the running firewall container.
+     * Called when a student adds or removes rules and clicks "Apply Rules".
+     * Generates nft commands in the main process and pipes them to the container
+     * via stdin — no image rebuild required.
+     *
+     * @param nodeId        - Canvas node ID of the firewall device.
+     * @param rules         - Current ACLRule array.
+     * @param defaultPolicy - "drop" or "accept".
+     */
+    reload: (args: {
+      nodeId: string
+      rules: ACLRule[]
+      defaultPolicy: string
+    }): Promise<{ ok: boolean; error?: string }> => ipcRenderer.invoke('firewall:reload', args)
   },
 
   // ── Attack terminal ───────────────────────────────────────────────────────────

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -873,7 +873,12 @@ export function ScadaCanvas({
         50
       )
     }
-  }, [scenario, activeLayer, setNodes, setEdges])
+    // Only re-sync when visual layout or device graph changes — security updates
+    // (firewallRules, IDS config) share the same scenario object but don't affect
+    // canvas nodes, and triggering setNodes on every security edit clears the
+    // React Flow selection, kicking the user out of the firewall panel.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scenario?.visual, scenario?.devices, activeLayer, setNodes, setEdges])
 
   /*
    * Re-fit whenever the browser window is resized or maximized.

--- a/packages/app/src/renderer/src/index.css
+++ b/packages/app/src/renderer/src/index.css
@@ -21,6 +21,9 @@
   --accent-red: #f85149;
   --accent-orange: #d29922;
   --accent-teal: #39d0b0;
+  --bg-input: #0d1117;
+  --bg-hover: #222831;
+  --bg-canvas: #161b22;
   font-family:
     'Segoe UI',
     system-ui,
@@ -184,6 +187,15 @@ select {
 }
 .btn-danger:not(:disabled):hover {
   background: rgba(248, 81, 73, 0.1);
+}
+
+.btn-success {
+  background: transparent;
+  color: var(--accent-green);
+  border-color: var(--accent-green);
+}
+.btn-success:not(:disabled):hover {
+  background: rgba(63, 185, 80, 0.1);
 }
 
 /* ── Logo mark ────────────────────────────────────────────────────────────────── */
@@ -2154,6 +2166,12 @@ code.prop-value {
   min-width: 36px;
 }
 
+/* Force option list colors so dark-theme backgrounds don't render invisible text. */
+.fw-select option {
+  background: var(--bg-panel);
+  color: var(--text-primary);
+}
+
 .fw-arrow {
   color: var(--text-muted);
   font-size: 0.7rem;
@@ -2183,6 +2201,22 @@ code.prop-value {
 .fw-add-btn {
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+/* ── Apply Rules row ─────────────────────────────────────────── */
+.fw-apply-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.fw-apply-btn {
+  white-space: nowrap;
+}
+
+.fw-apply-hint {
+  font-size: 0.62rem;
+  color: var(--text-muted);
 }
 
 /* ── IDS/IPS Panel (IDSPanel) ─────────────────────────────────── */

--- a/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
+++ b/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
@@ -342,7 +342,12 @@ export function PropertiesPanel({
           {/* ── Firewall panel (Phase 5) ──────────────────────────────────────── */}
           {/* Hidden in Student mode — security config is stripped from locked exports. */}
           {!readOnly && device.category === 'firewall' && security && (
-            <FirewallPanel security={security} onSecurityChange={onSecurityChange} />
+            <FirewallPanel
+              security={security}
+              onSecurityChange={onSecurityChange}
+              nodeId={device.nodeId}
+              simRunning={simRunning}
+            />
           )}
           {!readOnly && device.category === 'firewall' && !security && (
             <section className="prop-section">

--- a/packages/app/src/renderer/src/properties/SecurityPanel.tsx
+++ b/packages/app/src/renderer/src/properties/SecurityPanel.tsx
@@ -38,6 +38,10 @@ interface SecurityPanelProps {
   security: SecurityLayer
   /** Updater callback — same (prev => next) pattern used across the app. */
   onSecurityChange: (updater: (s: SecurityLayer) => SecurityLayer) => void
+  /** Canvas node ID of the selected device — used by FirewallPanel for runtime reload. */
+  nodeId?: string
+  /** True when a simulation is actively running — enables the Apply Rules button. */
+  simRunning?: boolean
 }
 
 // ── Firewall Panel ─────────────────────────────────────────────────────────────
@@ -82,9 +86,17 @@ const EMPTY_FORM = {
  * Saved rules are written to FW_RULES_JSON by compose-generator.ts and applied
  * one-for-one as `nft add rule inet ics_fw forward …` lines in entrypoint.sh.
  */
-export function FirewallPanel({ security, onSecurityChange }: SecurityPanelProps) {
+export function FirewallPanel({
+  security,
+  onSecurityChange,
+  nodeId,
+  simRunning
+}: SecurityPanelProps) {
   /** Local form state for the "add rule" inputs — not committed until Add is clicked. */
   const [form, setForm] = useState(EMPTY_FORM)
+
+  /** Tracks the in-progress / success / error state of the Apply Rules IPC call. */
+  const [applyState, setApplyState] = useState<'idle' | 'applying' | 'ok' | 'error'>('idle')
 
   /** Flip the default policy between deny-by-default and allow-by-default. */
   const togglePolicy = useCallback(() => {
@@ -122,6 +134,26 @@ export function FirewallPanel({ security, onSecurityChange }: SecurityPanelProps
     },
     [onSecurityChange]
   )
+
+  /**
+   * Pushes the current rules to the running firewall container via IPC so
+   * students don't need to restart the simulation after each rule change.
+   */
+  const applyRules = useCallback(async () => {
+    if (!nodeId || !simRunning) return
+    setApplyState('applying')
+    try {
+      const result = await window.electronAPI.firewall.reload({
+        nodeId,
+        rules: security.firewallRules,
+        defaultPolicy: security.defaultFirewallPolicy === 'deny' ? 'drop' : 'accept'
+      })
+      setApplyState(result.ok ? 'ok' : 'error')
+    } catch {
+      setApplyState('error')
+    }
+    setTimeout(() => setApplyState('idle'), 3000)
+  }, [nodeId, simRunning, security.firewallRules, security.defaultFirewallPolicy])
 
   const isDeny = security.defaultFirewallPolicy === 'deny'
 
@@ -269,6 +301,39 @@ export function FirewallPanel({ security, onSecurityChange }: SecurityPanelProps
               + Add
             </button>
           </div>
+        </div>
+      </section>
+
+      {/* ── Apply Rules ────────────────────────────────────────────────────────── */}
+      {/* Pushes the current ruleset to the running firewall container so students */}
+      {/* can reconfigure without restarting the simulation.                       */}
+      <section className="prop-section">
+        <div className="fw-apply-row">
+          <button
+            className={`btn btn-sm fw-apply-btn ${
+              applyState === 'ok'
+                ? 'btn-success'
+                : applyState === 'error'
+                  ? 'btn-danger'
+                  : 'btn-secondary'
+            }`}
+            onClick={applyRules}
+            disabled={!simRunning || applyState === 'applying'}
+            title={
+              simRunning
+                ? 'Apply current rules to the running firewall container'
+                : 'Start the simulation to apply rules'
+            }
+          >
+            {applyState === 'applying'
+              ? 'Applying…'
+              : applyState === 'ok'
+                ? '✓ Applied'
+                : applyState === 'error'
+                  ? '✗ Failed'
+                  : 'Apply Rules'}
+          </button>
+          {!simRunning && <span className="fw-apply-hint">Start simulation to apply</span>}
         </div>
       </section>
     </>

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -607,7 +607,11 @@ export function generateCompose(
     // NET_RAW is required for raw socket access (ICMP, packet capture).
     if (device.category === 'firewall') {
       services[serviceName].cap_add = ['NET_ADMIN', 'NET_RAW']
-      // Attach to OT (L0-2), Control (L3), and Plant DMZ (L3.5) at .254 (last usable host in /24).
+      // Attach to OT (L0-2), Control (L3), Plant DMZ (L3.5), and Internet DMZ (L5) at .254.
+      // Internet DMZ attachment is required so Kali (on internet-dmz-net) can route OT-bound
+      // traffic THROUGH the firewall — making nftables rules actually enforce zone boundaries.
+      // Without this leg, Kali's only path to OT was the direct extraNetworks bypass, which
+      // rendered deny rules ineffective.
       // Uses effectiveZones so the address stays inside the resolved (possibly auto-detected) subnet.
       services[serviceName].networks = {
         'ot-net': { ipv4_address: `${effectiveZones.ot.subnet.replace('.0/24', '.254')}` },
@@ -616,6 +620,9 @@ export function generateCompose(
         },
         'plant-dmz-net': {
           ipv4_address: `${effectiveZones['plant-dmz'].subnet.replace('.0/24', '.254')}`
+        },
+        'internet-dmz-net': {
+          ipv4_address: `${effectiveZones['internet-dmz'].subnet.replace('.0/24', '.254')}`
         }
       }
       // Inject scenario security config so the entrypoint can build the nftables ruleset.
@@ -686,6 +693,17 @@ export function generateCompose(
         attackEnv.push(`PLC_PORT=${plcPort}`)
         services[serviceName].environment = attackEnv
       }
+
+      // Inject firewall gateway IP and internal zone subnets so entrypoint.sh can
+      // add static routes routing OT/control/plant-dmz traffic through the firewall.
+      // FW_GW_IP is the firewall's internet-dmz-net address (.254 of that subnet).
+      // With these routes in place, nftables deny rules actually block the attack.
+      const attackEnvFw: string[] = services[serviceName].environment ?? []
+      attackEnvFw.push(`FW_GW_IP=${internetDmzBase}.254`)
+      attackEnvFw.push(`OT_SUBNET=${effectiveZones.ot.subnet}`)
+      attackEnvFw.push(`CONTROL_SUBNET=${effectiveZones.control.subnet}`)
+      attackEnvFw.push(`PLANT_DMZ_SUBNET=${effectiveZones['plant-dmz'].subnet}`)
+      services[serviceName].environment = attackEnvFw
 
       // Point Kali's resolver at the scenario's dns-server so exercise hostnames
       // (e.g., meridian-process.com) resolve inside the simulation without needing

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -210,6 +210,12 @@ interface ComposeService {
    * br-XXXX Docker bridge interfaces and see all inter-container traffic.
    */
   network_mode?: string
+  /**
+   * Overrides the Dockerfile ENTRYPOINT. Used on the attack machine to inject
+   * static routes via the firewall gateway before the main entrypoint runs,
+   * bypassing the need for an image rebuild when routing config changes.
+   */
+  entrypoint?: string[]
   /** Per-network IP assignments. Omitted when network_mode is set. */
   networks?: Record<string, { ipv4_address: string }>
   environment: string[] | undefined
@@ -698,12 +704,21 @@ export function generateCompose(
         services[serviceName].environment = attackEnv
       }
 
-      // Inject firewall gateway IP and internal zone subnets so entrypoint.sh can
-      // add static routes routing OT/control/plant-dmz traffic through the firewall.
-      // FW_GW_IP is the firewall's internet-dmz-net address (.254 of that subnet).
-      // With these routes in place, nftables deny rules actually block the attack.
+      // Inject static routes via the firewall gateway before the main entrypoint runs.
+      // Using compose entrypoint override avoids requiring an attack-base image rebuild
+      // when routing config changes. Routes OT/control/plant-dmz traffic through the
+      // firewall so nftables deny rules are effective for Tutorial 03 defense exercises.
+      const fwGwIp = `${attackerBase}.254`
+      services[serviceName].entrypoint = [
+        '/bin/sh',
+        '-c',
+        `ip route replace ${effectiveZones.ot.subnet} via ${fwGwIp} 2>/dev/null || true; ` +
+          `ip route replace ${effectiveZones.control.subnet} via ${fwGwIp} 2>/dev/null || true; ` +
+          `ip route replace ${effectiveZones['plant-dmz'].subnet} via ${fwGwIp} 2>/dev/null || true; ` +
+          `exec /entrypoint.sh`
+      ]
       const attackEnvFw: string[] = services[serviceName].environment ?? []
-      attackEnvFw.push(`FW_GW_IP=${attackerBase}.254`)
+      attackEnvFw.push(`FW_GW_IP=${fwGwIp}`)
       attackEnvFw.push(`OT_SUBNET=${effectiveZones.ot.subnet}`)
       attackEnvFw.push(`CONTROL_SUBNET=${effectiveZones.control.subnet}`)
       attackEnvFw.push(`PLANT_DMZ_SUBNET=${effectiveZones['plant-dmz'].subnet}`)

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -470,6 +470,7 @@ export function generateCompose(
   const otBase = effectiveZones.ot.subnet.replace('.0/24', '')
   const controlBase = effectiveZones.control.subnet.replace('.0/24', '')
   const internetDmzBase = effectiveZones['internet-dmz'].subnet.replace('.0/24', '')
+  const attackerBase = effectiveZones.attacker.subnet.replace('.0/24', '')
 
   /**
    * Returns a unique IP on netName for the given preferredIp.
@@ -621,8 +622,11 @@ export function generateCompose(
         'plant-dmz-net': {
           ipv4_address: `${effectiveZones['plant-dmz'].subnet.replace('.0/24', '.254')}`
         },
-        'internet-dmz-net': {
-          ipv4_address: `${effectiveZones['internet-dmz'].subnet.replace('.0/24', '.254')}`
+        // attacker-net attachment routes Kali's OT-bound traffic through the firewall
+        // so nftables rules see the source as the attacker zone IP (10.200.60.10),
+        // making deny rules actually effective for Tutorial 03 defense exercises.
+        'attacker-net': {
+          ipv4_address: `${effectiveZones.attacker.subnet.replace('.0/24', '.254')}`
         }
       }
       // Inject scenario security config so the entrypoint can build the nftables ruleset.
@@ -699,7 +703,7 @@ export function generateCompose(
       // FW_GW_IP is the firewall's internet-dmz-net address (.254 of that subnet).
       // With these routes in place, nftables deny rules actually block the attack.
       const attackEnvFw: string[] = services[serviceName].environment ?? []
-      attackEnvFw.push(`FW_GW_IP=${internetDmzBase}.254`)
+      attackEnvFw.push(`FW_GW_IP=${attackerBase}.254`)
       attackEnvFw.push(`OT_SUBNET=${effectiveZones.ot.subnet}`)
       attackEnvFw.push(`CONTROL_SUBNET=${effectiveZones.control.subnet}`)
       attackEnvFw.push(`PLANT_DMZ_SUBNET=${effectiveZones['plant-dmz'].subnet}`)


### PR DESCRIPTION
## Summary

- **Firewall routing**: Kali traffic now routes through the firewall container so nftables rules actually enforce zone boundaries. Previously, the attack machine had a direct Docker network path that bypassed the firewall entirely, making deny rules ineffective for Tutorial 03 defense exercises.
- **Live rule reload**: Students can add/remove firewall rules in the UI and click **Apply Rules** to push them to the running container instantly — no simulation restart needed.
- **Firewall panel UI fixes**: Add Rule button no longer kicks students out of the panel; dropdown option text is now visible in the dark theme.

## What changed

### Routing fixes (6 commits)
- Attach firewall to `attacker-net` so Kali's OT-bound traffic passes through nftables chains
- Inject static routes on the attack machine via compose entrypoint override so traffic routes through the firewall gateway rather than bypassing it
- Add NAT masquerade for the attacker zone so OT return traffic routes back through the firewall correctly
- Process deny rules before allow rules in the nftables chain so explicit student denies override pre-existing allows

### Live reload (`buildNftScript` in `main/index.ts`)
- Converts `ACLRule[]` to a sequence of `nft` commands and pipes them to `docker exec -i <container> sh` via stdin
- No image rebuild required — the container already has `sh` and `nft`
- Zone subnets captured at simulation start (`activeZones`) so the handler has CIDRs without re-running zone resolution

### UI fixes
- `ScadaCanvas`: narrow `useEffect` deps to `scenario.visual` / `scenario.devices` so security-only changes don't trigger `setNodes`, which was clearing React Flow selection and collapsing the firewall panel
- `index.css`: add missing `--bg-input`, `--bg-hover`, `--bg-canvas` CSS variables; add `.fw-select option` styling to force visible text in Electron's dark theme

## Test plan
- [ ] Start a simulation with a firewall device on the canvas
- [ ] Open the firewall panel — confirm Add Rule keeps you in the panel and the dropdowns are readable
- [ ] Add a deny rule (e.g. RED → OT TCP/502) and click **Apply Rules** — confirm traffic is blocked without restarting
- [ ] Delete the rule and click **Apply Rules** — confirm traffic is restored
- [ ] Confirm Apply Rules button is disabled when simulation is not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)