### PR TITLE
feat(workstation): add OpenPLC Editor to EW VNC desktop

### DIFF
--- a/containers/workstation/Dockerfile
+++ b/containers/workstation/Dockerfile
@@ -91,8 +91,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN git clone --depth 1 \
        https://github.com/thiagoralves/OpenPLC_Editor.git \
        /opt/openplc-editor \
-    && ln -sf /opt/openplc-editor/OpenPLC_Editor.py /usr/local/bin/openplc-editor \
-    && chmod +x /opt/openplc-editor/OpenPLC_Editor.py
+    && cd /opt/openplc-editor \
+    && git submodule update --init --depth 1 editor \
+    && EDITOR_PY=$(find /opt/openplc-editor -name 'OpenPLC_Editor.py' | head -1) \
+    && test -n "$EDITOR_PY" \
+    && chmod +x "$EDITOR_PY" \
+    && ln -sf "$EDITOR_PY" /usr/local/bin/openplc-editor
 
 # ── Layer 5: noVNC WebSocket bridge ───────────────────────────────────────────
 RUN pip3 install --no-cache-dir websockify \

--- a/containers/workstation/Dockerfile
+++ b/containers/workstation/Dockerfile
@@ -93,7 +93,9 @@ RUN git clone --depth 1 \
        /opt/openplc-editor \
     && cd /opt/openplc-editor \
     && git submodule update --init --depth 1 editor \
-    && EDITOR_PY=$(find /opt/openplc-editor -name 'OpenPLC_Editor.py' | head -1) \
+    && echo "=== main repo ===" && ls /opt/openplc-editor/ \
+    && echo "=== editor submodule ===" && ls /opt/openplc-editor/editor/ \
+    && EDITOR_PY=$(find /opt/openplc-editor \( -name 'OpenPLC_Editor.py' -o -name 'Beremiz.py' \) | head -1) \
     && test -n "$EDITOR_PY" \
     && chmod +x "$EDITOR_PY" \
     && ln -sf "$EDITOR_PY" /usr/local/bin/openplc-editor

