### PR TITLE
feat: promote safety-plc to fully functional device category

### DIFF
--- a/containers/safety-plc/example_2oo3_hpsd.st
+++ b/containers/safety-plc/example_2oo3_hpsd.st
@@ -1,0 +1,121 @@
+(* =========================================================================
+   example_2oo3_hpsd.st
+   High-Pressure Shutdown (HPSD) — Safety Instrumented Function example.
+
+   Demonstrates IEC 61511 SIS concepts using a 2oo3 (two-out-of-three)
+   voting architecture on three redundant pressure transmitters.
+
+   This program is for educational use in OTForge labs. It runs on the
+   standard OpenPLC runtime — no SIL certification is implied.
+
+   -------------------------------------------------------------------------
+   Process description:
+     Three pressure transmitters (PT-101A/B/C) monitor a reactor feed line.
+     If two or more transmitters read HIGH (coil = TRUE), the SIS trips:
+       - SDV-101 (shutdown valve) is de-energized to CLOSED
+       - ESD-K1  (emergency shutdown relay) is de-energized
+
+   De-energize-to-trip (fail-safe): outputs are energized during normal
+   operation and de-energized on trip, so a power or wiring fault causes
+   a safe trip rather than a missed trip (IEC 61511-1 Cl. 11.4.3).
+
+   -------------------------------------------------------------------------
+   Variable map (Modbus coil / holding register addresses):
+     %IX0.0  PT-101A pressure HIGH signal (from sensor coil)
+     %IX0.1  PT-101B pressure HIGH signal
+     %IX0.2  PT-101C pressure HIGH signal
+     %IX0.3  BYPASS  maintenance bypass (inhibits trip — alarmed separately)
+     %QX0.0  SDV-101 — shutdown valve (TRUE = open/energized, FALSE = tripped)
+     %QX0.1  ESD-K1  — ESD relay (TRUE = normal, FALSE = tripped)
+     %QX0.2  TRIP_ALARM — TRUE when SIS is in tripped state
+     %QX0.3  BYPASS_ALARM — TRUE when maintenance bypass is active
+     %MW0    VOTED_COUNT — number of sensors reading HIGH (0-3), for HMI display
+   =========================================================================
+*)
+
+PROGRAM HPSD_2oo3
+
+  (* ── Inputs ────────────────────────────────────────────────────── *)
+  VAR_INPUT
+    PT_101A   AT %IX0.0 : BOOL;  (* Pressure transmitter A — HIGH trip signal *)
+    PT_101B   AT %IX0.1 : BOOL;  (* Pressure transmitter B — HIGH trip signal *)
+    PT_101C   AT %IX0.2 : BOOL;  (* Pressure transmitter C — HIGH trip signal *)
+    BYPASS    AT %IX0.3 : BOOL;  (* Maintenance bypass — inhibits SIS trip    *)
+  END_VAR
+
+  (* ── Outputs ───────────────────────────────────────────────────── *)
+  VAR_OUTPUT
+    SDV_101      AT %QX0.0 : BOOL;  (* Shutdown valve   — de-energize to close  *)
+    ESD_K1       AT %QX0.1 : BOOL;  (* ESD relay        — de-energize to trip   *)
+    TRIP_ALARM   AT %QX0.2 : BOOL;  (* Trip status lamp — TRUE = tripped        *)
+    BYPASS_ALARM AT %QX0.3 : BOOL;  (* Bypass active warning lamp               *)
+  END_VAR
+
+  (* ── Internal variables ────────────────────────────────────────── *)
+  VAR
+    VOTED_COUNT AT %MW0 : INT;   (* Sensors reading HIGH — written to HMI  *)
+    VOTE_TRIP         : BOOL;    (* TRUE when 2 or more sensors are HIGH   *)
+    LATCHED_TRIP      : BOOL;    (* Trip latch — holds until manual reset  *)
+    (* Note: add a RESET input (%IX0.4) for full IEC 61511 compliance *)
+  END_VAR
+
+  (* ── 2oo3 voting logic ─────────────────────────────────────────── *)
+  (* Count how many of the three sensors are reading HIGH.            *)
+  VOTED_COUNT := BOOL_TO_INT(PT_101A) +
+                 BOOL_TO_INT(PT_101B) +
+                 BOOL_TO_INT(PT_101C);
+
+  (* Trip if two or more sensors vote HIGH (2oo3 architecture).       *)
+  VOTE_TRIP := (VOTED_COUNT >= 2);
+
+  (* ── Trip latch ────────────────────────────────────────────────── *)
+  (* Once tripped, hold the trip state until an operator reset.       *)
+  (* In this example the latch is self-clearing when all sensors      *)
+  (* return to normal — add a RESET coil for full manual-reset SIS.  *)
+  IF VOTE_TRIP THEN
+    LATCHED_TRIP := TRUE;
+  END_IF;
+
+  IF NOT VOTE_TRIP THEN
+    (* Auto-reset for lab simplicity — real SIS requires manual reset *)
+    LATCHED_TRIP := FALSE;
+  END_IF;
+
+  (* ── Bypass handling ───────────────────────────────────────────── *)
+  (* Bypass inhibits the trip output. Must be alarmed per IEC 61511.  *)
+  BYPASS_ALARM := BYPASS;
+
+  (* ── Output drive (de-energize-to-trip) ───────────────────────── *)
+  (* Outputs are TRUE (energized) during normal operation.            *)
+  (* They de-energize (FALSE) when a trip occurs AND bypass is off.   *)
+  IF LATCHED_TRIP AND NOT BYPASS THEN
+    SDV_101    := FALSE;   (* Close isolation valve *)
+    ESD_K1     := FALSE;   (* Drop ESD relay        *)
+    TRIP_ALARM := TRUE;
+  ELSE
+    SDV_101    := TRUE;    (* Valve open — normal operation *)
+    ESD_K1     := TRUE;    (* Relay energized — normal      *)
+    TRIP_ALARM := FALSE;
+  END_IF;
+
+END_PROGRAM
+
+(*
+  =========================================================================
+  Configuration notes for OTForge scenario authors:
+
+  1. Load this program into OpenPLC via the web IDE (localhost:18080).
+  2. Connect three field sensor devices to %IX0.0, %IX0.1, %IX0.2 using
+     a Modbus slave device in the OpenPLC hardware configuration.
+  3. Wire %QX0.0 (SDV-101) to an actuator or valve device downstream.
+  4. In the scenario, set safetyPlc.votingConfig = "2oo3" and
+     safetyPlc.safeState = "Close SDV-101, de-energize ESD-K1".
+  5. To simulate an attack: write TRUE to two or more pressure sensor
+     coils from the attack machine using a Modbus coil-write command.
+     The SIS should trip within one PLC scan cycle (~10 ms).
+  6. To demonstrate bypass vulnerability: set %IX0.3 = TRUE from the
+     attack machine before writing the pressure coils. The SIS will not
+     trip even with two sensors reading HIGH — demonstrating why bypass
+     management is a critical ICS security control (IEC 62443-3-3 SR 3.6).
+  =========================================================================
+*)

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -790,7 +790,7 @@ function registerIPCHandlers(): void {
         let attackIdx = 0
         let workstationIdx = 0
         for (const [nodeId, device] of Object.entries(scenario.devices.devices)) {
-          if (device.category === 'plc') {
+          if (device.category === 'plc' || device.category === 'safety-plc') {
             activePlcPorts.set(nodeId, 18080 + plcIdx)
             // 18550 matches PLC_MODBUS_PORT_BASE in compose-generator.ts
             activePlcModbusPorts.set(nodeId, 18550 + plcIdx)
@@ -2849,7 +2849,10 @@ async function configureFuxa(scenario: OTForgeScenario): Promise<void> {
     if (edge.data.protocol !== 'modbus-tcp') continue
     for (const candidateId of [edge.source, edge.target]) {
       const device = scenario.devices.devices[candidateId]
-      if (device && (device.category === 'plc' || device.category === 'rtu')) {
+      if (
+        device &&
+        (device.category === 'plc' || device.category === 'safety-plc' || device.category === 'rtu')
+      ) {
         modbusNodeIds.add(candidateId)
       }
     }

--- a/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
+++ b/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
@@ -160,8 +160,8 @@ export function PropertiesPanel({
         </div>
       </div>
 
-      {/* PLC devices: identity rows + prominent IDE launch button */}
-      {device.category === 'plc' && (
+      {/* PLC and Safety PLC: identity rows + IDE launch button */}
+      {(device.category === 'plc' || device.category === 'safety-plc') && (
         <div className="properties-body">
           {/* Identity section — same fields as non-PLC devices */}
           <section className="prop-section">
@@ -196,6 +196,37 @@ export function PropertiesPanel({
               )}
             </div>
           </section>
+
+          {/* SIS parameters — shown for safety-plc devices */}
+          {device.category === 'safety-plc' && device.safetyPlc && (
+            <section className="prop-section">
+              <div className="prop-section-title">Safety Instrumented System</div>
+              {device.safetyPlc.sisFunction && (
+                <div className="prop-row">
+                  <span className="prop-label">Function</span>
+                  <span className="prop-value">{device.safetyPlc.sisFunction}</span>
+                </div>
+              )}
+              {device.safetyPlc.votingConfig && (
+                <div className="prop-row">
+                  <span className="prop-label">Voting</span>
+                  <code className="prop-value">{device.safetyPlc.votingConfig}</code>
+                </div>
+              )}
+              {device.safetyPlc.proofTestIntervalHr !== undefined && (
+                <div className="prop-row">
+                  <span className="prop-label">Proof test</span>
+                  <span className="prop-value">{device.safetyPlc.proofTestIntervalHr} hr</span>
+                </div>
+              )}
+              {device.safetyPlc.safeState && (
+                <div className="prop-row">
+                  <span className="prop-label">Safe state</span>
+                  <span className="prop-value">{device.safetyPlc.safeState}</span>
+                </div>
+              )}
+            </section>
+          )}
 
           {/* PLC controls — hidden in Student mode (read-only); instructors only */}
           {!readOnly && (
@@ -235,7 +266,7 @@ export function PropertiesPanel({
       )}
 
       {/* Standard property rows for all non-PLC devices */}
-      {device.category !== 'plc' && (
+      {device.category !== 'plc' && device.category !== 'safety-plc' && (
         <div className="properties-body">
           {/* ── Identity section ─────────────────────────────────────────────── */}
           <section className="prop-section">

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -429,9 +429,15 @@ export function generateCompose(
       }
     } else {
       // Direct edge fallback: one endpoint is PLC, other is process-unit
-      if (srcDevice.category === 'plc' && tgtDevice.category === 'process-unit') {
+      if (
+        (srcDevice.category === 'plc' || srcDevice.category === 'safety-plc') &&
+        tgtDevice.category === 'process-unit'
+      ) {
         plcToProcessUnitNodeId.set(edge.source, edge.target)
-      } else if (srcDevice.category === 'process-unit' && tgtDevice.category === 'plc') {
+      } else if (
+        srcDevice.category === 'process-unit' &&
+        (tgtDevice.category === 'plc' || tgtDevice.category === 'safety-plc')
+      ) {
         plcToProcessUnitNodeId.set(edge.target, edge.source)
       }
     }
@@ -543,22 +549,17 @@ export function generateCompose(
     // NOTE: the ports: binding only works because we also attach PLCs to the
     // non-internal monitoring-net below — ot-net is internal: true and Docker
     // silently drops port bindings on internal-only networks.
-    if (device.category === 'plc') {
+    // Both plc and safety-plc run the OpenPLC runtime — same port layout,
+    // same PROCESS_SIM_IP wiring, same IDE access. safety-plc additionally
+    // receives SIS-specific env vars for display in logs and the properties panel.
+    if (device.category === 'plc' || device.category === 'safety-plc') {
       const hostWebPort = PLC_WEB_PORT_BASE + plcPortIndex
       const hostModbusPort = PLC_MODBUS_PORT_BASE + plcPortIndex
-      // Publish both the OpenPLC web IDE (8080) and the Modbus TCP server (502).
-      // Modbus is published so the Electron renderer can poll coil states directly
-      // via Node.js raw TCP sockets (modbus:readCoils IPC channel) for the
-      // live pipe-flow animation without needing docker exec or extra containers.
       services[serviceName].ports = [`${hostWebPort}:8080`, `${hostModbusPort}:502`]
       plcServiceNames.push(serviceName)
       plcPortIndex++
 
-      // If this PLC is connected to a process-unit, inject PROCESS_SIM_IP so the
-      // OpenPLC entrypoint generates a Modbus master config (mbconfig.cfg) pointing
-      // at the physics simulator. The simulator's IP is resolved from the scenario
-      // the same way all device IPs are — using the effective (post-dedup) address
-      // from claimedDeviceIps if already processed, or resolveDeviceIp otherwise.
+      // Inject PROCESS_SIM_IP when connected to a physics simulator.
       const processUnitNodeId = plcToProcessUnitNodeId.get(nodeId)
       if (processUnitNodeId) {
         const procSimIp =
@@ -571,6 +572,22 @@ export function generateCompose(
         const plcEnv: string[] = services[serviceName].environment ?? []
         plcEnv.push(`PROCESS_SIM_IP=${procSimIp}`)
         services[serviceName].environment = plcEnv
+      }
+
+      // SIS-specific env vars — injected for safety-plc devices only.
+      // These are informational (OpenPLC logs them at startup) and reinforce
+      // IEC 61511 concepts without implying any SIL certification.
+      if (device.category === 'safety-plc' && device.safetyPlc) {
+        const sisEnv: string[] = services[serviceName].environment ?? []
+        if (device.safetyPlc.sisFunction)
+          sisEnv.push(`SIS_FUNCTION=${device.safetyPlc.sisFunction}`)
+        if (device.safetyPlc.votingConfig)
+          sisEnv.push(`SIS_VOTING=${device.safetyPlc.votingConfig}`)
+        if (device.safetyPlc.proofTestIntervalHr !== undefined) {
+          sisEnv.push(`SIS_PROOF_TEST_INTERVAL_HR=${device.safetyPlc.proofTestIntervalHr}`)
+        }
+        if (device.safetyPlc.safeState) sisEnv.push(`SIS_SAFE_STATE=${device.safetyPlc.safeState}`)
+        services[serviceName].environment = sisEnv
       }
     }
 
@@ -788,7 +805,7 @@ export function generateCompose(
   if (workstationServiceNames.length > 0) {
     const plcWebUiEntries: string[] = []
     for (const [nodeId, device] of Object.entries(scenario.devices.devices)) {
-      if (device.category === 'plc') {
+      if (device.category === 'plc' || device.category === 'safety-plc') {
         const plcIp = claimedDeviceIps.get(nodeId)
         if (plcIp) {
           plcWebUiEntries.push(`${sanitizeServiceName(nodeId)}|http://${plcIp}:8080`)

--- a/packages/schema/src/icslab.ts
+++ b/packages/schema/src/icslab.ts
@@ -368,6 +368,42 @@ export interface DnsConfig {
   upstream?: string
 }
 
+/**
+ * Safety Instrumented System configuration for safety-plc devices (IEC 61511).
+ *
+ * These fields are informational — they are injected as environment variables
+ * into the OpenPLC container so students can see the SIS parameters in the
+ * properties panel and in container logs, reinforcing SIS design concepts.
+ * The underlying runtime is OpenPLC; no SIL certification is implied.
+ */
+export interface SafetyPlcConfig {
+  /**
+   * Plain-language description of the safety function this SIS performs.
+   * Displayed in the properties panel and injected as SIS_FUNCTION env var.
+   * Example: "High Pressure Shutdown — reactor feed isolation"
+   */
+  sisFunction?: string
+  /**
+   * Voting architecture for redundant sensor inputs (IEC 61511 terminology).
+   * Injected as SIS_VOTING env var.
+   *   1oo1 = single sensor, trip on fault
+   *   2oo3 = two-out-of-three (most common for SIL 2 applications)
+   */
+  votingConfig?: '1oo1' | '1oo2' | '2oo2' | '2oo3' | '1oo3'
+  /**
+   * Proof-test interval in hours — how often the SIS is functionally tested.
+   * Injected as SIS_PROOF_TEST_INTERVAL_HR env var for display purposes.
+   * Typical values: 8760 (annual), 4380 (semi-annual), 2190 (quarterly).
+   */
+  proofTestIntervalHr?: number
+  /**
+   * Human-readable description of the safe state this SIS drives to on trip.
+   * Injected as SIS_SAFE_STATE env var.
+   * Example: "Close SDV-101, de-energize ESD relay K1"
+   */
+  safeState?: string
+}
+
 export interface DeviceConfig {
   nodeId: string // matches CanvasNode.id
   category: DeviceCategory
@@ -383,6 +419,7 @@ export interface DeviceConfig {
   processUnit?: ProcessUnitConfig // Physics process simulation config (Phase 11)
   dns?: DnsConfig // DNS server config (dns-server devices, Phase 12)
   plcProgram?: PLCProgramConfig
+  safetyPlc?: SafetyPlcConfig // SIS config for safety-plc devices
   dockerImage?: string // override default image for this device type
   /**
    * Additional Purdue Model zone networks to attach this device to, beyond the


### PR DESCRIPTION
## Summary

- `safety-plc` now behaves identically to `plc` (port publishing, OpenPLC IDE button, FUXA Modbus provisioning, process-unit wiring) with SIS-specific additions
- New `SafetyPlcConfig` schema type adds `sisFunction`, `votingConfig`, `proofTestIntervalHr`, and `safeState` fields — displayed in the properties panel and injected as env vars into the container
- Sample `example_2oo3_hpsd.st` demonstrates IEC 61511 2oo3 voting high-pressure shutdown with de-energize-to-trip, trip latch, bypass handling, and an attack surface for lab exercises

## Files changed

| File | Change |
|---|---|
| `packages/schema/src/icslab.ts` | Add `SafetyPlcConfig` interface + `safetyPlc?` on `DeviceConfig` |
| `packages/orchestrator/src/compose-generator.ts` | Extend PLC port/env/FUXA/workstation logic to include `safety-plc` |
| `packages/app/src/main/index.ts` | Add `safety-plc` to port maps and FUXA Modbus provisioning |
| `packages/app/src/renderer/src/properties/PropertiesPanel.tsx` | Show IDE button + SIS section for `safety-plc` devices |
| `containers/safety-plc/example_2oo3_hpsd.st` | Sample 2oo3 voting SIS ST program |

## Test plan
- [ ] Add a `safety-plc` device to a scenario canvas — confirm IDE button appears in properties panel
- [ ] Set `safetyPlc` fields in scenario JSON — confirm they appear in the SIS section of the properties panel
- [ ] Start simulation — confirm the safety-plc container starts (same as plc), IDE accessible at its host port
- [ ] Load `example_2oo3_hpsd.st` into OpenPLC IDE — confirm it compiles and runs
- [ ] Write TRUE to two pressure sensor coils from Kali — confirm SDV-101 and ESD-K1 de-energize (trip)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)