### PR TITLE
feat: open-relay SMTP mail server for spear-phishing tutorial

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,6 +69,11 @@ jobs:
           # on Alpine. Logs all queries so students observe reconnaissance in real time.
           - image: otforge-dns
             context: containers/dns-server
+          # Phase 12: Corporate mail server — open-relay SMTP (aiosmtpd on Alpine).
+          # Accepts all inbound mail without authentication; logs every message so
+          # students verify spear-phishing delivery in 'docker logs'.
+          - image: otforge-mail
+            context: containers/mail-server
           # Engineering workstation: Ubuntu 22.04 Xfce4 desktop with Wireshark, nmap,
           # and Python ICS protocol tools, served via TigerVNC + noVNC on port 6080.
           - image: otforge-workstation

--- a/containers/dns-server/entrypoint.sh
+++ b/containers/dns-server/entrypoint.sh
@@ -25,6 +25,10 @@ set -e
 
 DNS_DOMAIN="${DNS_DOMAIN:-meridian-process.com}"
 WEB_SERVER_IP="${WEB_SERVER_IP:-203.0.113.10}"
+# MAIL_SERVER_IP defaults to WEB_SERVER_IP when not injected by the compose
+# generator.  The compose generator auto-injects the claimed email-server IP
+# whenever an email-server device is present in the scenario.
+MAIL_SERVER_IP="${MAIL_SERVER_IP:-${WEB_SERVER_IP}}"
 # Use ${VAR-default} (not ${VAR:-default}) so that DNS_UPSTREAM="" (empty string,
 # injected by the compose generator for air-gapped scenarios) is respected.
 # With :- the shell replaces even an empty value with the default.
@@ -33,6 +37,7 @@ DNS_UPSTREAM="${DNS_UPSTREAM-8.8.8.8}"
 echo "[otforge-dns] ================================================"
 echo "[otforge-dns] Domain:      ${DNS_DOMAIN}"
 echo "[otforge-dns] Web server:  ${WEB_SERVER_IP}"
+echo "[otforge-dns] Mail server: ${MAIL_SERVER_IP}"
 if [ -n "${DNS_UPSTREAM}" ]; then
     echo "[otforge-dns] Upstream:    ${DNS_UPSTREAM}"
 else
@@ -67,13 +72,19 @@ domain=${DNS_DOMAIN}
 # exercise by making non-existent names like ot/scada/plc appear to resolve.
 host-record=${DNS_DOMAIN},${WEB_SERVER_IP}
 
-# Specific subdomains — only www and remote resolve (both hosted on the same
-# single internet-facing server). vpn/mail/ot/scada/plc/hmi all return NXDOMAIN:
-# Meridian uses a cloud mail provider (not in this zone) and has no VPN appliance.
-# The OT names are absent from DNS deliberately — the network is reachable only
-# because of the firewall misconfiguration, not because it is advertised.
+# Specific subdomains — www and remote resolve to the internet-facing web server.
+# mail resolves to the mail server (may be the same host as www when MAIL_SERVER_IP
+# was not set explicitly — the compose generator injects a separate IP when an
+# email-server device is present in the scenario).
+# vpn/ot/scada/plc/hmi all return NXDOMAIN — the OT network is reachable only
+# because of the firewall misconfiguration, not because it is advertised in DNS.
 address=/www.${DNS_DOMAIN}/${WEB_SERVER_IP}
 address=/remote.${DNS_DOMAIN}/${WEB_SERVER_IP}
+address=/mail.${DNS_DOMAIN}/${MAIL_SERVER_IP}
+
+# MX record — mail exchange for the domain pointing at mail.${DNS_DOMAIN}
+# Priority 10 is the standard single-server priority (lower = higher priority).
+mx-host=${DNS_DOMAIN},mail.${DNS_DOMAIN},10
 DNSCONF
 
 # Add upstream resolver unless air-gapped mode is requested
@@ -83,6 +94,9 @@ fi
 
 echo "[otforge-dns] Zone records:"
 grep "^address=" /tmp/dnsmasq.conf | while IFS= read -r line; do
+    echo "[otforge-dns]   ${line}"
+done
+grep "^mx-host=" /tmp/dnsmasq.conf | while IFS= read -r line; do
     echo "[otforge-dns]   ${line}"
 done
 echo ""