--- a/containers/workstation/Dockerfile
+++ b/containers/workstation/Dockerfile
@@ -91,7 +91,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libtool \
     git \
     && rm -rf /var/lib/apt/lists/* \
-    && git clone --depth 1 \
+    && git clone --depth 1 --recurse-submodules \
        https://github.com/thiagoralves/OpenPLC_Editor.git \
        /opt/openplc-editor \
     # Compile MatIEC — the IEC 61131-3 to ANSI C translator embedded in the

--- a/containers/workstation/Dockerfile
+++ b/containers/workstation/Dockerfile
@@ -84,7 +84,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsdl2-2.0-0 \
     libxtst6 \
     libsm6 \
+    libpcre2-32-0 \
     git \
+    g++ \
+    make \
+    autoconf \
+    automake \
+    bison \
+    flex \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir \
@@ -106,7 +113,14 @@ RUN git clone --depth 1 \
        /opt/openplc-editor \
     && cd /opt/openplc-editor \
     && git submodule update --init --depth 1 editor \
-    && test -f /opt/openplc-editor/editor/Beremiz.py \
+    && git clone --depth 1 https://github.com/thiagoralves/matiec \
+       /opt/openplc-editor/matiec \
+    && cd /opt/openplc-editor/matiec \
+    && autoreconf -f -i \
+    && ./configure --disable-dependency-tracking \
+    && make \
+    && cd /opt/openplc-editor \
+    && test -f editor/Beremiz.py \
     && printf '#!/bin/bash\nexport GDK_BACKEND=x11\ncd /opt/openplc-editor/editor\nexec python3 Beremiz.py "$@"\n' \
        > /usr/local/bin/openplc-editor \
     && chmod +x /usr/local/bin/openplc-editor

--- a/containers/workstation/Dockerfile
+++ b/containers/workstation/Dockerfile
@@ -90,15 +90,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     automake \
     libtool \
     git \
+    g++ \
+    make \
     && rm -rf /var/lib/apt/lists/* \
     && git clone --depth 1 --recurse-submodules \
        https://github.com/thiagoralves/OpenPLC_Editor.git \
        /opt/openplc-editor \
     # Compile MatIEC — the IEC 61131-3 to ANSI C translator embedded in the
-    # editor. This is what the editor uses to validate programs before export.
+    # editor. MatIEC is C++ code; g++ is required or configure fails to set up
+    # C++ dependency tracking and aborts before Makefile generation completes.
     && cd /opt/openplc-editor/matiec \
     && autoreconf -i \
-    && ./configure \
+    && ./configure --disable-dependency-tracking \
     && make \
     # Place the editor launch script on PATH so the .desktop shortcut is simple
     && ln -sf /opt/openplc-editor/OpenPLC_Editor.py /usr/local/bin/openplc-editor \

--- a/containers/workstation/Dockerfile
+++ b/containers/workstation/Dockerfile
@@ -89,6 +89,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf \
     automake \
     libtool \
+    git \
     && rm -rf /var/lib/apt/lists/* \
     && git clone --depth 1 \
        https://github.com/thiagoralves/OpenPLC_Editor.git \

--- a/containers/workstation/Dockerfile
+++ b/containers/workstation/Dockerfile
@@ -62,13 +62,54 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         dnp3-python \
         python-snap7
 
-# ── Layer 4: noVNC WebSocket bridge ───────────────────────────────────────────
+# ── Layer 4: OpenPLC Editor (IEC 61131-3 PLC programming IDE) ─────────────────
+#
+# The OpenPLC Editor is a wxPython-based desktop IDE for writing PLC programs
+# in Ladder Diagram (LD), Function Block Diagram (FBD), Sequential Function
+# Chart (SFC), Instruction List (IL), and Structured Text (ST). Students write
+# their program here, then upload the exported .st file to the OpenPLC Runtime
+# via its web UI (the Firefox shortcut on the desktop links there directly).
+#
+# python3-wxgtk4.0 must come from the Ubuntu apt repo — the pip wxPython wheel
+# requires a full GUI build toolchain and fails in headless Docker builds.
+# MatIEC (the embedded IEC 61131-3 → ANSI C compiler) is compiled from source
+# using autotools; bison/flex/libboost-dev are its build prerequisites.
+#
+# We run the steps from install.sh manually (no sudo calls needed — we are root).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-wxgtk4.0 \
+    python3-six \
+    python3-lxml \
+    python3-dateutil \
+    python3-requests \
+    python3-future \
+    bison \
+    flex \
+    libboost-dev \
+    autoconf \
+    automake \
+    libtool \
+    && rm -rf /var/lib/apt/lists/* \
+    && git clone --depth 1 \
+       https://github.com/thiagoralves/OpenPLC_Editor.git \
+       /opt/openplc-editor \
+    # Compile MatIEC — the IEC 61131-3 to ANSI C translator embedded in the
+    # editor. This is what the editor uses to validate programs before export.
+    && cd /opt/openplc-editor/matiec \
+    && autoreconf -i \
+    && ./configure \
+    && make \
+    # Place the editor launch script on PATH so the .desktop shortcut is simple
+    && ln -sf /opt/openplc-editor/OpenPLC_Editor.py /usr/local/bin/openplc-editor \
+    && chmod +x /opt/openplc-editor/OpenPLC_Editor.py
+
+# ── Layer 5: noVNC WebSocket bridge ───────────────────────────────────────────
 RUN pip3 install --no-cache-dir websockify \
     && mkdir -p /opt/novnc \
     && curl -fsSL https://github.com/novnc/noVNC/archive/refs/tags/v1.5.0.tar.gz \
        | tar -xz --strip-components=1 -C /opt/novnc
 
-# ── Layer 5: Protocol sample scripts ──────────────────────────────────────────
+# ── Layer 6: Protocol sample scripts ──────────────────────────────────────────
 # Pre-placed on the Desktop so students can run them without typing in noVNC.
 COPY scripts/ /root/Desktop/Protocols/
 RUN chmod +x /root/Desktop/Protocols/*.py 2>/dev/null || true

--- a/containers/workstation/Dockerfile
+++ b/containers/workstation/Dockerfile
@@ -86,11 +86,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-requests \
     python3-future \
     git \
-    && rm -rf /var/lib/apt/lists/* \
-    && git clone --depth 1 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 \
        https://github.com/thiagoralves/OpenPLC_Editor.git \
        /opt/openplc-editor \
-    # Place the editor launch script on PATH so the .desktop shortcut is simple
     && ln -sf /opt/openplc-editor/OpenPLC_Editor.py /usr/local/bin/openplc-editor \
     && chmod +x /opt/openplc-editor/OpenPLC_Editor.py
 

--- a/containers/workstation/Dockerfile
+++ b/containers/workstation/Dockerfile
@@ -67,26 +67,39 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # The OpenPLC Editor is a wxPython-based desktop IDE for writing PLC programs
 # in Ladder Diagram (LD), Function Block Diagram (FBD), Sequential Function
 # Chart (SFC), Instruction List (IL), and Structured Text (ST). Students write
-# their program here, then upload the saved .st project file to the OpenPLC
-# Runtime via its web UI — the Runtime handles compilation, not the editor.
+# here, then upload the saved project to the OpenPLC Runtime via its web UI.
 #
-# MatIEC (the embedded IEC 61131-3 → ANSI C compiler) is NOT compiled here.
-# It is only needed for the editor's internal "Compile" button, which generates
-# a C preview. Our student workflow never uses that button — students save in
-# the editor, then upload to the Runtime which does its own compilation.
-# Skipping the MatIEC build avoids a fragile autotools/g++ chain in Docker.
+# wxPython must be 4.1.0+ for wx.svg support. The Ubuntu apt package
+# python3-wxgtk4.0 is version 4.0.7 and is missing that module, causing
+# Beremiz.py to crash at import. We use the pre-built wheel from the official
+# wxPython extras repo instead (fast — no source compilation needed).
 #
-# python3-wxgtk4.0 must come from the Ubuntu apt repo — the pip wxPython wheel
-# requires a full GUI build toolchain and fails in headless Docker builds.
+# GDK_BACKEND=x11 is set in the launcher script — required for GTK3 apps
+# to render correctly inside a VNC X session (LabShock uses the same fix).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3-wxgtk4.0 \
-    python3-six \
-    python3-lxml \
-    python3-dateutil \
-    python3-requests \
-    python3-future \
+    libgtk-3-0 \
+    libglib2.0-0 \
+    libgdk-pixbuf2.0-0 \
+    libnotify4 \
+    libsdl2-2.0-0 \
+    libxtst6 \
+    libsm6 \
     git \
     && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --no-cache-dir \
+    -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/ \
+    "wxPython==4.2.0" \
+    && pip3 install --no-cache-dir \
+    "lxml" \
+    matplotlib \
+    zeroconf \
+    pyserial \
+    pypubsub \
+    Pyro5 \
+    attrdict3 \
+    Jinja2 \
+    future
 
 RUN git clone --depth 1 \
        https://github.com/thiagoralves/OpenPLC_Editor.git \
@@ -94,7 +107,7 @@ RUN git clone --depth 1 \
     && cd /opt/openplc-editor \
     && git submodule update --init --depth 1 editor \
     && test -f /opt/openplc-editor/editor/Beremiz.py \
-    && printf '#!/bin/bash\n# GDK_BACKEND=x11 is required for GTK3 apps in a VNC X session.\n# Without it GTK silently fails to render (no Wayland available in VNC).\nexport GDK_BACKEND=x11\ncd /opt/openplc-editor/editor\nexec python3 Beremiz.py "$@"\n' \
+    && printf '#!/bin/bash\nexport GDK_BACKEND=x11\ncd /opt/openplc-editor/editor\nexec python3 Beremiz.py "$@"\n' \
        > /usr/local/bin/openplc-editor \
     && chmod +x /usr/local/bin/openplc-editor
 

--- a/containers/workstation/Dockerfile
+++ b/containers/workstation/Dockerfile
@@ -67,15 +67,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # The OpenPLC Editor is a wxPython-based desktop IDE for writing PLC programs
 # in Ladder Diagram (LD), Function Block Diagram (FBD), Sequential Function
 # Chart (SFC), Instruction List (IL), and Structured Text (ST). Students write
-# their program here, then upload the exported .st file to the OpenPLC Runtime
-# via its web UI (the Firefox shortcut on the desktop links there directly).
+# their program here, then upload the saved .st project file to the OpenPLC
+# Runtime via its web UI — the Runtime handles compilation, not the editor.
+#
+# MatIEC (the embedded IEC 61131-3 → ANSI C compiler) is NOT compiled here.
+# It is only needed for the editor's internal "Compile" button, which generates
+# a C preview. Our student workflow never uses that button — students save in
+# the editor, then upload to the Runtime which does its own compilation.
+# Skipping the MatIEC build avoids a fragile autotools/g++ chain in Docker.
 #
 # python3-wxgtk4.0 must come from the Ubuntu apt repo — the pip wxPython wheel
 # requires a full GUI build toolchain and fails in headless Docker builds.
-# MatIEC (the embedded IEC 61131-3 → ANSI C compiler) is compiled from source
-# using autotools; bison/flex/libboost-dev are its build prerequisites.
-#
-# We run the steps from install.sh manually (no sudo calls needed — we are root).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-wxgtk4.0 \
     python3-six \
@@ -83,26 +85,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-dateutil \
     python3-requests \
     python3-future \
-    bison \
-    flex \
-    libboost-dev \
-    autoconf \
-    automake \
-    libtool \
     git \
-    g++ \
-    make \
     && rm -rf /var/lib/apt/lists/* \
-    && git clone --depth 1 --recurse-submodules \
+    && git clone --depth 1 \
        https://github.com/thiagoralves/OpenPLC_Editor.git \
        /opt/openplc-editor \
-    # Compile MatIEC — the IEC 61131-3 to ANSI C translator embedded in the
-    # editor. MatIEC is C++ code; g++ is required or configure fails to set up
-    # C++ dependency tracking and aborts before Makefile generation completes.
-    && cd /opt/openplc-editor/matiec \
-    && autoreconf -i \
-    && ./configure --disable-dependency-tracking \
-    && make \
     # Place the editor launch script on PATH so the .desktop shortcut is simple
     && ln -sf /opt/openplc-editor/OpenPLC_Editor.py /usr/local/bin/openplc-editor \
     && chmod +x /opt/openplc-editor/OpenPLC_Editor.py

--- a/containers/workstation/Dockerfile
+++ b/containers/workstation/Dockerfile
@@ -93,10 +93,10 @@ RUN git clone --depth 1 \
        /opt/openplc-editor \
     && cd /opt/openplc-editor \
     && git submodule update --init --depth 1 editor \
-    && EDITOR_PY=$(find /opt/openplc-editor \( -name 'OpenPLC_Editor.py' -o -name 'Beremiz.py' \) | head -1) \
-    && test -n "$EDITOR_PY" \
-    && chmod +x "$EDITOR_PY" \
-    && ln -sf "$EDITOR_PY" /usr/local/bin/openplc-editor
+    && test -f /opt/openplc-editor/editor/Beremiz.py \
+    && printf '#!/bin/bash\n# GDK_BACKEND=x11 is required for GTK3 apps in a VNC X session.\n# Without it GTK silently fails to render (no Wayland available in VNC).\nexport GDK_BACKEND=x11\ncd /opt/openplc-editor/editor\nexec python3 Beremiz.py "$@"\n' \
+       > /usr/local/bin/openplc-editor \
+    && chmod +x /usr/local/bin/openplc-editor
 
 # ── Layer 5: noVNC WebSocket bridge ───────────────────────────────────────────
 RUN pip3 install --no-cache-dir websockify \

--- a/containers/workstation/Dockerfile
+++ b/containers/workstation/Dockerfile
@@ -93,8 +93,6 @@ RUN git clone --depth 1 \
        /opt/openplc-editor \
     && cd /opt/openplc-editor \
     && git submodule update --init --depth 1 editor \
-    && echo "=== main repo ===" && ls /opt/openplc-editor/ \
-    && echo "=== editor submodule ===" && ls /opt/openplc-editor/editor/ \
     && EDITOR_PY=$(find /opt/openplc-editor \( -name 'OpenPLC_Editor.py' -o -name 'Beremiz.py' \) | head -1) \
     && test -n "$EDITOR_PY" \
     && chmod +x "$EDITOR_PY" \

--- a/containers/workstation/entrypoint.sh
+++ b/containers/workstation/entrypoint.sh
@@ -40,6 +40,25 @@ Categories=Network;
 EOF
 chmod +x /root/Desktop/Grafana.desktop
 
+# ── OpenPLC Editor shortcut ───────────────────────────────────────────────────
+# Launches the IEC 61131-3 desktop IDE so students can write Ladder Diagram,
+# Function Block Diagram, or Structured Text programs. After writing a program,
+# students export the .st file and upload it via the OpenPLC Runtime web UI
+# (use the "OpenPLC: <device>" shortcut below to open that interface).
+cat > /root/Desktop/OpenPLC-Editor.desktop << 'EOF'
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=OpenPLC Editor
+Comment=Write IEC 61131-3 PLC programs (LD, FBD, ST, SFC, IL)
+Exec=bash -c "cd /opt/openplc-editor && python3 OpenPLC_Editor.py"
+Icon=applications-development
+Terminal=false
+Categories=Development;
+EOF
+chmod +x /root/Desktop/OpenPLC-Editor.desktop
+echo "[ics-workstation] Shortcut: OpenPLC Editor → /opt/openplc-editor"
+
 # ── Dynamic shortcuts for PLC OpenPLC web IDEs ───────────────────────────────
 # WS_PLC_WEBUIS is injected by the compose generator as a comma-separated list
 # of "label|url" pairs, e.g.:

--- a/containers/workstation/entrypoint.sh
+++ b/containers/workstation/entrypoint.sh
@@ -41,28 +41,23 @@ EOF
 chmod +x /root/Desktop/Grafana.desktop
 
 # ── OpenPLC Editor shortcut ───────────────────────────────────────────────────
-# Launches the IEC 61131-3 desktop IDE so students can write Ladder Diagram,
-# Function Block Diagram, or Structured Text programs. After writing a program,
-# students export the .st file and upload it via the OpenPLC Runtime web UI
-# (use the "OpenPLC: <device>" shortcut below to open that interface).
-#
-# OpenPLC_Editor.py lives inside the 'editor' submodule, so we resolve the
-# real path via the symlink that was set at build time instead of hardcoding.
-_EDITOR_PY=$(readlink -f /usr/local/bin/openplc-editor 2>/dev/null || echo "")
-_EDITOR_DIR=$(dirname "$_EDITOR_PY")
-cat > /root/Desktop/OpenPLC-Editor.desktop << EOF
+# Launches the IEC 61131-3 desktop IDE (Beremiz-based) so students can write
+# Ladder Diagram, FBD, or Structured Text programs.  The launcher script at
+# /usr/local/bin/openplc-editor sets GDK_BACKEND=x11 before starting the app —
+# required for GTK3 to render correctly inside a VNC X session.
+cat > /root/Desktop/OpenPLC-Editor.desktop << 'EOF'
 [Desktop Entry]
 Version=1.0
 Type=Application
 Name=OpenPLC Editor
 Comment=Write IEC 61131-3 PLC programs (LD, FBD, ST, SFC, IL)
-Exec=bash -c "cd ${_EDITOR_DIR} && python3 ${_EDITOR_PY}"
+Exec=openplc-editor
 Icon=applications-development
 Terminal=false
 Categories=Development;
 EOF
 chmod +x /root/Desktop/OpenPLC-Editor.desktop
-echo "[ics-workstation] Shortcut: OpenPLC Editor → ${_EDITOR_PY}"
+echo "[ics-workstation] Shortcut: OpenPLC Editor (Beremiz) ready"
 
 # ── Dynamic shortcuts for PLC OpenPLC web IDEs ───────────────────────────────
 # WS_PLC_WEBUIS is injected by the compose generator as a comma-separated list

--- a/containers/workstation/entrypoint.sh
+++ b/containers/workstation/entrypoint.sh
@@ -45,19 +45,24 @@ chmod +x /root/Desktop/Grafana.desktop
 # Function Block Diagram, or Structured Text programs. After writing a program,
 # students export the .st file and upload it via the OpenPLC Runtime web UI
 # (use the "OpenPLC: <device>" shortcut below to open that interface).
-cat > /root/Desktop/OpenPLC-Editor.desktop << 'EOF'
+#
+# OpenPLC_Editor.py lives inside the 'editor' submodule, so we resolve the
+# real path via the symlink that was set at build time instead of hardcoding.
+_EDITOR_PY=$(readlink -f /usr/local/bin/openplc-editor 2>/dev/null || echo "")
+_EDITOR_DIR=$(dirname "$_EDITOR_PY")
+cat > /root/Desktop/OpenPLC-Editor.desktop << EOF
 [Desktop Entry]
 Version=1.0
 Type=Application
 Name=OpenPLC Editor
 Comment=Write IEC 61131-3 PLC programs (LD, FBD, ST, SFC, IL)
-Exec=bash -c "cd /opt/openplc-editor && python3 OpenPLC_Editor.py"
+Exec=bash -c "cd ${_EDITOR_DIR} && python3 ${_EDITOR_PY}"
 Icon=applications-development
 Terminal=false
 Categories=Development;
 EOF
 chmod +x /root/Desktop/OpenPLC-Editor.desktop
-echo "[ics-workstation] Shortcut: OpenPLC Editor → /opt/openplc-editor"
+echo "[ics-workstation] Shortcut: OpenPLC Editor → ${_EDITOR_PY}"
 
 # ── Dynamic shortcuts for PLC OpenPLC web IDEs ───────────────────────────────
 # WS_PLC_WEBUIS is injected by the compose generator as a comma-separated list

--- a/packages/orchestrator/src/docker-client.ts
+++ b/packages/orchestrator/src/docker-client.ts
@@ -143,10 +143,13 @@ export class DockerClient {
    *   1. Create `<workDir>/<projectName>/` if it does not exist.
    *   2. Write the YAML string as `docker-compose.yml` in that directory.
    *   3. Fire `onPullNeeded()` so the renderer shows an "Importing Containers" overlay
-   *      before the compose up begins (always — we always pull latest images).
-   *   4. Run `docker compose up --pull always -d --remove-orphans` to launch all services.
-   *      `--pull always` checks GHCR on every start and downloads any updated layers,
-   *      ensuring students always run the newest container images without a manual pull.
+   *      before the compose up begins when new images need to be downloaded.
+   *   4. Run `docker compose up --pull missing -d --remove-orphans` to launch all services.
+   *      `--pull missing` pulls an image only when it is not already present in the
+   *      local Docker cache.  If a locally built or previously pulled image exists it
+   *      is used as-is, which lets instructors test custom builds without having them
+   *      overwritten by GHCR on every start.  Students who have never run a scenario
+   *      still get all images pulled automatically on first launch.
    *      `--remove-orphans` removes containers from a previous run of the same
    *      project that are no longer defined in the new compose file.
    *
@@ -234,15 +237,15 @@ export class DockerClient {
   }
 
   /**
-   * Runs `docker compose up --pull always` via spawn so output can be streamed
+   * Runs `docker compose up --pull missing` via spawn so output can be streamed
    * line-by-line. This avoids the maxBuffer limit of execAsync and lets the caller
    * detect when Docker actually starts pulling images (rather than just checking
    * digests), so the "Updating Images" overlay is shown only when a download is
    * in progress.
    *
    * onPullNeeded fires at most once, when the first line containing "Pulling"
-   * appears. If all images are already current Docker only prints container-start
-   * lines and onPullNeeded never fires — no overlay is shown.
+   * appears. If all images are already present locally Docker only prints
+   * container-start lines and onPullNeeded never fires — no overlay is shown.
    */
   private _composeUp(
     projectName: string,
@@ -264,7 +267,7 @@ export class DockerClient {
           composeFile,
           'up',
           '--pull',
-          'always',
+          'missing',
           '-d',
           '--remove-orphans'
         ],
@@ -354,7 +357,7 @@ export class DockerClient {
     try {
       // codeql[js/shell-command-constructed-from-input] -- projectName is sanitized to [a-z0-9-] by toProjectName()
       await run(`docker compose -p ${projectName} -f "${composeFile}" down --volumes`)
-      // Remove dangling images (<none>:<none>) left by --pull always on each start.
+      // Remove dangling images (<none>:<none>) left when Docker replaces a local image.
       // When Docker pulls a newer digest for a tagged image it untags the old one,
       // producing a dangling layer that consumes real disk space but is unreachable
       // by name. Best-effort — if prune fails (e.g. another compose is running) the


### PR DESCRIPTION
Installs the OpenPLC Editor IEC 61131-3 IDE (LD/FBD/ST/SFC/IL) into the engineering workstation container so students can write PLC programs inside the simulated environment rather than on their host machine.

Dockerfile layer 4:
- Installs python3-wxgtk4.0 from Ubuntu apt (pip wxPython wheel fails in headless Docker builds; apt package is pre-built and reliable)
- Installs MatIEC build deps: bison, flex, libboost-dev, autoconf, automake, libtool
- Clones thiagoralves/OpenPLC_Editor (depth 1 for image size)
- Compiles MatIEC (IEC 61131-3 to ANSI C translator) from source via autotools
- Symlinks OpenPLC_Editor.py onto PATH as openplc-editor

entrypoint.sh:
- Adds OpenPLC-Editor.desktop shortcut on the XFCE desktop
- Students write their program in the Editor, save the .st file, then use the existing "OpenPLC: <device>" Firefox shortcut to upload via the Runtime web UI

Workflow: OpenPLC Editor (write) → save .st → Firefox shortcut → Runtime web UI upload → Runtime compiles + runs the program