### PR TITLE
feat(schema): add sensor node categories and SensorConfig for FUXA pr…

### DIFF
--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -325,6 +325,9 @@ const DEFAULT_PROTOCOLS: Record<DeviceCategory, Protocol[]> = {
   pmu: ['dnp3'], // PMUs report via DNP3 by default; IEC 61850 in substation deployments
   'iiot-sensor': ['mqtt'], // wireless IIoT sensor publishes MQTT
   'iot-gateway': ['mqtt'], // gateway bridges MQTT ↔ OPC-UA/historian
+  'temperature-sensor': ['modbus-tcp'], // FUXA Simulator → PLC via Modbus TCP
+  'gas-detector': ['modbus-tcp'],
+  'vibration-sensor': ['modbus-tcp'],
   // ── Control Center (L3) ─────────────────────────────────────────────────────
   hmi: ['none'],
   historian: ['none'],
@@ -376,6 +379,9 @@ const CATEGORY_LABELS: Record<DeviceCategory, string> = {
   pmu: 'PMU',
   'iiot-sensor': 'IIoT Sensor',
   'iot-gateway': 'IoT GW',
+  'temperature-sensor': 'Temp Sensor',
+  'gas-detector': 'Gas Detector',
+  'vibration-sensor': 'Vibration',
   // ── Control Center (L3) ─────────────────────────────────────────────────────
   hmi: 'HMI',
   historian: 'Historian',

--- a/packages/app/src/renderer/src/canvas/connectionRules.ts
+++ b/packages/app/src/renderer/src/canvas/connectionRules.ts
@@ -1072,6 +1072,9 @@ const CATEGORY_NAMES: Record<DeviceCategory, string> = {
   pmu: 'Phasor Measurement Unit',
   'iiot-sensor': 'IIoT Sensor',
   'iot-gateway': 'IoT Gateway',
+  'temperature-sensor': 'Temperature Sensor',
+  'gas-detector': 'Gas Detector',
+  'vibration-sensor': 'Vibration Sensor',
   hmi: 'HMI',
   historian: 'Historian',
   'scada-server': 'SCADA Server',
@@ -1154,6 +1157,9 @@ const DEVICE_CABLE_CAPABILITIES: Record<DeviceCategory, Set<CableType>> = {
   pmu: new Set(['cat5e', 'cat6', 'mmf', 'smf', 'ac']), // Ethernet/fiber; GPS antenna not modeled
   'iiot-sensor': new Set(['wifi', 'dc']), // wireless only; battery/loop powered
   'iot-gateway': new Set(['rs485', 'cat5e', 'cat6', 'wifi', 'ac']), // bridges serial→Ethernet
+  'temperature-sensor': new Set(['rs485', 'cat5e', 'dc']), // 4-20 mA loop / Modbus RTU / Ethernet
+  'gas-detector': new Set(['rs485', 'cat5e', 'dc']), // 4-20 mA loop / Modbus RTU / relay
+  'vibration-sensor': new Set(['rs485', 'cat5e', 'wifi', 'dc']), // 4-20 mA / wireless IIoT
 
   // ── Control center (L3) — Ethernet; EWS also has RS-232 console port ─────────────
   // HMI: Cat5e/Cat6 wired; modern panel PCs may also have Wi-Fi for roaming tablets.

--- a/packages/app/src/renderer/src/icons/DeviceIcons.tsx
+++ b/packages/app/src/renderer/src/icons/DeviceIcons.tsx
@@ -714,6 +714,60 @@ function IotGatewaySvg() {
 }
 
 /**
+ * Temperature Sensor / Transmitter — ISA instrument bubble with an internal
+ * vertical bar representing a mercury/RTD element. Follows ISA-5.1 "TT" symbol
+ * (Temperature Transmitter). 4-20 mA or HART output to PLC/DCS.
+ */
+function TemperatureSensorSvg() {
+  return (
+    <svg viewBox="0 0 24 24" {...S}>
+      {/* ISA instrument bubble */}
+      <circle cx="12" cy="13" r="9" />
+      {/* RTD / thermometer element — vertical bar with bulb */}
+      <line x1="12" y1="7" x2="12" y2="14" />
+      <circle cx="12" cy="15.5" r="1.5" fill="currentColor" stroke="none" />
+      {/* Connection nub at top */}
+      <line x1="12" y1="4" x2="12" y2="4" />
+    </svg>
+  )
+}
+
+/**
+ * Gas Detector — ISA instrument bubble with a stylized cloud / plume indicating
+ * the gas sensing element. Represents fixed combustible gas (LEL), toxic gas
+ * (H₂S, CO), or oxygen-depletion detectors common in oil & gas and water treatment.
+ */
+function GasDetectorSvg() {
+  return (
+    <svg viewBox="0 0 24 24" {...S}>
+      {/* ISA instrument bubble */}
+      <circle cx="12" cy="14" r="8" />
+      {/* Gas plume — bumpy cloud shape above center */}
+      <path d="M8 12 Q9 9 12 10 Q13 7.5 16 9 Q17 11 16 12" />
+      {/* Center sensing element dot */}
+      <circle cx="12" cy="14" r="1.5" fill="currentColor" stroke="none" />
+    </svg>
+  )
+}
+
+/**
+ * Vibration Sensor / Accelerometer — ISA instrument bubble with three sine-wave
+ * arcs representing mechanical vibration. Used for rotating machinery health
+ * monitoring (bearings, pumps, compressors) via 4-20 mA or IIoT wireless.
+ */
+function VibrationSensorSvg() {
+  return (
+    <svg viewBox="0 0 24 24" {...S}>
+      {/* ISA instrument bubble */}
+      <circle cx="12" cy="13" r="9" />
+      {/* Vibration wave lines */}
+      <path d="M7 11 Q8.5 9 10 11 Q11.5 13 13 11 Q14.5 9 16 11" />
+      <path d="M7 14 Q8.5 12 10 14 Q11.5 16 13 14 Q14.5 12 16 14" />
+    </svg>
+  )
+}
+
+/**
  * SCADA Server / Master Station — horizontal workstation-style chassis with a
  * mini P&ID display on the front panel (a sensor bubble + pipe + pump circle),
  * representing the process visualization running on the SCADA backend. Distinct
@@ -855,6 +909,9 @@ const ICON_MAP: Record<DeviceCategory, () => JSX.Element> = {
   pmu: PmuSvg, // IEEE C37.118 Phasor Measurement Unit
   'iiot-sensor': IiotSensorSvg, // IIoT wireless sensor node
   'iot-gateway': IotGatewaySvg, // IIoT protocol gateway / Modbus-to-MQTT bridge
+  'temperature-sensor': TemperatureSensorSvg, // RTD/thermocouple temperature transmitter
+  'gas-detector': GasDetectorSvg, // fixed combustible/toxic gas detector
+  'vibration-sensor': VibrationSensorSvg, // rotating machinery vibration / accelerometer
   // ── Control Center (Level 3) ────────────────────────────────────────────────
   hmi: HmiSvg,
   historian: HistorianSvg,

--- a/packages/orchestrator/src/__tests__/schema-fuzz.test.ts
+++ b/packages/orchestrator/src/__tests__/schema-fuzz.test.ts
@@ -106,7 +106,10 @@ const deviceCategory = fc.constantFrom(
   'dns-server',
   'process-unit',
   'flow-meter',
-  'pressure-transmitter'
+  'pressure-transmitter',
+  'temperature-sensor',
+  'gas-detector',
+  'vibration-sensor'
 )
 
 /** Well-formed CIDR strings from common RFC 1918 ranges */

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -79,6 +79,10 @@ const DEVICE_IMAGES: Record<DeviceCategory, string> = {
   'iiot-sensor': 'ghcr.io/iburres/alpine:latest',
   // STUB: IoT gateway — MQTT broker/bridge stub until otforge-iot-gateway is built.
   'iot-gateway': 'ghcr.io/iburres/alpine:latest',
+  // No container — values live in FUXA Simulator; image field satisfies Record type only.
+  'temperature-sensor': '',
+  'gas-detector': '',
+  'vibration-sensor': '',
   // ── Control Center (Level 3) ────────────────────────────────────────────────
   hmi: 'ghcr.io/iburres/fuxa:latest',
   // OPC UA 1.04 server — asyncua Python server on Alpine (containers/opcua)
@@ -158,6 +162,10 @@ const DEVICE_LIMITS: Record<DeviceCategory, { memory: number; cpus: string }> = 
   pmu: { memory: 80, cpus: '0.2' }, // PMU — DNP3/IEC C37.118 publisher
   'iiot-sensor': { memory: 64, cpus: '0.1' }, // IIoT sensor — lightweight MQTT publish loop
   'iot-gateway': { memory: 96, cpus: '0.2' }, // IoT gateway — MQTT broker + protocol bridge
+  // No container — zero resource budget; FUXA Simulator provides the synthetic values.
+  'temperature-sensor': { memory: 0, cpus: '0' },
+  'gas-detector': { memory: 0, cpus: '0' },
+  'vibration-sensor': { memory: 0, cpus: '0' },
   // ── Control Center (Level 3) ────────────────────────────────────────────────
   hmi: { memory: 256, cpus: '0.5' }, // FUXA Node.js HMI
   'scada-server': { memory: 256, cpus: '0.5' }, // OPC UA server (asyncua Python)
@@ -502,7 +510,18 @@ export function generateCompose(
     return `${prefix}${host}`
   }
 
+  // Sensor categories that live entirely inside FUXA's Simulator device — no Docker
+  // container is spawned. fuxa-provisioning.ts reads their SensorConfig and generates
+  // the corresponding FUXA device/tag JSON before compose up.
+  const FUXA_SENSOR_CATEGORIES = new Set<DeviceCategory>([
+    'temperature-sensor',
+    'gas-detector',
+    'vibration-sensor'
+  ])
+
   for (const [nodeId, device] of Object.entries(scenario.devices.devices)) {
+    if (FUXA_SENSOR_CATEGORIES.has(device.category)) continue
+
     // Use a custom image if specified (for advanced scenarios), otherwise use the category default
     const image = device.dockerImage ?? DEVICE_IMAGES[device.category]
     const limits = DEVICE_LIMITS[device.category]

--- a/packages/schema/src/icslab.ts
+++ b/packages/schema/src/icslab.ts
@@ -87,6 +87,9 @@ export type DeviceCategory =
   | 'pmu' // Phasor Measurement Unit — IEEE C37.118 synchrophasor, GPS-timestamped grid telemetry
   | 'iiot-sensor' // IIoT wireless sensor node — WirelessHART, ISA100.11a, MQTT publisher
   | 'iot-gateway' // IIoT protocol gateway — Modbus-to-MQTT/REST bridge, edge aggregator
+  | 'temperature-sensor' // Temperature transmitter — RTD/thermocouple, 4-20 mA / HART output
+  | 'gas-detector' // Fixed gas detector — combustible / toxic gas, 4-20 mA / relay output
+  | 'vibration-sensor' // Vibration / proximity sensor — rotating machinery health monitoring
   // ── Control Center (Level 3) ─────────────────────────────────────────────────
   | 'hmi'
   | 'historian'
@@ -575,6 +578,72 @@ export interface RtuConfig {
   siteType?: string
 }
 
+/**
+ * Physics simulation parameters for sensor nodes on the OT canvas.
+ *
+ * Sensor nodes (temperature-sensor, pressure-transmitter, flow-meter,
+ * level-transmitter, gas-detector, vibration-sensor) do NOT spawn Docker
+ * containers. Instead, this config is read at simulation start by
+ * fuxa-provisioning.ts and written into FUXA's device/tag JSON so the
+ * FUXA Simulator device generates realistic synthetic process values.
+ *
+ * The PLC polls sensor values over real Modbus TCP — FUXA exposes each
+ * sensor tag as a holding register at the address in `modbusRegister`.
+ * Students can capture this traffic in Wireshark on the OT network.
+ *
+ * Waveforms map directly to FUXA's Simulator signal types:
+ *   sine     — smooth oscillation between min and max (default for most sensors)
+ *   random   — white noise bounded by min/max (gas detectors, turbulence)
+ *   sawtooth — linear ramp then reset (e.g. tank level during fill/drain cycle)
+ *   square   — two-state output (e.g. discrete level switch, pump run/stop)
+ *   constant — fixed value at (min + max) / 2 (baseline / fault scenario)
+ */
+export interface SensorConfig {
+  /**
+   * FUXA Simulator waveform type for this sensor tag.
+   * Determines the shape of the synthetic process value over time.
+   */
+  waveform: 'sine' | 'random' | 'sawtooth' | 'square' | 'constant'
+  /** Minimum engineering value (bottom of the 4-20 mA / signal range). */
+  minValue: number
+  /** Maximum engineering value (top of the 4-20 mA / signal range). */
+  maxValue: number
+  /** Engineering units string displayed on the FUXA HMI gauge (e.g. "°C", "bar", "L/min", "ppm", "mm/s²"). */
+  units: string
+  /**
+   * Random noise added on top of the waveform as a percentage of the full range.
+   * 0 = clean waveform; 5 = ±5% noise (typical for field instruments); 20 = noisy.
+   */
+  noisePercent: number
+  /**
+   * Modbus holding register address FUXA exposes this tag on (0-based).
+   * The PLC reads this register via FC03 to get the current sensor value.
+   * Assign unique addresses per sensor — duplicates cause silent value collisions.
+   */
+  modbusRegister: number
+  /**
+   * FUXA tag update interval in milliseconds (default 1000).
+   * Lower values produce faster waveforms and higher Modbus polling load.
+   */
+  sampleRateMs?: number
+  /**
+   * Low end of the normal operating band (optional — used for FUXA alarm config).
+   * When the simulated value drops below this threshold, FUXA highlights the tag.
+   */
+  normalMin?: number
+  /**
+   * High end of the normal operating band (optional — used for FUXA alarm config).
+   * When the simulated value exceeds this threshold, FUXA highlights the tag.
+   */
+  normalMax?: number
+  /**
+   * FUXA tag name override. When absent, fuxa-provisioning.ts auto-generates a
+   * name from the device label (e.g. "TT-101" becomes tag "TT_101").
+   * Must be unique within the scenario — FUXA uses this as the tag identifier.
+   */
+  tagName?: string
+}
+
 export interface DeviceConfig {
   nodeId: string // matches CanvasNode.id
   category: DeviceCategory
@@ -595,6 +664,7 @@ export interface DeviceConfig {
   plcProgram?: PLCProgramConfig
   safetyPlc?: SafetyPlcConfig // SIS config for safety-plc devices
   rtuConfig?: RtuConfig // RTU deployment configuration (rtu, iec104-rtu devices)
+  sensor?: SensorConfig // Physics simulation parameters for sensor canvas nodes (no container)
   dockerImage?: string // override default image for this device type
   /**
    * Additional Purdue Model zone networks to attach this device to, beyond the


### PR DESCRIPTION
…ovisioning

Add three new DeviceCategory values alongside existing flow-meter, pressure-transmitter, and level-transmitter: temperature-sensor, gas-detector, and vibration-sensor. Add SensorConfig interface with FUXA Simulator physics parameters (waveform, min/max, units, noise, modbusRegister, sampleRateMs, alarm thresholds, tagName). Add optional sensor field to DeviceConfig. No containers — sensor values live in FUXA and are polled by the PLC over Modbus TCP.