--- a/containers/mail-server/Dockerfile
+++ b/containers/mail-server/Dockerfile
@@ -1,0 +1,38 @@
+# containers/mail-server/Dockerfile
+#
+# Meridian Process Controls -- corporate mail server for the simulated internet DMZ.
+#
+# Runs a minimal Python SMTP server (aiosmtpd) that accepts all inbound mail
+# for the configured domain without authentication -- a deliberately misconfigured
+# "open relay" that students exploit in the spear-phishing tutorial.
+#
+# Students on Kali send phishing emails using:
+#   curl --url smtp://<mail-ip>:25/ \
+#        --mail-from attacker@evil.com \
+#        --mail-rcpt it@meridian-process.com \
+#        -T phishing.txt
+#
+# Every received message is logged to stdout (visible via 'docker logs') and
+# saved as a .eml file in /var/mail/ so students can verify delivery with:
+#   docker exec <container> ls /var/mail/
+#   docker exec <container> cat /var/mail/<file>
+#
+# Environment variables (with defaults):
+#   MAIL_DOMAIN  -- Domain to display in the startup banner  (default: meridian-process.com)
+#
+# Image: alpine:3.20 + python3 + aiosmtpd (~30 MB total)
+FROM alpine:3.20
+
+RUN apk add --no-cache python3 py3-pip \
+    && pip install --no-cache-dir --break-system-packages aiosmtpd==1.4.6
+
+COPY smtp_server.py /smtp_server.py
+
+RUN mkdir -p /var/mail
+
+ENV MAIL_DOMAIN=meridian-process.com
+
+# Standard SMTP port
+EXPOSE 25
+
+ENTRYPOINT ["python3", "/smtp_server.py"]

