### PR TITLE
fix: nmap /24 scans hang due to silent TCP drops at firewall

### DIFF
--- a/containers/firewall/entrypoint.sh
+++ b/containers/firewall/entrypoint.sh
@@ -156,6 +156,16 @@ if [ -n "${FW_RULES_JSON}" ] && [ "${FW_RULES_JSON}" != "[]" ]; then
     done
 fi
 
+# ── Terminal reject rule ───────────────────────────────────────────────────────
+# Unmatched forwarded packets are rejected with ICMP admin-prohibited rather than
+# silently dropped. This lets network scanners (nmap) receive an immediate response
+# for non-allowed traffic instead of waiting for a TCP timeout per host, which makes
+# /24 scans hang for minutes.
+#
+# Explicit student-added deny rules still use 'drop' (silent) so defense exercises
+# work as intended. This rule only fires when no other rule has already matched.
+nft add rule inet ics_fw forward reject with icmp type admin-prohibited
+
 # ── NAT masquerade for attacker zone ───────────────────────────────────────────
 # Without masquerade, return traffic from OT devices back to Kali routes through
 # the Docker host kernel, which Docker's isolation rules block between bridges.

--- a/containers/firewall/reload-fw-rules.sh
+++ b/containers/firewall/reload-fw-rules.sh
@@ -101,5 +101,9 @@ else
     echo "[ics-firewall] No ACL rules — default policy (${POLICY}) applies to all traffic."
 fi
 
+# Terminal reject: unmatched traffic gets ICMP admin-prohibited (fast response for
+# scanners) rather than a silent drop. Explicit deny rules still use 'drop'.
+nft add rule inet ics_fw forward reject with icmp type admin-prohibited
+
 echo "[ics-firewall] Reload complete."
 nft list chain inet ics_fw forward

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -2695,6 +2695,11 @@ function buildNftScript(
     lines.push(parts.join(' '))
   }
 
+  // Terminal reject: unmatched traffic gets ICMP admin-prohibited (immediate response)
+  // rather than a silent drop. Explicit deny rules above still use 'drop'.
+  // This prevents nmap /24 scans from hanging on TCP probe timeouts.
+  lines.push('nft add rule inet ics_fw forward reject with icmp type admin-prohibited')
+
   lines.push(
     'echo "[ics-firewall] Reload complete — $(nft list chain inet ics_fw forward | grep -c rule) rule(s) active"'
   )


### PR DESCRIPTION
## Problem

nmap scans of the full OT subnet (e.g. \`nmap 10.200.10.0/24\`) hang for minutes. Scanning a specific host (\`nmap 10.200.10.10\`) works fine.

**Root cause:** nmap's default host discovery sends TCP SYN probes to ports 443 and 80 for every host in the subnet before doing the actual port scan. The firewall's default-deny policy silently DROPs these probes — no RST, no ICMP response. nmap has to wait for each TCP probe to time out (~10–30 s per host group). With 254 hosts and nmap's adaptive timing slowing down as it sees more timeouts, the scan appears to hang indefinitely.

## Fix

**Terminal reject rule** added as the last rule in the \`ics_fw forward\` chain:
\`\`\`
nft add rule inet ics_fw forward reject with icmp type admin-prohibited
\`\`\`

Unmatched forwarded traffic now gets an immediate ICMP admin-prohibited response instead of a silent drop. nmap receives a fast answer for every probe and moves on immediately.

**Explicit student-added deny rules still use \`drop\`** (silent/stealth) — the terminal reject only fires when no other rule has matched, so Tutorial 03 defense exercises are unaffected.

Applied to: `entrypoint.sh`, `reload-fw-rules.sh` (runtime reload path), and `buildNftScript()` in `main/index.ts` (Apply Rules path).

## Note on Tutorial 01

The tutorial nmap command (`scenarios/tutorial-01-modbus-coil-write.otflab`) was also updated locally from `-T2` to `-T4 -Pn` — scenario files are gitignored so this is a manual deploy step.

## Test plan
- [ ] Start Tutorial 01 simulation
- [ ] From Kali: `nmap -T4 10.200.10.0/24` — should complete in under 30 seconds
- [ ] From Kali: `nmap -T4 10.200.10.10` — should still work as before
- [ ] Tutorial 03: add deny rule for attacker→OT:502, confirm nmap shows port 502 as `filtered` (not `closed`) — explicit deny still uses drop
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)