### PR TITLE
docs: simplify student update flow to git pull + npm run dev

### DIFF
--- a/docs/student-setup.html
+++ b/docs/student-setup.html
@@ -414,14 +414,14 @@ npm run dev</code></pre>
   <!-- ── Getting Updates ── -->
   <h2 id="updating">Getting Updates</h2>
 
-  <p class="platform-label">Windows &mdash; PowerShell (from <code>C:\OTForge</code>)</p>
+  <p>Run these two commands from your OTForge folder &mdash; same on Windows and macOS:</p>
 <pre><code>git pull
 npm run dev</code></pre>
-  <p>Do <strong>not</strong> run <code>npm ci</code> on updates &mdash; it wipes <code>node_modules</code> and breaks the Electron installation. Only run <code>npm ci</code> once during initial setup.</p>
+  <p><code>git pull</code> downloads the latest code. <code>npm run dev</code> rebuilds and relaunches automatically &mdash; nothing else needed.</p>
 
-  <p class="platform-label">macOS &mdash; Terminal (from <code>~/OTForge</code>)</p>
-<pre><code>bash get-updates.sh</code></pre>
-  <p>The script handles resetting <code>package-lock.json</code>, pulling, reinstalling, and rebuilding automatically. Then run <code>npm run dev</code>.</p>
+  <blockquote class="note">
+    <p><strong>If your instructor announces that new packages were added</strong>, run <code>.\get-updates.ps1</code> (Windows) or <code>bash get-updates.sh</code> (macOS) instead of <code>git pull</code>. This is rare &mdash; most updates are source-code only and need nothing more than <code>git pull</code>.</p>
+  </blockquote>
 
   <hr>
 
@@ -529,7 +529,7 @@ npm run dev</code></pre>
         <tr><td>Navigate to OTForge</td><td><code>cd C:\OTForge</code></td><td><code>cd ~/OTForge</code></td></tr>
         <tr><td>Launch OTForge</td><td><code>npm run dev</code></td><td><code>npm run dev</code></td></tr>
         <tr><td>Scenarios folder</td><td><code>C:\OTForge\scenarios\</code></td><td><code>~/OTForge/scenarios/</code></td></tr>
-        <tr><td>Get updates</td><td><code>git pull &amp;&amp; npm run dev</code></td><td><code>bash get-updates.sh</code></td></tr>
+        <tr><td>Get updates</td><td><code>git pull</code> then <code>npm run dev</code></td><td><code>git pull</code> then <code>npm run dev</code></td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/student-setup.md
+++ b/docs/student-setup.md
@@ -137,19 +137,16 @@ This folder is created automatically when you clone the repository. When your in
 
 ## Getting Updates
 
-**Windows (PowerShell in `C:\OTForge`):**
-```powershell
-.\get-updates.ps1
+Run these two commands from your OTForge folder — same on Windows and macOS:
+
+```
+git pull
 npm run dev
 ```
 
-**macOS (Terminal in `~/OTForge`):**
-```bash
-bash get-updates.sh
-npm run dev
-```
+That's it. `git pull` downloads the latest code and `npm run dev` rebuilds and relaunches the app automatically.
 
-> The update scripts handle resetting package files, pulling the latest changes, reinstalling dependencies, and rebuilding automatically. Do **not** run `git pull` directly — it will conflict with platform-specific files that npm rewrites during installation.
+> **If your instructor announces that new packages were added**, run `.\get-updates.ps1` (Windows) or `bash get-updates.sh` (macOS) instead of `git pull`. This is rare — most updates are source-code only and need nothing more than `git pull`.
 
 ---
 
@@ -239,7 +236,7 @@ New-NetFirewallRule `
 | Navigate to OTForge | `cd C:\OTForge` | `cd ~/OTForge` |
 | Launch OTForge | `npm run dev` | `npm run dev` |
 | Scenarios folder | `C:\OTForge\scenarios\` | `~/OTForge/scenarios/` |
-| Get updates | `.\get-updates.ps1` then `npm run dev` | `bash get-updates.sh` then `npm run dev` |
+| Get updates | `git pull` then `npm run dev` | `git pull` then `npm run dev` |
 
 ---
 

--- a/get-updates.sh
+++ b/get-updates.sh
@@ -1,19 +1,51 @@
 #!/usr/bin/env bash
 # get-updates.sh -- Pull the latest OTForge changes and rebuild.
 #
-# Run this instead of "git pull" whenever you want to update.
+# For routine updates all you need is:
+#   git pull && npm run dev
+#
+# This script is only needed when new npm packages were added to package.json.
+# Running it unnecessarily causes npm to rewrite package-lock.json, which
+# breaks future git pulls.
+#
+# Usage: bash get-updates.sh
 set -e
 
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+# ── Step 1: Pull new code ────────────────────────────────────────────────────
 echo "[otforge] Pulling latest changes..."
-git pull
+CHANGED=$(git pull --no-rebase 2>&1)
+echo "$CHANGED"
 
-echo "[otforge] Installing dependencies..."
-npm ci
+# ── Step 2: Reinstall packages only if package-lock.json changed ─────────────
+# npm ci would delete node_modules entirely (including the Electron binary)
+# every time. Use npm install instead -- it only adds/removes packages that
+# actually changed, leaving node_modules intact.
+if echo "$CHANGED" | grep -q 'package-lock.json'; then
+    echo "[otforge] Dependencies changed -- running npm install..."
+    npm install --legacy-peer-deps
+else
+    echo "[otforge] No dependency changes -- skipping npm install."
+fi
 
-echo "[otforge] Installing Electron binary..."
-node node_modules/electron/install.js
+# ── Step 3: Ensure Electron binary is present ────────────────────────────────
+ELECTRON_EXE="$ROOT/node_modules/electron/dist/Electron.app"
+if [ ! -e "$ELECTRON_EXE" ]; then
+    echo "[otforge] Electron binary missing -- reinstalling..."
+    INSTALL_JS="$ROOT/node_modules/electron/install.js"
+    if [ -f "$INSTALL_JS" ]; then
+        node "$INSTALL_JS"
+    else
+        echo "[otforge] install.js not found. Run: node node_modules/electron/install.js"
+    fi
+else
+    echo "[otforge] Electron binary present -- skipping download."
+fi
 
+# ── Step 4: Rebuild TypeScript packages ──────────────────────────────────────
 echo "[otforge] Building packages..."
 npm run build:packages
 
+echo ""
 echo "[otforge] Done. Run 'npm run dev' to launch."


### PR DESCRIPTION
Students no longer need update scripts for routine updates. Both platforms now use the same two commands: git pull then npm run dev (npm run dev already calls build:packages before launching so rebuilding is automatic).

- Getting Updates section rewritten for both md and html: same two commands on Windows and macOS, scripts demoted to a note for the rare case new npm packages are added
- Quick Reference table updated on both platforms: git pull + npm run dev
- Wrong warning removed ("do not run git pull directly" -- was never true)
- get-updates.sh fixed to mirror get-updates.ps1: no npm ci, conditional npm install only when package-lock.json changed, Electron check before download