--- a/containers/mail-server/smtp_server.py
+++ b/containers/mail-server/smtp_server.py
@@ -28,8 +28,6 @@ Environment variables:
 """
 
 import asyncio
-import email
-import email.policy
 import logging
 import os
 import time
@@ -71,25 +69,36 @@ class OpenRelayHandler:
         """Receive message, log it, and save it to disk."""
         raw = envelope.content  # bytes
 
-        # Parse with Python's email library for structured access
-        msg = email.message_from_bytes(raw, policy=email.policy.default)
-
         sender = envelope.mail_from
         recipients = envelope.rcpt_tos
-        subject = msg.get("Subject", "(no subject)")
 
-        # Extract plain-text body for logging
-        body = ""
-        if msg.is_multipart():
-            for part in msg.walk():
-                if part.get_content_type() == "text/plain":
-                    body = part.get_content()
-                    break
-        else:
-            try:
-                body = msg.get_content()
-            except Exception:
-                body = raw.decode("utf-8", errors="replace")
+        # Parse everything from the raw message bytes directly.
+        # curl sends minimal SMTP messages that often lack Content-Type and other
+        # MIME headers, causing the email library's structured parser to misidentify
+        # headers as body content. Raw line-by-line scanning is more reliable and
+        # handles malformed messages (indented headers, mixed line endings, etc.).
+        raw_str = raw.decode("utf-8", errors="replace")
+
+        # Scan line by line — the first line that is empty or whitespace-only
+        # marks the boundary between headers and body (RFC 5322 section 2.1).
+        header_lines: list[str] = []
+        body_lines: list[str] = []
+        in_body = False
+        for line in raw_str.splitlines():
+            if not in_body and line.strip() == "":
+                in_body = True
+                continue
+            (body_lines if in_body else header_lines).append(line)
+
+        body = "\n".join(body_lines)
+
+        # Extract Subject from headers (strip leading whitespace to handle
+        # indented or folded header lines produced by some mail clients/scripts).
+        subject = "(no subject)"
+        for line in header_lines:
+            if line.strip().lower().startswith("subject:"):
+                subject = line.strip()[8:].strip()
+                break
 
         # Log to stdout so students see it in 'docker logs'
         sep = "=" * 62

--- a/containers/mail-server/smtp_server.py
+++ b/containers/mail-server/smtp_server.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+containers/mail-server/smtp_server.py
+
+OTForge simulated corporate mail server for the internet DMZ zone.
+
+Intentionally misconfigured as an open relay -- no authentication required,
+no SPF/DKIM checks, no recipient validation. All mail to any address is
+accepted and logged. This models the kind of poorly secured mail server
+that is common in legacy ICS environments and enables the spear-phishing
+tutorial attack chain.
+
+Attack chain (from Kali):
+  1. OSINT: scrape email addresses from meridian-process.com HTML source
+  2. Send phishing email:
+       curl --url smtp://<MAIL_IP>:25/              \
+            --mail-from "noreply@update-notice.com" \
+            --mail-rcpt "it@meridian-process.com"   \
+            --upload-file phishing.txt
+  3. Observe delivery in docker logs or /var/mail/
+
+Every received message is:
+  - Logged to stdout in full (From, To, Subject, Body) for 'docker logs' visibility
+  - Saved to /var/mail/<timestamp>_<recipient>.eml for forensic inspection
+
+Environment variables:
+  MAIL_DOMAIN  Displayed in the startup banner (default: meridian-process.com)
+"""
+
+import asyncio
+import email
+import email.policy
+import logging
+import os
+import time
+
+from aiosmtpd.controller import Controller
+from aiosmtpd.smtp import AuthResult
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+MAIL_DOMAIN = os.environ.get("MAIL_DOMAIN", "meridian-process.com")
+MAIL_DIR = "/var/mail"
+
+os.makedirs(MAIL_DIR, exist_ok=True)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[otforge-mail] %(message)s",
+)
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SMTP handler
+# ---------------------------------------------------------------------------
+
+class OpenRelayHandler:
+    """
+    Accepts all mail unconditionally (open relay).
+    Logs every message and writes it to /var/mail/.
+    """
+
+    async def handle_RCPT(self, server, session, envelope, address, rcpt_options):
+        """Accept any recipient without validation."""
+        envelope.rcpt_tos.append(address)
+        return "250 OK"
+
+    async def handle_DATA(self, server, session, envelope):
+        """Receive message, log it, and save it to disk."""
+        raw = envelope.content  # bytes
+
+        # Parse with Python's email library for structured access
+        msg = email.message_from_bytes(raw, policy=email.policy.default)
+
+        sender = envelope.mail_from
+        recipients = envelope.rcpt_tos
+        subject = msg.get("Subject", "(no subject)")
+
+        # Extract plain-text body for logging
+        body = ""
+        if msg.is_multipart():
+            for part in msg.walk():
+                if part.get_content_type() == "text/plain":
+                    body = part.get_content()
+                    break
+        else:
+            try:
+                body = msg.get_content()
+            except Exception:
+                body = raw.decode("utf-8", errors="replace")
+
+        # Log to stdout so students see it in 'docker logs'
+        sep = "=" * 62
+        log.info(sep)
+        log.info("MESSAGE RECEIVED")
+        log.info(f"  From:    {sender}")
+        log.info(f"  To:      {', '.join(recipients)}")
+        log.info(f"  Subject: {subject}")
+        log.info("  --- Body ---")
+        for line in body.strip().splitlines():
+            log.info(f"  {line}")
+        log.info(sep)
+
+        # Save one .eml file per recipient
+        ts = int(time.time())
+        for rcpt in recipients:
+            safe = rcpt.replace("@", "_at_").replace("/", "_").replace("..", "_")
+            filename = f"{ts}_{safe}.eml"
+            filepath = os.path.join(MAIL_DIR, filename)
+            with open(filepath, "wb") as f:
+                f.write(raw)
+            log.info(f"Saved: {filepath}")
+
+        return "250 Message accepted for delivery"
+
+
+# ---------------------------------------------------------------------------
+# Startup
+# ---------------------------------------------------------------------------
+
+async def main():
+    handler = OpenRelayHandler()
+    controller = Controller(
+        handler,
+        hostname="0.0.0.0",
+        port=25,
+    )
+
+    sep = "=" * 62
+    log.info(sep)
+    log.info("OTForge Mail Server")
+    log.info(f"  Domain:   {MAIL_DOMAIN}")
+    log.info( "  SMTP:     port 25  (open relay -- no authentication)")
+    log.info(f"  Storage:  {MAIL_DIR}")
+    log.info( "")
+    log.info( "  Configured mailboxes:")
+    log.info(f"    webmaster@{MAIL_DOMAIN}")
+    log.info(f"    it@{MAIL_DOMAIN}")
+    log.info(f"    support@{MAIL_DOMAIN}")
+    log.info( "")
+    log.info( "  Attack vector (from Kali):")
+    log.info( "    curl --url smtp://<mail-ip>:25/         \\")
+    log.info( "         --mail-from attacker@evil.com      \\")
+    log.info(f"         --mail-rcpt it@{MAIL_DOMAIN} \\")
+    log.info( "         --upload-file phishing.txt")
+    log.info(sep)
+    log.info("")
+    log.info("Waiting for connections...")
+
+    controller.start()
+    try:
+        await asyncio.sleep(float("inf"))
+    finally:
+        controller.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -115,9 +115,9 @@ const DEVICE_IMAGES: Record<DeviceCategory, string> = {
   // Replace with otforge-workstation once published.
   'enterprise-desktop': 'lscr.io/linuxserver/webtop:ubuntu-xfce',
   // ── Internet DMZ (Level 5) ───────────────────────────────────────────────────
-  // STUB: mailhog provides a lightweight SMTP+web UI for email simulation.
-  // Replace with otforge-mail once published.
-  'email-server': 'mailhog/mailhog:latest',
+  // Open-relay SMTP server — aiosmtpd on Alpine (containers/mail-server).
+  // Accepts all inbound mail without auth; logs every message to stdout.
+  'email-server': 'ghcr.io/iburres/otforge-mail:latest',
   // STUB: nginx:alpine for generic internet-facing servers.
   // The tutorial scenario overrides this with otforge-web-company via deviceConfig.dockerImage.
   'internet-server': 'nginx:alpine',
@@ -765,6 +765,32 @@ export function generateCompose(
         // internet) via attacker-net even when the scenario's DNS server is air-gapped
         // (DNS_UPSTREAM=""). Without this fallback, Firefox and apt can't reach the internet.
         services[serviceName].dns = [dnsIp, '8.8.8.8']
+      }
+    }
+
+    // DNS server — auto-inject MAIL_SERVER_IP from the scenario's email-server device
+    // so the dnsmasq entrypoint publishes an MX record and mail.<domain> A record.
+    // Only injected when the scenario contains an email-server; scenarios without one
+    // leave the mail subdomain unadvertised (NXDOMAIN), which is intentional for
+    // exercises that teach DNS enumeration against limited-zone configurations.
+    //
+    // Priority: explicit device.dns.mailServerIp (set in buildDeviceEnv above) wins.
+    // Auto-injection only fires when that key is absent to avoid double-injection.
+    if (device.category === 'dns-server') {
+      const mailDevice = Object.values(scenario.devices.devices).find(
+        d => d.category === 'email-server'
+      )
+      if (mailDevice) {
+        const dnsEnv: string[] = services[serviceName].environment ?? []
+        if (!dnsEnv.some(e => e.startsWith('MAIL_SERVER_IP='))) {
+          // Use the claimed (post-dedup) IP when the email-server was processed before
+          // the dns-server in the JSON object; fall back to resolveDeviceIp otherwise.
+          const mailIp =
+            claimedDeviceIps.get(mailDevice.nodeId) ??
+            resolveDeviceIp(mailDevice.ipAddress, scenario, effectiveZones)
+          dnsEnv.push(`MAIL_SERVER_IP=${mailIp}`)
+          services[serviceName].environment = dnsEnv
+        }
       }
     }
 
@@ -1448,17 +1474,27 @@ function buildDeviceEnv(
       env.push(`PIPELINE_PUMP_MAX_LPM=${pu.pipelinePumpMaxLpm}`)
   }
 
-  // Phase 12: DNS server — inject domain and web server IP from the optional DnsConfig.
+  // Phase 12: DNS server — inject domain and web/mail server IPs from the optional DnsConfig.
   // The container Dockerfile already sets DNS_DOMAIN=meridian-process.com and
   // WEB_SERVER_IP=203.0.113.10 as defaults; these overrides are only emitted when
   // the scenario explicitly configures different values, keeping the Compose YAML clean.
   if (device.dns) {
     if (device.dns.domain) env.push(`DNS_DOMAIN=${device.dns.domain}`)
     if (device.dns.webServerIp) env.push(`WEB_SERVER_IP=${device.dns.webServerIp}`)
+    // MAIL_SERVER_IP: explicit override from DnsConfig (author-set). When omitted,
+    // the outer device loop auto-injects the email-server device's claimed IP instead.
+    if (device.dns.mailServerIp) env.push(`MAIL_SERVER_IP=${device.dns.mailServerIp}`)
     // Use !== undefined (not truthiness check) so that upstream: "" correctly
     // injects DNS_UPSTREAM= (empty), overriding the container default of 8.8.8.8.
     // An empty value triggers air-gapped mode in the dns entrypoint.sh.
     if (device.dns.upstream !== undefined) env.push(`DNS_UPSTREAM=${device.dns.upstream}`)
+  }
+
+  // Mail server — inject domain name if explicitly configured.
+  // The container Dockerfile already sets MAIL_DOMAIN=meridian-process.com;
+  // this override is only emitted when the scenario configures a different domain.
+  if (device.mail?.domain) {
+    env.push(`MAIL_DOMAIN=${device.mail.domain}`)
   }
 
   // PLC program pre-load (Phase 4):

--- a/packages/schema/src/icslab.ts
+++ b/packages/schema/src/icslab.ts
@@ -358,14 +358,48 @@ export interface ProcessUnitConfig {
  *   DNS_DOMAIN      = meridian-process.com
  *   WEB_SERVER_IP   = 203.0.113.10   (RFC 5737 documentation prefix)
  *   DNS_UPSTREAM    = 8.8.8.8
+ *   MAIL_SERVER_IP  = (same as WEB_SERVER_IP when omitted)
  */
 export interface DnsConfig {
   /** Authoritative domain served by this dnsmasq instance (default: meridian-process.com). */
   domain?: string
   /** A-record IP injected for www.<domain> — should match the internet-server IP (default: 203.0.113.10). */
   webServerIp?: string
+  /**
+   * A-record IP injected for mail.<domain> and MX record target.
+   * Should match the email-server device IP in the scenario.
+   * When omitted the DNS entrypoint defaults to the same value as WEB_SERVER_IP.
+   */
+  mailServerIp?: string
   /** Upstream recursive resolver for non-authoritative queries (default: 8.8.8.8). */
   upstream?: string
+}
+
+/**
+ * Runtime configuration for an otforge-mail container.
+ *
+ * The container runs an open-relay SMTP server (aiosmtpd on port 25) that
+ * accepts all inbound mail without authentication -- modelling the insecure
+ * legacy mail infrastructure common in ICS environments.
+ *
+ * Students exploit this to send phishing emails from Kali using:
+ *   curl --url smtp://<mail-ip>:25/ \
+ *        --mail-from attacker@evil.com \
+ *        --mail-rcpt it@meridian-process.com \
+ *        --upload-file phishing.txt
+ *
+ * All received messages are logged to stdout and saved to /var/mail/ inside
+ * the container for forensic verification.
+ *
+ * All fields are optional — the container Dockerfile sets safe defaults:
+ *   MAIL_DOMAIN = meridian-process.com
+ */
+export interface MailConfig {
+  /**
+   * Domain displayed in the startup banner and accepted by the SMTP server.
+   * (default: meridian-process.com)
+   */
+  domain?: string
 }
 
 /**
@@ -418,6 +452,7 @@ export interface DeviceConfig {
   iec104?: Iec104Config // IEC 60870-5-104 config (iec104-rtu devices, Phase 10)
   processUnit?: ProcessUnitConfig // Physics process simulation config (Phase 11)
   dns?: DnsConfig // DNS server config (dns-server devices, Phase 12)
+  mail?: MailConfig // Mail server config (email-server devices)
   plcProgram?: PLCProgramConfig
   safetyPlc?: SafetyPlcConfig // SIS config for safety-plc devices
   dockerImage?: string // override default image for this device type


### PR DESCRIPTION
## Summary

- Adds `otforge-mail` container: an intentionally misconfigured open-relay SMTP server (aiosmtpd, port 25) that accepts all mail without authentication, logs every received message to stdout, and saves `.eml` files to `/var/mail/`
- Wires DNS: `mail.<domain>` A record + MX record auto-generated by `entrypoint.sh`; compose generator auto-injects `MAIL_SERVER_IP` from the scenario's `email-server` device so no manual config is needed
- Extends schema: `DnsConfig.mailServerIp` and `DeviceConfig.mail.domain` fields
- Adds `otforge-mail` to the CI Docker build matrix

## Attack chain enabled (from Kali)

```
printf 'Subject: ...\nFrom: ...\nTo: ...\n\nBody\n' > /tmp/phishing.txt
curl --url smtp://<mail-ip>:25/ --mail-from attacker@evil.com \
     --mail-rcpt it@meridian-process.com --upload-file /tmp/phishing.txt
docker logs <email-server-container>
```

## Test plan

- [x] Container starts and prints startup banner
- [x] Kali sends SMTP via curl — message received, Subject and body correctly parsed
- [x] `.eml` file saved to `/var/mail/`
- [x] DNS resolves `mail.meridian-process.com` → mail server IP
- [x] Image pushed to `ghcr.io/iburres/otforge-mail:latest`
- [x] CI matrix updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)