### PR TITLE
Consolidate FUXA-simulated sensors into smart-sensor

### DIFF
--- a/docs/research/fuxa-demo-export.json
+++ b/docs/research/fuxa-demo-export.json
@@ -1,0 +1,1943 @@
+{
+  "devices": {
+    "MyOPC UA": {
+      "id": "f4e2f73e-56414b65",
+      "property": {
+        "address": "opc.tcp://maxim:48010",
+        "port": null,
+        "slot": null,
+        "rack": null
+      },
+      "enabled": false,
+      "tags": {
+        "ns=2;s=Demo.Static.Scalar.Byte": {
+          "id": "ns=2;s=Demo.Static.Scalar.Byte",
+          "name": "ns=2;s=Demo.Static.Scalar.Byte",
+          "type": "Byte",
+          "address": "ns=2;s=Demo.Static.Scalar.Byte"
+        },
+        "ns=2;s=Demo.Static.Scalar.Int16": {
+          "id": "ns=2;s=Demo.Static.Scalar.Int16",
+          "name": "ns=2;s=Demo.Static.Scalar.Int16",
+          "type": "Int16",
+          "address": "ns=2;s=Demo.Static.Scalar.Int16"
+        }
+      },
+      "name": "MyOPC UA",
+      "type": "OPCUA"
+    },
+    "SPS": {
+      "id": "133b69e2-3f58-4107-8eca-6e9225a1d8ce",
+      "property": {
+        "address": "192.168.1.177",
+        "port": 102,
+        "slot": 2,
+        "rack": 0
+      },
+      "enabled": false,
+      "tags": {
+        "Bit 0.0": {
+          "id": "Bit 0.0",
+          "name": "Bit 0.0",
+          "type": "Bool",
+          "address": "db1.dbx0.0"
+        },
+        "Byte 1": {
+          "id": "Byte 1",
+          "name": "Byte 1",
+          "type": "Byte",
+          "address": "db2.dbb1"
+        },
+        "Byte 2": {
+          "id": "Byte 2",
+          "name": "Byte 2",
+          "type": "Byte",
+          "address": "db2.dbb2"
+        },
+        "Byte 3": {
+          "id": "Byte 3",
+          "name": "Byte 3",
+          "type": "Byte",
+          "address": "db2.dbb3"
+        },
+        "Byte 4": {
+          "id": "Byte 4",
+          "name": "Byte 4",
+          "type": "Byte",
+          "address": "db2.dbb4"
+        },
+        "Byte 5": {
+          "id": "Byte 5",
+          "name": "Byte 5",
+          "type": "Byte",
+          "address": "db2.dbb5"
+        },
+        "Int 1": {
+          "id": "Int 1",
+          "name": "Int 1",
+          "type": "Int",
+          "address": "db4.dbw1"
+        },
+        "Int 2": {
+          "id": "Int 2",
+          "name": "Int 2",
+          "type": "Int",
+          "address": "db4.dbw2"
+        },
+        "Int 3": {
+          "id": "Int 3",
+          "name": "Int 3",
+          "type": "Int",
+          "address": "db4.dbw3"
+        },
+        "Int 4": {
+          "id": "Int 4",
+          "name": "Int 4",
+          "type": "Int",
+          "address": "db4.dbw4"
+        },
+        "Int 5": {
+          "id": "Int 5",
+          "name": "Int 5",
+          "type": "Int",
+          "address": "db4.dbw5"
+        },
+        "Word 1": {
+          "id": "Word 1",
+          "name": "Word 1",
+          "type": "Word",
+          "address": "db4.dbw41"
+        },
+        "Word 2": {
+          "id": "Word 2",
+          "name": "Word 2",
+          "type": "Word",
+          "address": "db4.dbw42"
+        },
+        "Word 3": {
+          "id": "Word 3",
+          "name": "Word 3",
+          "type": "Word",
+          "address": "db4.dbw43"
+        },
+        "Word 4": {
+          "id": "Word 4",
+          "name": "Word 4",
+          "type": "Word",
+          "address": "db4.dbw48"
+        },
+        "Word 5": {
+          "id": "Word 5",
+          "name": "Word 5",
+          "type": "Word",
+          "address": "db4.dbw50"
+        },
+        "DInt 1": {
+          "id": "DInt 1",
+          "name": "DInt 1",
+          "type": "DInt",
+          "address": "db5.dbd0"
+        },
+        "DWord 1": {
+          "id": "DWord 1",
+          "name": "DWord 1",
+          "type": "DWord",
+          "address": "db5.dbd4"
+        },
+        "Real 1": {
+          "id": "Real 1",
+          "name": "Real 1",
+          "type": "Real",
+          "address": "db5.dbd8"
+        },
+        "Bit 0.1": {
+          "id": "Bit 0.1",
+          "name": "Bit 0.1",
+          "type": "Bool",
+          "address": "db1.dbx0.1"
+        },
+        "Bit 0.5": {
+          "id": "Bit 0.5",
+          "name": "Bit 0.5",
+          "type": "Bool",
+          "address": "db1.dbx0.5"
+        }
+      },
+      "name": "SPS",
+      "type": "SiemensS7"
+    }
+  },
+  "hmi": {
+    "views": [
+      {
+        "id": "v_1571818563529",
+        "name": "DashboardView",
+        "profile": {
+          "width": 1200,
+          "height": 800,
+          "bkcolor": "#ffffffff"
+        },
+        "items": {
+          "HXC_8f3aadfa-f5a8-4798-a62e-c8cf6d8a7758": {
+            "id": "HXC_8f3aadfa-f5a8-4798-a62e-c8cf6d8a7758",
+            "type": "svg-ext-html_chart",
+            "name": "Compressor A",
+            "property": {
+              "id": "5674a998-b453433c",
+              "type": "realtime1"
+            },
+            "label": "HtmlChart"
+          },
+          "HXC_7608a2f6-9f87-4e95-8573-4d3e08dcc78d": {
+            "id": "HXC_7608a2f6-9f87-4e95-8573-4d3e08dcc78d",
+            "type": "svg-ext-html_chart",
+            "name": "Compressor A",
+            "property": {
+              "id": "5674a998-b453433c",
+              "type": "history"
+            },
+            "label": "HtmlChart"
+          },
+          "HXC_705e5360-804e-4625-8501-d8eb1b9a4450": {
+            "id": "HXC_705e5360-804e-4625-8501-d8eb1b9a4450",
+            "type": "svg-ext-html_chart",
+            "name": "Pumps",
+            "property": {
+              "id": "f66c7d82-5ad2469d",
+              "type": "history"
+            },
+            "label": "HtmlChart"
+          },
+          "HXS_78481f37-6849-4e7e-a681-b399d8646de6": {
+            "id": "HXS_78481f37-6849-4e7e-a681-b399d8646de6",
+            "type": "svg-ext-html_select",
+            "name": "W1",
+            "property": {
+              "events": [],
+              "variable": "Word 1",
+              "variableId": "SPS^~^Word 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "step",
+                  "min": "0",
+                  "max": "0",
+                  "text": "OFF"
+                },
+                {
+                  "type": "step",
+                  "min": "255",
+                  "text": "ON",
+                  "max": "255"
+                }
+              ]
+            },
+            "label": "HtmlSelect"
+          },
+          "HXS_7f175bf8-c8b5-4e87-8471-239a1649f1e9": {
+            "id": "HXS_7f175bf8-c8b5-4e87-8471-239a1649f1e9",
+            "type": "svg-ext-html_select",
+            "name": "W2",
+            "property": {
+              "events": [],
+              "variable": "Word 2",
+              "variableId": "SPS^~^Word 2",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "step",
+                  "min": "0",
+                  "max": "0",
+                  "text": "OFF"
+                },
+                {
+                  "type": "step",
+                  "min": "255",
+                  "text": "ON",
+                  "max": "255"
+                }
+              ]
+            },
+            "label": "HtmlSelect"
+          },
+          "HXS_7b9a7b26-39d4-421d-8dd3-5d6bafad8b5e": {
+            "id": "HXS_7b9a7b26-39d4-421d-8dd3-5d6bafad8b5e",
+            "type": "svg-ext-html_select",
+            "name": "W3",
+            "property": {
+              "events": [],
+              "variable": "Word 3",
+              "variableId": "SPS^~^Word 3",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "step",
+                  "min": "0",
+                  "max": "0",
+                  "text": "ON"
+                },
+                {
+                  "type": "step",
+                  "min": "255",
+                  "text": "OFF",
+                  "max": "255"
+                }
+              ]
+            },
+            "label": "HtmlSelect"
+          },
+          "HXB_96c30d35-a524-42e1-bb90-cc09171fb8ef": {
+            "id": "HXB_96c30d35-a524-42e1-bb90-cc09171fb8ef",
+            "type": "svg-ext-html_button",
+            "name": "ON",
+            "property": {
+              "events": [
+                {
+                  "type": "click",
+                  "action": "onSetValue",
+                  "actparam": "255"
+                }
+              ],
+              "variable": "Byte 5",
+              "variableId": "SPS^~^Byte 5",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": ""
+            },
+            "label": "HtmlButton"
+          },
+          "HXB_b45efe3b-b81f-4ae5-8cb7-2cfe5ec56f0b": {
+            "id": "HXB_b45efe3b-b81f-4ae5-8cb7-2cfe5ec56f0b",
+            "type": "svg-ext-html_button",
+            "name": "OFF",
+            "property": {
+              "events": [
+                {
+                  "type": "click",
+                  "action": "onSetValue",
+                  "actparam": "0"
+                }
+              ],
+              "variable": "Byte 5",
+              "variableId": "SPS^~^Byte 5",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": ""
+            },
+            "label": "HtmlButton"
+          },
+          "VAL_6779b2e1-a263-4104-84f5-4b1b9b86a680": {
+            "id": "VAL_6779b2e1-a263-4104-84f5-4b1b9b86a680",
+            "type": "svg-ext-value",
+            "name": "W1",
+            "property": {
+              "events": [],
+              "variable": "Word 1",
+              "variableId": "SPS^~^Word 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " rpm"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_1b52de49-5d85-496c-9460-e0f54462b9bc": {
+            "id": "VAL_1b52de49-5d85-496c-9460-e0f54462b9bc",
+            "type": "svg-ext-value",
+            "name": "W2",
+            "property": {
+              "events": [],
+              "variable": "Word 2",
+              "variableId": "SPS^~^Word 2",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " rpm"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_90dce4cc-c4cb-4eb2-954a-a815987abaaf": {
+            "id": "VAL_90dce4cc-c4cb-4eb2-954a-a815987abaaf",
+            "type": "svg-ext-value",
+            "name": "W3",
+            "property": {
+              "events": [],
+              "variable": "Word 3",
+              "variableId": "SPS^~^Word 3",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " rpm"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_61063ce7-ab58-4fb6-841d-930de8ca57f4": {
+            "id": "VAL_61063ce7-ab58-4fb6-841d-930de8ca57f4",
+            "type": "svg-ext-value",
+            "name": "W4",
+            "property": {
+              "events": [],
+              "variable": "Word 4",
+              "variableId": "SPS^~^Word 4",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " rpm"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "MTR_368a33db-0f78-43dd-85f3-12ff343e58ed": {
+            "id": "MTR_368a33db-0f78-43dd-85f3-12ff343e58ed",
+            "type": "svg-ext-motor",
+            "name": "W4",
+            "property": {
+              "events": [],
+              "variable": "Word 4",
+              "variableId": "SPS^~^Word 4",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "100",
+                  "color": "#a5a5a5"
+                },
+                {
+                  "type": "range",
+                  "min": "100",
+                  "max": "200",
+                  "color": "#00b0f0"
+                },
+                {
+                  "type": "range",
+                  "min": "200",
+                  "max": "300",
+                  "color": "#ffd04a"
+                }
+              ]
+            },
+            "label": "Motor"
+          },
+          "HXS_cd126b6e-3b85-4b9d-bcbc-73a8feb04e8b": {
+            "id": "HXS_cd126b6e-3b85-4b9d-bcbc-73a8feb04e8b",
+            "type": "svg-ext-html_select",
+            "name": "W4",
+            "property": {
+              "events": [],
+              "variable": "Word 4",
+              "variableId": "SPS^~^Word 4",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "step",
+                  "min": 1,
+                  "max": 1,
+                  "text": "OFF"
+                },
+                {
+                  "type": "step",
+                  "text": "NORMAL",
+                  "min": "150",
+                  "max": "150"
+                },
+                {
+                  "type": "step",
+                  "min": "250",
+                  "text": "MAX",
+                  "max": "250"
+                }
+              ]
+            },
+            "label": "HtmlSelect"
+          },
+          "GXP_36b64454-8a80-4a06-a260-0b233f95d963": {
+            "id": "GXP_36b64454-8a80-4a06-a260-0b233f95d963",
+            "type": "svg-ext-gauge_progress",
+            "name": "B1",
+            "property": {
+              "events": [],
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "minmax",
+                  "min": 0,
+                  "max": "260",
+                  "style": [
+                    true,
+                    true
+                  ],
+                  "color": "#76a9ff"
+                }
+              ],
+              "variable": "Byte 1",
+              "variableId": "SPS^~^Byte 1",
+              "variableSrc": "SPS"
+            },
+            "label": "HtmlProgress"
+          },
+          "HXI_bd765710-8927-4624-ae5e-d526e7a0f158": {
+            "id": "HXI_bd765710-8927-4624-ae5e-d526e7a0f158",
+            "type": "svg-ext-html_input",
+            "name": "I5",
+            "property": {
+              "events": [],
+              "variable": "Int 5",
+              "variableId": "SPS^~^Int 5",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": ""
+            },
+            "label": "HtmlInput"
+          },
+          "HXI_f10a6145-cb49-46b8-a5fe-fa385442c8f3": {
+            "id": "HXI_f10a6145-cb49-46b8-a5fe-fa385442c8f3",
+            "type": "svg-ext-html_input",
+            "name": "I4",
+            "property": {
+              "events": [],
+              "variable": "Int 4",
+              "variableId": "SPS^~^Int 4",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": ""
+            },
+            "label": "HtmlInput"
+          },
+          "VAL_e62fbc6b-eba9-4a36-aa09-25c35203e38b": {
+            "id": "VAL_e62fbc6b-eba9-4a36-aa09-25c35203e38b",
+            "type": "svg-ext-value",
+            "name": "",
+            "property": {
+              "events": [],
+              "variable": "Byte 1",
+              "variableId": "SPS^~^Byte 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " %"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_be8a95d8-2b40-464e-9b94-c291707680f3": {
+            "id": "VAL_be8a95d8-2b40-464e-9b94-c291707680f3",
+            "type": "svg-ext-value",
+            "name": "B2",
+            "property": {
+              "events": [],
+              "variable": "Byte 2",
+              "variableId": "SPS^~^Byte 2",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_697c8d67-a079-41cd-a8da-d6111999cb28": {
+            "id": "VAL_697c8d67-a079-41cd-a8da-d6111999cb28",
+            "type": "svg-ext-value",
+            "name": "I3",
+            "property": {
+              "events": [],
+              "variable": "Int 3",
+              "variableId": "SPS^~^Int 3",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " rpm"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "GSE_e580695d-c9a5-4201-9ff4-706b1c2b0f6b": {
+            "id": "GSE_e580695d-c9a5-4201-9ff4-706b1c2b0f6b",
+            "type": "svg-ext-gauge_semaphore",
+            "name": "Bit 1",
+            "property": {
+              "events": [],
+              "variable": "Bit 0.1",
+              "variableId": "SPS^~^Bit 0.1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "0",
+                  "color": "#ff0000"
+                },
+                {
+                  "type": "range",
+                  "min": "1",
+                  "max": "1"
+                }
+              ]
+            },
+            "label": "HtmlSemaphore"
+          },
+          "GSE_fb2169f5-01f5-4899-87e3-24c14cd8fba4": {
+            "id": "GSE_fb2169f5-01f5-4899-87e3-24c14cd8fba4",
+            "type": "svg-ext-gauge_semaphore",
+            "name": "Bit1",
+            "property": {
+              "events": [],
+              "variable": "Bit 0.1",
+              "variableId": "SPS^~^Bit 0.1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "1",
+                  "max": "1",
+                  "color": "#0ac97d"
+                },
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "0",
+                  "color": "#7f7f7f"
+                }
+              ]
+            },
+            "label": "HtmlSemaphore"
+          },
+          "VLA_6a85480b-4f2e-46bd-a359-3ddae822b898": {
+            "id": "VLA_6a85480b-4f2e-46bd-a359-3ddae822b898",
+            "type": "svg-ext-valve",
+            "name": "B5",
+            "property": {
+              "events": [],
+              "variable": "Byte 5",
+              "variableId": "SPS^~^Byte 5",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "125",
+                  "color": "#ff0000"
+                },
+                {
+                  "type": "range",
+                  "min": "126",
+                  "max": "255",
+                  "color": "#00b050"
+                }
+              ]
+            },
+            "label": "Valve"
+          },
+          "HXB_e78ce203-ce84-4872-b863-693d31378f7c": {
+            "id": "HXB_e78ce203-ce84-4872-b863-693d31378f7c",
+            "type": "svg-ext-html_button",
+            "name": "ON",
+            "property": {
+              "events": [
+                {
+                  "type": "click",
+                  "action": "onSetValue",
+                  "actparam": "200"
+                }
+              ],
+              "variable": "Byte 4",
+              "variableId": "SPS^~^Byte 4",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": ""
+            },
+            "label": "HtmlButton"
+          },
+          "VLA_fa79e23d-5492-48f5-906b-22630532f4a3": {
+            "id": "VLA_fa79e23d-5492-48f5-906b-22630532f4a3",
+            "type": "svg-ext-valve",
+            "name": "B4",
+            "property": {
+              "events": [],
+              "variable": "Byte 4",
+              "variableId": "SPS^~^Byte 4",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": 0,
+                  "max": "125",
+                  "color": "#ff0000"
+                },
+                {
+                  "type": "range",
+                  "min": "126",
+                  "max": "255",
+                  "color": "#00b050"
+                }
+              ]
+            },
+            "label": "Valve"
+          },
+          "HXB_9a3c708a-4450-4aa0-9626-1e36649fb2d1": {
+            "id": "HXB_9a3c708a-4450-4aa0-9626-1e36649fb2d1",
+            "type": "svg-ext-html_button",
+            "name": "OFF",
+            "property": {
+              "events": [
+                {
+                  "type": "click",
+                  "action": "onSetValue",
+                  "actparam": "0"
+                }
+              ],
+              "variable": "Byte 4",
+              "variableId": "SPS^~^Byte 4",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": ""
+            },
+            "label": "HtmlButton"
+          },
+          "VLA_f28dac7c-da82-4361-981d-a0d800c809c6": {
+            "id": "VLA_f28dac7c-da82-4361-981d-a0d800c809c6",
+            "type": "svg-ext-valve",
+            "name": "B3",
+            "property": {
+              "events": [],
+              "variable": "Byte 3",
+              "variableId": "SPS^~^Byte 3",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "125",
+                  "color": "#00b050"
+                },
+                {
+                  "type": "range",
+                  "min": "126",
+                  "max": "255",
+                  "color": "#ff0000"
+                }
+              ]
+            },
+            "label": "Valve"
+          },
+          "HXB_2a48aac3-2d12-454b-b8d7-752885775dfa": {
+            "id": "HXB_2a48aac3-2d12-454b-b8d7-752885775dfa",
+            "type": "svg-ext-html_button",
+            "name": "ON",
+            "property": {
+              "events": [
+                {
+                  "type": "click",
+                  "action": "onSetValue",
+                  "actparam": "0"
+                }
+              ],
+              "variable": "Byte 3",
+              "variableId": "SPS^~^Byte 3",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": ""
+            },
+            "label": "HtmlButton"
+          },
+          "HXB_902c51cb-851d-4a46-9582-d40efb41a5fa": {
+            "id": "HXB_902c51cb-851d-4a46-9582-d40efb41a5fa",
+            "type": "svg-ext-html_button",
+            "name": "OFF",
+            "property": {
+              "events": [
+                {
+                  "type": "click",
+                  "action": "onSetValue",
+                  "actparam": "200"
+                }
+              ],
+              "variable": "Byte 3",
+              "variableId": "SPS^~^Byte 3",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": ""
+            },
+            "label": "HtmlButton"
+          },
+          "MTR_e38fab85-8022-45b2-9e47-c7d015f59013": {
+            "id": "MTR_e38fab85-8022-45b2-9e47-c7d015f59013",
+            "type": "svg-ext-motor",
+            "name": "W1",
+            "property": {
+              "events": [],
+              "variable": "Word 1",
+              "variableId": "SPS^~^Word 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "1",
+                  "max": "1000",
+                  "color": "#0ac97d"
+                },
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "0"
+                }
+              ]
+            },
+            "label": "Motor"
+          },
+          "MTR_1452baf3-b725-4773-9f6f-e8d1c68bab5b": {
+            "id": "MTR_1452baf3-b725-4773-9f6f-e8d1c68bab5b",
+            "type": "svg-ext-motor",
+            "name": "W2",
+            "property": {
+              "events": [],
+              "variable": "Word 2",
+              "variableId": "SPS^~^Word 2",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "1",
+                  "max": "2000",
+                  "color": "#0ac97d"
+                },
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "0"
+                }
+              ]
+            },
+            "label": "Motor"
+          },
+          "MTR_176a92ab-8aef-4d96-a54f-3c22a14662c3": {
+            "id": "MTR_176a92ab-8aef-4d96-a54f-3c22a14662c3",
+            "type": "svg-ext-motor",
+            "name": "W3",
+            "property": {
+              "events": [],
+              "variable": "Word 3",
+              "variableId": "SPS^~^Word 3",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "1",
+                  "max": "3000",
+                  "color": "#0ac97d"
+                },
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "0"
+                }
+              ]
+            },
+            "label": "Motor"
+          }
+        },
+        "variables": {},
+        "svgcontent": "<svg width=\"1200\" height=\"800\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:svg=\"http://www.w3.org/2000/svg\" xmlns:html=\"http://www.w3.org/1999/xhtml\">\n <g>\n  <title>Layer 1</title>\n  <rect height=\"146\" width=\"108\" y=\"344\" x=\"422\" fill=\"#f5f5f5ff\" id=\"svg_71846b7f-62ae-4c39-ab30-cc2af36adf52\"/>\n  <rect height=\"146\" width=\"108\" y=\"344\" x=\"262\" fill=\"#f5f5f5ff\" id=\"svg_3588c852-8f6d-47d5-91b5-0dc1613900b9\"/>\n  <rect height=\"146\" width=\"108\" y=\"344\" x=\"98\" fill=\"#f5f5f5ff\" id=\"svg_f2692e79-e843-4560-8a55-0453a7d5c19e\"/>\n  <line fill=\"none\" stroke=\"#000000\" x1=\"450\" y1=\"404\" x2=\"500\" y2=\"404\" stroke-width=\"4\" id=\"svg_25908fc1-acdf-410a-bcb8-3e8285502d1a\"/>\n  <line fill=\"none\" stroke=\"#000000\" x1=\"290\" y1=\"404\" x2=\"340\" y2=\"404\" stroke-width=\"4\" id=\"svg_22569a40-a75e-41f5-9bd3-754b1cb10180\"/>\n  <line fill=\"none\" stroke=\"#000000\" x1=\"126\" y1=\"404\" x2=\"176\" y2=\"404\" id=\"svg_7ec83494-b890-49af-8487-f8265e50146f\" stroke-width=\"4\"/>\n  <g id=\"CPS_62104731-6c74-491a-9531-101b1981ffd8\" type=\"svg-ext-compressor\" fill=\"#f5f5f5ff\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" transform=\"rotate(-90 160.93647766113284,192.9193572998047) \" stroke=\"#ffffff\">\n   <path stroke-width=\"4\" id=\"vCPS_22b7e568-64c8-443d-8453-4e0c1ca25422\" d=\"M132.43648,140.70436L212.23648,165.48436M132.43648,242.18436L212.23648,217.40436M217.93648,192.91936A57,59 0 0 1 160.93648,251.91936A57,59 0 0 1 103.93648,192.91936A57,59 0 0 1 160.93648,133.91936A57,59 0 0 1 217.93648,192.91936z\" stroke=\"#ffffff\"/>\n  </g>\n  <rect id=\"svg_c3977aa5-5ec0-4c13-89f6-c08abb7bdf48\" height=\"146\" width=\"300\" y=\"598\" x=\"228\" fill=\"#f5f5f5ff\"/>\n  <rect id=\"svg_7a641ed0-09f2-416e-b9b0-f3040a255b70\" height=\"146\" width=\"108\" y=\"598\" x=\"98\" fill=\"#f5f5f5ff\"/>\n  <rect stroke=\"#bfbfbf\" id=\"svg_f9565426-5764-43dc-aee9-c8b277031707\" height=\"32\" width=\"130\" y=\"204\" x=\"440\" fill=\"#f1f1f1ff\"/>\n  <rect fill=\"#bfbfbf\" x=\"682\" y=\"64\" width=\"492\" height=\"222\" id=\"svg_88ceee65-d4fb-4624-9962-7e69f4451d73\" stroke=\"null\"/>\n  <rect id=\"svg_71bfce0a-a2ab-45a3-9d41-ff7e9fdf94a5\" fill=\"#bfbfbf\" x=\"682\" y=\"312\" width=\"492\" height=\"222\" stroke=\"null\"/>\n  <rect id=\"svg_8fd8bb2c-9996-4038-b20d-8fe645162f55\" fill=\"#bfbfbf\" x=\"682\" y=\"562\" width=\"492\" height=\"222\" stroke=\"null\"/>\n  <g id=\"HXC_8f3aadfa-f5a8-4798-a62e-c8cf6d8a7758\" type=\"svg-ext-html_chart\" fill=\"#FFFFFF\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"right\" stroke=\"#000000\">\n   <rect stroke-width=\"0\" x=\"690.00001\" y=\"70\" width=\"475.99998\" height=\"208.00001\" id=\"svg_5706f9d9-f743-4913-b3de-2938afe39597\" fill=\"#ffffff\" stroke=\"null\"/>\n   <foreignObject x=\"690.00001\" y=\"70\" height=\"208.00001\" width=\"475.99998\" id=\"H-HXC_d3dd44fa-e65c-4c86-bc86-a911391de4d5\">\n    <DIV style=\"width: 100%; height: 100%; vector-effect: non-scaling-stroke;\" id=\"D-HXC_d3dd44fa-e65c-4c86-bc86-a911391de4d5\">\n\n    </DIV>\n   </foreignObject>\n  </g>\n  <g id=\"HXC_7608a2f6-9f87-4e95-8573-4d3e08dcc78d\" type=\"svg-ext-html_chart\" fill=\"#FFFFFF\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"right\" stroke=\"#000000\">\n   <rect stroke-width=\"0\" x=\"690\" y=\"318\" width=\"475.99999\" height=\"208\" id=\"svg_a622b31a-b06c-48bd-896c-edb9ee7359e4\" stroke=\"null\"/>\n   <foreignObject x=\"690\" y=\"318\" height=\"208\" width=\"475.99999\" id=\"H-HXC_870416b0-e814-43fc-b41b-4f69caf8c7d2\">\n    <DIV style=\"width: 100%; height: 100%; vector-effect: non-scaling-stroke;\" id=\"D-HXC_870416b0-e814-43fc-b41b-4f69caf8c7d2\">\n\n    </DIV>\n   </foreignObject>\n  </g>\n  <g id=\"HXC_705e5360-804e-4625-8501-d8eb1b9a4450\" type=\"svg-ext-html_chart\" fill=\"#ffffff\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"right\" stroke=\"#000000\">\n   <rect stroke-width=\"0\" x=\"690\" y=\"568\" width=\"475.99999\" height=\"208\" id=\"svg_8a011ddd-29ee-4832-af5e-b138cc1d75b8\" stroke=\"null\"/>\n   <foreignObject x=\"690\" y=\"568\" height=\"208\" width=\"475.99999\" id=\"H-HXC_e2107b4f-a9a5-4bfe-a3c5-b39b30d95063\">\n    <DIV style=\"width: 100%; height: 100%; vector-effect: non-scaling-stroke;\" id=\"D-HXC_e2107b4f-a9a5-4bfe-a3c5-b39b30d95063\">\n\n    </DIV>\n   </foreignObject>\n  </g>\n  <text xml:space=\"preserve\" text-anchor=\"start\" font-family=\"sans-serif\" font-size=\"20\" id=\"svg_d7119108-733d-4647-91a4-ebce3dc7316a\" y=\"84\" x=\"56\" stroke-width=\"0\" stroke=\"#000000\" fill=\"#000000\">Compressor</text>\n  <text id=\"svg_78055773-b334-402c-a589-c8da59f94bd1\" xml:space=\"preserve\" text-anchor=\"start\" font-family=\"sans-serif\" font-size=\"20\" y=\"328\" x=\"56\" stroke-width=\"0\" stroke=\"#000000\" fill=\"#000000\">Valves</text>\n  <text id=\"svg_9c6a2e68-91c7-4732-9e9f-87cf4b35106a\" xml:space=\"preserve\" text-anchor=\"start\" font-family=\"sans-serif\" font-size=\"20\" y=\"580\" x=\"56\" stroke-width=\"0\" stroke=\"#000000\" fill=\"#000000\">Pumps</text>\n  <text xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" id=\"svg_445b0b4d-7f6e-42be-bf3d-cef730f25a2d\" y=\"624\" x=\"154\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" fill=\"#3f3f3f\">Pump W</text>\n  <g text-anchor=\"middle\" font-family=\"sans-serif\" stroke-width=\"0\" font-size=\"14\" fill=\"none\" type=\"svg-ext-value\" id=\"VAL_61063ce7-ab58-4fb6-841d-930de8ca57f4\">\n   <text y=\"689\" x=\"150\" xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#000000\" id=\"VAL_949e0aef-ccea-4291-aa1b-0cd332869d4d\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\">##.##</text>\n  </g>\n  <g text-anchor=\"right\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#000000\" type=\"svg-ext-html_select\" id=\"HXS_cd126b6e-3b85-4b9d-bcbc-73a8feb04e8b\">\n   <rect id=\"svg_53c207b0-b7f0-42bf-8a9a-3bac37899496\" fill=\"#000000\" height=\"26\" width=\"80\" y=\"704\" x=\"109\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\"/>\n   <foreignObject id=\"H-HXS_46c8eba6-c1e2-4f49-83fc-b35d2ee8458c\" width=\"80\" height=\"26\" y=\"704\" x=\"109\">\n    <SELECT style=\"width:100%;height:100%;text-align: right;margin-top:unset;\" id=\"S-HXS_46c8eba6-c1e2-4f49-83fc-b35d2ee8458c\">\n     <OPTION/>\n    </SELECT>\n   </foreignObject>\n  </g>\n  <g stroke=\"#262626ff\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#ffffff\" type=\"svg-ext-motor\" id=\"MTR_368a33db-0f78-43dd-85f3-12ff343e58ed\">\n   <ellipse stroke=\"#262626ff\" ry=\"16.59524\" rx=\"16.59524\" cy=\"647\" cx=\"150.19048\" id=\"cMTR_131aa4ee-e3ae-4ec3-8872-b3ba1288ee2a\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\"/>\n   <path stroke=\"null\" fill=\"#000000\" d=\"M150.19048,631.61905L166.38095,647.20238L150.19048,662.78571L150.19048,631.61905z\" id=\"sMTR_4f227a9d-be60-4fbe-bc09-72710277ef00\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\"/>\n  </g>\n  <text id=\"svg_f525d9bc-cc98-4462-a22e-a9bbe25ff48d\" xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" y=\"624\" x=\"278\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" fill=\"#3f3f3f\">Pump 1</text>\n  <g id=\"VAL_6779b2e1-a263-4104-84f5-4b1b9b86a680\" text-anchor=\"middle\" font-family=\"sans-serif\" stroke-width=\"0\" font-size=\"14\" fill=\"none\" type=\"svg-ext-value\">\n   <text id=\"VAL_59a4a557-9428-48c6-b8a1-2792bb699e00\" y=\"689\" x=\"276.5\" xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#000000\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\">##.##</text>\n  </g>\n  <g id=\"MTR_e38fab85-8022-45b2-9e47-c7d015f59013\" stroke=\"#262626ff\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#ffffff\" type=\"svg-ext-motor\">\n   <ellipse id=\"cMTR_a337482d-c7bc-467c-805e-d46cc55c02a7\" stroke=\"#262626ff\" ry=\"16.59524\" rx=\"16.59524\" cy=\"646.99519\" cx=\"276.69048\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\"/>\n   <path id=\"sMTR_9ec1a1c5-3d30-4b76-ae8b-1e1f9a3f4bcb\" stroke=\"null\" fill=\"#000000\" d=\"M276.69048,631.61424L292.88095,647.19757L276.69048,662.7809L276.69048,631.61424z\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\"/>\n  </g>\n  <g text-anchor=\"right\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#000000\" type=\"svg-ext-html_select\" id=\"HXS_78481f37-6849-4e7e-a681-b399d8646de6\">\n   <rect id=\"svg_c5d37e2f-119d-465a-8425-0149da8939f5\" fill=\"#000000\" height=\"26\" width=\"80\" y=\"704\" x=\"236\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\"/>\n   <foreignObject id=\"H-HXS_409593d1-c417-484f-880a-f981f70379bf\" width=\"80\" height=\"26\" y=\"704\" x=\"236\">\n    <SELECT style=\"width:100%;height:100%;text-align: right;margin-top:unset;\" id=\"S-HXS_409593d1-c417-484f-880a-f981f70379bf\">\n     <OPTION/>\n    </SELECT>\n   </foreignObject>\n  </g>\n  <text xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" y=\"624\" x=\"380\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" fill=\"#3f3f3f\" id=\"svg_fa3bd24b-072d-4985-8f2e-a91850a918bc\">Pump 2</text>\n  <g text-anchor=\"middle\" font-family=\"sans-serif\" stroke-width=\"0\" font-size=\"14\" fill=\"none\" type=\"svg-ext-value\" id=\"VAL_1b52de49-5d85-496c-9460-e0f54462b9bc\">\n   <text y=\"689\" x=\"378.53125\" xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#000000\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" id=\"VAL_2a798f2b-29e9-40a9-83b4-2f802a9ea879\">##.##</text>\n  </g>\n  <g stroke=\"#262626ff\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#ffffff\" type=\"svg-ext-motor\" id=\"MTR_1452baf3-b725-4773-9f6f-e8d1c68bab5b\">\n   <ellipse stroke=\"#262626ff\" ry=\"16.59524\" rx=\"16.59524\" cy=\"646.99519\" cx=\"378.59523\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" id=\"cMTR_760ab7d4-8a8c-4b52-a3b7-274cf94bdaf8\"/>\n   <path stroke=\"null\" fill=\"#000000\" d=\"M378.59523,631.61424L394.7857,647.19757L378.59523,662.7809L378.59523,631.61424z\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" id=\"sMTR_8f8c67bd-884d-421b-a251-b43183d15764\"/>\n  </g>\n  <g text-anchor=\"right\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#000000\" type=\"svg-ext-html_select\" id=\"HXS_7f175bf8-c8b5-4e87-8471-239a1649f1e9\">\n   <rect fill=\"#000000\" height=\"26\" width=\"80\" y=\"704\" x=\"339\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" id=\"svg_832d8d95-fc25-4d07-9bfb-ba7d0b70ee84\"/>\n   <foreignObject width=\"80\" height=\"26\" y=\"704\" x=\"339\" id=\"H-HXS_16cbb729-93cb-4cc5-b6ba-3a13cdf94ef2\">\n    <SELECT id=\"S-HXS_e3f886f2-6a06-43d0-bfd4-e5309be033b8\" style=\"width:100%;height:100%;text-align: right;margin-top:unset;\">\n     <OPTION/>\n    </SELECT>\n   </foreignObject>\n  </g>\n  <text xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" y=\"624\" x=\"482\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" fill=\"#3f3f3f\" id=\"svg_be517d9a-abea-42f5-bf13-8c0cf84fcfc8\">Pump 3</text>\n  <g text-anchor=\"middle\" font-family=\"sans-serif\" stroke-width=\"0\" font-size=\"14\" fill=\"none\" type=\"svg-ext-value\" id=\"VAL_90dce4cc-c4cb-4eb2-954a-a815987abaaf\">\n   <text y=\"689\" x=\"480.5\" xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#000000\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" id=\"VAL_c3337f48-2511-4622-b7fa-05d3e6239422\">##.##</text>\n  </g>\n  <g stroke=\"#262626ff\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#ffffff\" type=\"svg-ext-motor\" id=\"MTR_176a92ab-8aef-4d96-a54f-3c22a14662c3\">\n   <ellipse stroke=\"#262626ff\" ry=\"16.59524\" rx=\"16.59524\" cy=\"646.9952\" cx=\"480.69048\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" id=\"cMTR_c4fddb6d-82d3-4553-b3c3-de692374413e\"/>\n   <path stroke=\"null\" fill=\"#000000\" d=\"M480.69048,631.61425L496.88095,647.19758L480.69048,662.78091L480.69048,631.61425z\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" id=\"sMTR_5569f705-b9e7-49a4-8af9-89c645b351a7\"/>\n  </g>\n  <g text-anchor=\"right\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#000000\" type=\"svg-ext-html_select\" id=\"HXS_7b9a7b26-39d4-421d-8dd3-5d6bafad8b5e\">\n   <rect fill=\"#000000\" height=\"26\" width=\"80\" y=\"704\" x=\"440\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" id=\"svg_eeeb1b37-3401-46dc-9f75-a266f68e503f\"/>\n   <foreignObject width=\"80\" height=\"26\" y=\"704\" x=\"440\" id=\"H-HXS_d807f6f7-52b1-47a1-b216-df011ac22257\">\n    <SELECT id=\"S-HXS_22a935f4-0b9c-4cc3-a9d0-73c21a6f9c61\" style=\"width:100%;height:100%;text-align: right;margin-top:unset;\">\n     <OPTION/>\n    </SELECT>\n   </foreignObject>\n  </g>\n  <g id=\"VLA_6a85480b-4f2e-46bd-a359-3ddae822b898\" type=\"svg-ext-valve\" fill=\"#7f7f7f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\">\n   <path id=\"tlVLA_b990e6d8-5b10-465b-95a8-81df9d51f7d8\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M136,393.00001L151,404.00001L136,415.00001L136,393.00001z\" stroke=\"#000000\"/>\n   <path id=\"trVLA_9a603dc2-63bf-45d8-b8a2-4b1928381ffa\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M167,415.00001L152,404.00001L167,393.00001L167,415.00001z\" stroke=\"#000000\"/>\n  </g>\n  <g id=\"HXB_96c30d35-a524-42e1-bb90-cc09171fb8ef\" type=\"svg-ext-html_button\" fill=\"#FFFFFF\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"right\" stroke=\"#000000\">\n   <rect stroke-width=\"0\" x=\"104\" y=\"425\" width=\"44\" height=\"24\" fill=\"#81ce37ff\" id=\"svg_03fca70f-0855-465f-a390-22aaf8f79871\" stroke=\"#ffffff\"/>\n   <foreignObject x=\"104\" y=\"425\" height=\"24\" width=\"44\" id=\"H-HXB_e5fc9a10-1f71-44c5-aa0f-f4fce2fac9c9\">\n    <BUTTON style=\"width: 100%; height: 100%; vector-effect: non-scaling-stroke; background-color: rgb(129, 206, 55); color: rgb(255, 255, 255);\" class=\"md-btn  md-btn-raised\" id=\"B-HXB_e5fc9a10-1f71-44c5-aa0f-f4fce2fac9c9\">ON</BUTTON>\n   </foreignObject>\n  </g>\n  <g type=\"svg-ext-html_button\" fill=\"#FFFFFF\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"right\" stroke=\"#000000\" id=\"HXB_b45efe3b-b81f-4ae5-8cb7-2cfe5ec56f0b\">\n   <rect stroke-width=\"0\" x=\"155.5\" y=\"425\" width=\"44\" height=\"24\" fill=\"#f73f3fff\" stroke=\"#ffffff\" id=\"svg_32b7f151-14b2-4bf4-92c3-edef827c25c9\"/>\n   <foreignObject x=\"155.5\" y=\"425\" height=\"24\" width=\"44\" id=\"H-HXB_77bcad31-1d32-4022-b615-01eb9d76f351\">\n    <BUTTON id=\"B-HXB_5d4755ff-8b0e-4cf2-9b96-ab3441846822\" style=\"width: 100%; height: 100%; vector-effect: non-scaling-stroke; background-color: rgb(247, 63, 63); color: rgb(255, 255, 255);\" class=\"md-btn  md-btn-raised\">OFF</BUTTON>\n   </foreignObject>\n  </g>\n  <text xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" y=\"380\" x=\"152\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" fill=\"#3f3f3f\" id=\"svg_9d748b85-27d3-4dff-97c0-b25843072a6f\">Valve 1</text>\n  <g type=\"svg-ext-valve\" fill=\"#7f7f7f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\" id=\"VLA_fa79e23d-5492-48f5-906b-22630532f4a3\">\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M300.5,393.00001L315.5,404.00001L300.5,415.00001L300.5,393.00001z\" stroke=\"#000000\" id=\"tlVLA_ecdbd3c7-d76d-4c43-a250-4f1ac165546c\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M331.5,415.00001L316.5,404.00001L331.5,393.00001L331.5,415.00001z\" stroke=\"#000000\" id=\"trVLA_8776f277-39aa-49c9-8144-22b2b2f4d0ce\"/>\n  </g>\n  <g type=\"svg-ext-html_button\" fill=\"#FFFFFF\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"right\" stroke=\"#000000\" id=\"HXB_e78ce203-ce84-4872-b863-693d31378f7c\">\n   <rect stroke-width=\"0\" x=\"268.5\" y=\"425\" width=\"44\" height=\"24\" fill=\"#81ce37ff\" stroke=\"#ffffff\" id=\"svg_11ed9729-33f2-4b85-a7be-b11287fd9430\"/>\n   <foreignObject x=\"268.5\" y=\"425\" height=\"24\" width=\"44\" id=\"H-HXB_100d9a99-d498-4d65-bfae-c4714b3fb27f\">\n    <BUTTON id=\"B-HXB_a4901d1a-243a-4343-94c6-43c82989b69d\" style=\"width: 100%; height: 100%; vector-effect: non-scaling-stroke; background-color: rgb(129, 206, 55); color: rgb(255, 255, 255);\" class=\"md-btn  md-btn-raised\">ON</BUTTON>\n   </foreignObject>\n  </g>\n  <g type=\"svg-ext-html_button\" fill=\"#FFFFFF\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"right\" stroke=\"#000000\" id=\"HXB_9a3c708a-4450-4aa0-9626-1e36649fb2d1\">\n   <rect stroke-width=\"0\" x=\"320\" y=\"425\" width=\"44\" height=\"24\" fill=\"#f73f3fff\" stroke=\"#ffffff\" id=\"svg_1a97f5f1-5c29-4018-8744-980922577aed\"/>\n   <foreignObject x=\"320\" y=\"425\" height=\"24\" width=\"44\" id=\"H-HXB_78e0443e-a42b-4c88-9673-5c6fb824fd6f\">\n    <BUTTON id=\"B-HXB_d57a0c7f-d0ad-4e82-af7a-02217f6e46b9\" style=\"width: 100%; height: 100%; vector-effect: non-scaling-stroke; background-color: rgb(247, 63, 63); color: rgb(255, 255, 255);\" class=\"md-btn  md-btn-raised\">OFF</BUTTON>\n   </foreignObject>\n  </g>\n  <text xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" y=\"380\" x=\"316\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" fill=\"#3f3f3f\" id=\"svg_9327ef77-27d5-4d3e-8513-f4ffd59aa240\">Valve 2</text>\n  <g type=\"svg-ext-valve\" fill=\"#7f7f7f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\" id=\"VLA_f28dac7c-da82-4361-981d-a0d800c809c6\">\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M460.5,393.00001L475.5,404.00001L460.5,415.00001L460.5,393.00001z\" stroke=\"#000000\" id=\"tlVLA_82463a4d-830c-430d-b61b-fe9f56288bc8\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M491.5,415.00001L476.5,404.00001L491.5,393.00001L491.5,415.00001z\" stroke=\"#000000\" id=\"trVLA_9b0ced94-0ed8-4140-96bc-af3c45750128\"/>\n  </g>\n  <g type=\"svg-ext-html_button\" fill=\"#FFFFFF\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"right\" stroke=\"#000000\" id=\"HXB_2a48aac3-2d12-454b-b8d7-752885775dfa\">\n   <rect stroke-width=\"0\" x=\"428.5\" y=\"425\" width=\"44\" height=\"24\" fill=\"#81ce37ff\" stroke=\"#ffffff\" id=\"svg_490ca5a1-d1b1-4bb1-8535-d1b25740a5b9\"/>\n   <foreignObject x=\"428.5\" y=\"425\" height=\"24\" width=\"44\" id=\"H-HXB_f8f71e48-32e7-44eb-a694-292d508f9159\">\n    <BUTTON id=\"B-HXB_d675ff2d-6125-417d-b7d6-66a8cdb98e11\" style=\"width: 100%; height: 100%; vector-effect: non-scaling-stroke; background-color: rgb(129, 206, 55); color: rgb(255, 255, 255);\" class=\"md-btn  md-btn-raised\">ON</BUTTON>\n   </foreignObject>\n  </g>\n  <g type=\"svg-ext-html_button\" fill=\"#FFFFFF\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"right\" stroke=\"#000000\" id=\"HXB_902c51cb-851d-4a46-9582-d40efb41a5fa\">\n   <rect stroke-width=\"0\" x=\"480\" y=\"425\" width=\"44\" height=\"24\" fill=\"#f73f3fff\" stroke=\"#ffffff\" id=\"svg_f21202d3-d200-4914-959d-689ca288223e\"/>\n   <foreignObject x=\"480\" y=\"425\" height=\"24\" width=\"44\" id=\"H-HXB_be9621da-18f0-4449-b1da-33aec0ed8b06\">\n    <BUTTON id=\"B-HXB_24889135-d883-43a5-87c7-dcf16323511b\" style=\"width: 100%; height: 100%; vector-effect: non-scaling-stroke; background-color: rgb(247, 63, 63); color: rgb(255, 255, 255);\" class=\"md-btn  md-btn-raised\">OFF</BUTTON>\n   </foreignObject>\n  </g>\n  <text xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" y=\"380\" x=\"476\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" fill=\"#3f3f3f\" id=\"svg_cd42f0f7-cc7c-4b3c-b358-17b34040a1bd\">Valve 3</text>\n  <g font-family=\"sans-serif\" font-size=\"14\" type=\"svg-ext-gauge_progress\" id=\"GXP_36b64454-8a80-4a06-a260-0b233f95d963\" stroke=\"null\">\n   <rect fill=\"#dededeff\" height=\"118\" width=\"44.53441\" y=\"132\" x=\"372\" id=\"A-GXP_996214e3-90a6-4a00-8d13-e559946475d0\" stroke=\"null\"/>\n   <rect fill=\"#76a9ff\" height=\"59\" width=\"44.53441\" y=\"191\" x=\"372\" id=\"B-GXP_42f77367-b5ad-4b78-916e-f2e95e25d77d\" stroke=\"null\"/>\n   <foreignObject font-size=\"14\" id=\"H-GXP_635f8599-d986-4d4c-9ea6-399b14c692cf\" width=\"44.53441\" height=\"118\" y=\"132\" x=\"372\"/>\n  </g>\n  <text id=\"svg_b8aae7c6-c91f-4e93-bc14-267a62fc2f98\" xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"20\" y=\"84\" x=\"354\" stroke-width=\"0\" stroke=\"#000000\" fill=\"#000000\">Tank</text>\n  <text fill=\"#3f3f3f\" stroke=\"#000000\" stroke-width=\"0\" x=\"162\" y=\"210\" id=\"svg_9d5d1259-858b-4449-a31b-b5f1067985a9\" font-size=\"12\" font-family=\"Sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">Speed</text>\n  <text fill=\"#3f3f3f\" stroke=\"#000000\" stroke-width=\"0\" x=\"160\" y=\"158\" id=\"svg_38808a61-cea3-4348-b1c7-755785258a09\" font-size=\"12\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">Output</text>\n  <text fill=\"#3f3f3f\" stroke=\"#000000\" stroke-width=\"0\" x=\"230\" y=\"138\" id=\"svg_a8821bb2-2482-4e4a-b5e3-d581ffb668b3\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">Status</text>\n  <text fill=\"#3f3f3f\" stroke=\"#000000\" stroke-width=\"0\" x=\"92\" y=\"138\" id=\"svg_518b5cb4-7c7d-44c0-bbc0-65669e590a33\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">Alarm</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" x=\"344\" y=\"132\" id=\"svg_6341f818-02ad-4c0a-a045-be4ecd0d5dd3\" font-size=\"12\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">100% _</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" x=\"352\" y=\"248\" id=\"svg_ae6d89a7-4470-4835-9d4a-d814c31620ba\" font-size=\"12\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">0% _</text>\n  <g id=\"VAL_697c8d67-a079-41cd-a8da-d6111999cb28\" type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\">\n   <text stroke-width=\"0\" id=\"VAL_98ea0a80-5665-403f-a2a8-3faf3530a871\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"162.39844\" y=\"230\">##.##</text>\n  </g>\n  <g id=\"VAL_be8a95d8-2b40-464e-9b94-c291707680f3\" type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\">\n   <text stroke-width=\"0\" id=\"VAL_401611cd-80c7-4eec-a8f4-510c410a0dfa\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"160\" y=\"178\">##.##</text>\n  </g>\n  <g id=\"GSE_fb2169f5-01f5-4899-87e3-24c14cd8fba4\" type=\"svg-ext-gauge_semaphore\" fill=\"#000000\" font-size=\"14\" stroke=\"#000000\" font-family=\"sans-serif\">\n   <ellipse id=\"GSE_d9e7f956-73b6-4011-b98c-1504eebfb9c3\" cx=\"230\" cy=\"162\" rx=\"14\" ry=\"14\" fill=\"#bfbfbf\" stroke=\"#000000\"/>\n  </g>\n  <g type=\"svg-ext-gauge_semaphore\" fill=\"#000000\" font-size=\"14\" stroke=\"#000000\" font-family=\"sans-serif\" id=\"GSE_e580695d-c9a5-4201-9ff4-706b1c2b0f6b\">\n   <ellipse cx=\"92\" cy=\"162\" rx=\"14\" ry=\"14\" fill=\"#bfbfbf\" stroke=\"#000000\" id=\"GSE_f2209e39-7e79-4629-aac2-0d49adfde97d\"/>\n  </g>\n  <g id=\"VAL_e62fbc6b-eba9-4a36-aa09-25c35203e38b\" type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\">\n   <text stroke-width=\"0\" id=\"VAL_96125744-4367-48ea-aefe-e048cd80d460\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"394\" y=\"212\">##.##</text>\n  </g>\n  <text xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" y=\"224\" x=\"462\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" fill=\"#3f3f3f\" id=\"svg_56cdcd1b-b724-408e-8285-dee2c34985e4\">TK 1</text>\n  <g stroke=\"#000000\" text-anchor=\"right\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#f1f1f1ff\" type=\"svg-ext-html_input\" id=\"HXI_f10a6145-cb49-46b8-a5fe-fa385442c8f3\">\n   <rect stroke=\"null\" fill=\"#ffffff\" id=\"svg_28f460a0-dbe6-46bf-9618-088bb8df99f2\" height=\"24\" width=\"42\" y=\"208\" x=\"488\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\"/>\n   <foreignObject id=\"H-HXI_4e8c11ad-e002-413e-ad3c-69084f74f00e\" width=\"42\" height=\"24\" y=\"208\" x=\"488\">\n    <INPUT style=\"width: calc(100% - 7px); height: calc(100% - 7px); text-align: right; border: unset; background-color: rgb(255, 255, 255); color: rgb(0, 0, 0); vector-effect: non-scaling-stroke;\" type=\"text\" id=\"I-HXI_4e8c11ad-e002-413e-ad3c-69084f74f00e\"/>\n   </foreignObject>\n  </g>\n  <text xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" id=\"svg_5b80f00f-827e-40c1-b078-1467b707cb6c\" y=\"224\" x=\"550\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" stroke=\"null\" fill=\"#000000\">%</text>\n  <rect id=\"svg_aee7046e-fbe1-4422-8a81-37333287a19f\" stroke=\"#bfbfbf\" height=\"32\" width=\"130\" y=\"148\" x=\"440\" fill=\"#f1f1f1ff\"/>\n  <text id=\"svg_cb901166-41e8-4c76-8221-4f6a701caef6\" xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" y=\"168\" x=\"462\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" fill=\"#3f3f3f\">TW 1</text>\n  <g id=\"HXI_bd765710-8927-4624-ae5e-d526e7a0f158\" stroke=\"#000000\" text-anchor=\"right\" font-family=\"sans-serif\" font-size=\"14\" fill=\"#f1f1f1ff\" type=\"svg-ext-html_input\">\n   <rect id=\"svg_03378937-5883-4ce1-9945-7e1f09d860c5\" stroke=\"null\" fill=\"#ffffff\" height=\"24\" width=\"42\" y=\"152\" x=\"487\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\"/>\n   <foreignObject id=\"H-HXI_3d904248-8094-4d33-aa72-4c291191667f\" width=\"42\" height=\"24\" y=\"152\" x=\"487\">\n    <INPUT id=\"I-HXI_ff6f45d3-7a26-40d2-9374-8161f7195a57\" style=\"width: calc(100% - 7px); height: calc(100% - 7px); text-align: right; border: unset; background-color: rgb(255, 255, 255); color: rgb(0, 0, 0); vector-effect: non-scaling-stroke;\" type=\"text\"/>\n   </foreignObject>\n  </g>\n  <text id=\"svg_34edaa19-d2c6-489f-9314-f53f7f367c7d\" xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"14\" y=\"168\" x=\"550\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"0\" stroke=\"null\" fill=\"#000000\">%</text>\n  <text id=\"svg_1a339dd5-4b8c-49c0-89b2-3fd6874e8962\" xml:space=\"preserve\" text-anchor=\"start\" font-family=\"sans-serif\" font-size=\"26\" y=\"28\" x=\"4\" stroke-width=\"0\" stroke=\"#000000\" fill=\"#000000\">My Dashboard</text>\n </g>\n</svg>"
+      },
+      {
+        "id": "v_1571818530964",
+        "name": "MainView",
+        "profile": {
+          "width": 1200,
+          "height": 800,
+          "bkcolor": ""
+        },
+        "items": {
+          "GXP_1d70fd59-8d25-4b4c-b47f-eac0f348ac7b": {
+            "id": "GXP_1d70fd59-8d25-4b4c-b47f-eac0f348ac7b",
+            "type": "svg-ext-gauge_progress",
+            "name": "B1",
+            "property": {
+              "events": [],
+              "variable": "Byte 1",
+              "variableId": "SPS^~^Byte 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "minmax",
+                  "min": 0,
+                  "max": "260",
+                  "style": [
+                    true,
+                    true
+                  ],
+                  "color": "#5a81ef"
+                }
+              ]
+            },
+            "label": "HtmlProgress"
+          },
+          "VAL_4e6cb375-3222-4563-8e34-18f986fc77b1": {
+            "id": "VAL_4e6cb375-3222-4563-8e34-18f986fc77b1",
+            "type": "svg-ext-value",
+            "name": "B2",
+            "property": {
+              "events": [],
+              "variable": "Byte 2",
+              "variableId": "SPS^~^Byte 2",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": "\u00b0C "
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_83ffab8d-7b3a-4f75-8b19-cbefbeb0bed5": {
+            "id": "VAL_83ffab8d-7b3a-4f75-8b19-cbefbeb0bed5",
+            "type": "svg-ext-value",
+            "name": "Int 1",
+            "property": {
+              "events": [],
+              "variable": "Int 1",
+              "variableId": "SPS^~^Int 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": "A"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_7f3c9a21-387a-45c3-9e5f-46548fb41231": {
+            "id": "VAL_7f3c9a21-387a-45c3-9e5f-46548fb41231",
+            "type": "svg-ext-value",
+            "name": "Int 2",
+            "property": {
+              "events": [],
+              "variable": "Int 2",
+              "variableId": "SPS^~^Int 2",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": "A"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_4a99178d-9d48-4cce-b69c-ae3783aa14f8": {
+            "id": "VAL_4a99178d-9d48-4cce-b69c-ae3783aa14f8",
+            "type": "svg-ext-value",
+            "name": "Int 3",
+            "property": {
+              "events": [],
+              "variable": "Int 3",
+              "variableId": "SPS^~^Int 3",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": "A"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "MTR_ea17f635-1b44-4708-a6cc-7d9521210d68": {
+            "id": "MTR_ea17f635-1b44-4708-a6cc-7d9521210d68",
+            "type": "svg-ext-motor",
+            "name": "W1",
+            "property": {
+              "events": [
+                {
+                  "type": "click",
+                  "action": "ondialog",
+                  "actparam": "v_1571825012326"
+                }
+              ],
+              "variable": "Word 1",
+              "variableId": "SPS^~^Word 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "1",
+                  "max": "1000",
+                  "color": "#0ac97d"
+                },
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "0"
+                }
+              ]
+            },
+            "label": "Motor"
+          },
+          "MTR_103ee2be-6f2a-40cf-a20e-784f07495540": {
+            "id": "MTR_103ee2be-6f2a-40cf-a20e-784f07495540",
+            "type": "svg-ext-motor",
+            "name": "W2",
+            "property": {
+              "events": [
+                {
+                  "type": "click",
+                  "action": "ondialog",
+                  "actparam": "v_1571825012326"
+                }
+              ],
+              "variable": "Word 2",
+              "variableId": "SPS^~^Word 2",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "1",
+                  "max": "2000",
+                  "color": "#0ac97d"
+                },
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "0"
+                }
+              ]
+            },
+            "label": "Motor"
+          },
+          "MTR_c5c1e898-e07c-41b9-bc3a-350772d0ab2d": {
+            "id": "MTR_c5c1e898-e07c-41b9-bc3a-350772d0ab2d",
+            "type": "svg-ext-motor",
+            "name": "W3",
+            "property": {
+              "events": [
+                {
+                  "type": "click",
+                  "action": "ondialog",
+                  "actparam": "v_1571825012326"
+                }
+              ],
+              "variable": "Word 3",
+              "variableId": "SPS^~^Word 3",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "1",
+                  "max": "3000",
+                  "color": "#0ac97d"
+                },
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "0"
+                }
+              ]
+            },
+            "label": "Motor"
+          },
+          "MTR_16843c86-5559-4366-a1b3-ce62e290ad7a": {
+            "id": "MTR_16843c86-5559-4366-a1b3-ce62e290ad7a",
+            "type": "svg-ext-motor",
+            "name": "W4",
+            "property": {
+              "events": [
+                {
+                  "type": "click",
+                  "action": "ondialog",
+                  "actparam": "v_1571825012326"
+                }
+              ],
+              "variable": "Word 4",
+              "variableId": "SPS^~^Word 4",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "100",
+                  "color": "#a5a5a5"
+                },
+                {
+                  "type": "range",
+                  "min": "100",
+                  "max": "200",
+                  "color": "#00b0f0"
+                },
+                {
+                  "type": "range",
+                  "min": "200",
+                  "max": "300",
+                  "color": "#ffc000"
+                }
+              ]
+            },
+            "label": "Motor"
+          },
+          "VAL_8d3be0b8-84fb-485b-80fb-b18f99d62dd2": {
+            "id": "VAL_8d3be0b8-84fb-485b-80fb-b18f99d62dd2",
+            "type": "svg-ext-value",
+            "name": "B5",
+            "property": {
+              "events": [],
+              "variable": "Byte 5",
+              "variableId": "SPS^~^Byte 5",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": "\u00b0C"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_457d654f-c426-4dca-afe3-a0d9bb1990b0": {
+            "id": "VAL_457d654f-c426-4dca-afe3-a0d9bb1990b0",
+            "type": "svg-ext-value",
+            "name": "B4",
+            "property": {
+              "events": [],
+              "variable": "Byte 4",
+              "variableId": "SPS^~^Byte 4",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": "\u00b0C"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_839bf3d7-32c4-4716-bd65-ce931acb254d": {
+            "id": "VAL_839bf3d7-32c4-4716-bd65-ce931acb254d",
+            "type": "svg-ext-value",
+            "name": "DW1",
+            "property": {
+              "events": [],
+              "variable": "DWord 1",
+              "variableId": "SPS^~^DWord 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": "bar"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_36eb85fa-5da4-4245-bf43-435044dfc1aa": {
+            "id": "VAL_36eb85fa-5da4-4245-bf43-435044dfc1aa",
+            "type": "svg-ext-value",
+            "name": "DI1",
+            "property": {
+              "events": [],
+              "variable": "DInt 1",
+              "variableId": "SPS^~^DInt 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": "bar"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VLA_8ca8d63a-e8b1-47ba-8f64-a8e98620dcee": {
+            "id": "VLA_8ca8d63a-e8b1-47ba-8f64-a8e98620dcee",
+            "type": "svg-ext-valve",
+            "name": "I1",
+            "property": {
+              "events": [],
+              "variable": "Int 1",
+              "variableId": "SPS^~^Int 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": 20,
+                  "max": 80
+                }
+              ]
+            },
+            "label": "Valve"
+          },
+          "VLA_6a85480b-4f2e-46bd-a359-3ddae822b898": {
+            "id": "VLA_6a85480b-4f2e-46bd-a359-3ddae822b898",
+            "type": "svg-ext-valve",
+            "name": "B5",
+            "property": {
+              "events": [],
+              "variable": "Byte 5",
+              "variableId": "SPS^~^Byte 5",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "125",
+                  "color": "#ff0000"
+                },
+                {
+                  "type": "range",
+                  "min": "126",
+                  "max": "255",
+                  "color": "#00b050"
+                }
+              ]
+            },
+            "label": "Valve"
+          },
+          "VLA_6b051259-26cd-4002-98c9-a3809029dffa": {
+            "id": "VLA_6b051259-26cd-4002-98c9-a3809029dffa",
+            "type": "svg-ext-valve",
+            "name": "B4",
+            "property": {
+              "events": [],
+              "variable": "Byte 4",
+              "variableId": "SPS^~^Byte 4",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "125",
+                  "color": "#ff0000"
+                },
+                {
+                  "type": "range",
+                  "min": "126",
+                  "max": "255",
+                  "color": "#00b050"
+                }
+              ]
+            },
+            "label": "Valve"
+          },
+          "VLA_db861d5f-6bbc-42da-bc8f-2912a6e3575f": {
+            "id": "VLA_db861d5f-6bbc-42da-bc8f-2912a6e3575f",
+            "type": "svg-ext-valve",
+            "name": "B3",
+            "property": {
+              "events": [],
+              "variable": "Byte 3",
+              "variableId": "SPS^~^Byte 3",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "125",
+                  "color": "#00b050"
+                },
+                {
+                  "type": "range",
+                  "min": "126",
+                  "max": "255",
+                  "color": "#ff0000"
+                }
+              ]
+            },
+            "label": "Valve"
+          },
+          "VLA_f1b60d2e-8dac-4d6e-8059-f72ca7da1314": {
+            "id": "VLA_f1b60d2e-8dac-4d6e-8059-f72ca7da1314",
+            "type": "svg-ext-valve",
+            "name": "Int 5",
+            "property": {
+              "events": [
+                {
+                  "type": "click",
+                  "action": "ondialog",
+                  "actparam": "v_1573047881338"
+                }
+              ],
+              "variable": "Int 5",
+              "variableId": "SPS^~^Int 5",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "1",
+                  "max": "50",
+                  "color": "#0ac97d"
+                },
+                {
+                  "type": "range",
+                  "min": "51",
+                  "max": "100",
+                  "color": "#00873e"
+                }
+              ]
+            },
+            "label": "Valve"
+          },
+          "VLA_ae222e5f-d9b1-465e-97e2-fc2e8b6db886": {
+            "id": "VLA_ae222e5f-d9b1-465e-97e2-fc2e8b6db886",
+            "type": "svg-ext-valve",
+            "name": "Int 4",
+            "property": {
+              "events": [
+                {
+                  "type": "click",
+                  "action": "onwindow",
+                  "actparam": "v_1573047881338"
+                }
+              ],
+              "variable": "Int 4",
+              "variableId": "SPS^~^Int 4",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "1",
+                  "max": "50",
+                  "color": "#ffd04a"
+                },
+                {
+                  "type": "range",
+                  "min": "51",
+                  "max": "100",
+                  "color": "#0ac97d"
+                }
+              ]
+            },
+            "label": "Valve"
+          },
+          "VLA_5634224b-08e9-476e-872c-665886ee30db": {
+            "id": "VLA_5634224b-08e9-476e-872c-665886ee30db",
+            "type": "svg-ext-valve",
+            "name": "DW1",
+            "property": {
+              "events": [],
+              "variable": "DWord 1",
+              "variableId": "SPS^~^DWord 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "range",
+                  "min": "0",
+                  "max": "3000",
+                  "color": "#ffd04a"
+                }
+              ]
+            },
+            "label": "Valve"
+          }
+        },
+        "variables": {},
+        "svgcontent": "<svg width=\"1200\" height=\"800\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:svg=\"http://www.w3.org/2000/svg\">\n <g>\n  <title>Layer 1</title>\n  <line fill=\"none\" stroke-width=\"4\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x1=\"816\" y1=\"150\" x2=\"816\" y2=\"594\" id=\"svg_b1fb3ded-b4b7-4ac4-9b4e-940dc33f5f46\" stroke=\"#000000\"/>\n  <line fill=\"none\" stroke-width=\"4\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x1=\"406\" y1=\"152\" x2=\"406\" y2=\"298\" stroke=\"#000000\" id=\"svg_5a703673-bf1e-4333-9756-fd1caed58f18\"/>\n  <line fill=\"none\" stroke-width=\"4\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x1=\"332\" y1=\"154\" x2=\"332\" y2=\"300\" id=\"svg_3bea3806-61d6-4e6f-9223-db51a0ed2c72\" stroke=\"#000000\"/>\n  <line fill=\"none\" stroke-width=\"4\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x1=\"696\" y1=\"276\" x2=\"696\" y2=\"914\" id=\"svg_d00ee9a4-5117-46e9-8c96-6709c54d37f2\" transform=\"rotate(90 696,595.0000000000001) \" stroke=\"#000000\"/>\n  <g id=\"svg_b9eeeb40-843a-4b51-affc-b161d0390980\">\n   <g id=\"svg_8a804563-b935-45db-aac7-fd319a6d77d3\">\n    <path fill=\"#e2e2e2ff\" stroke-width=\"null\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M334.98183,296L420.48144,296Q448.98183,296 448.98183,350.62562Q448.98183,405.25124 420.48144,405.25124L334.98183,405.25124L334.98183,296z\" id=\"SHP_754306a2-f101-4b4a-bb10-6b262472a422\" stroke=\"#e2e2e2ff\"/>\n    <path fill=\"#e2e2e2ff\" stroke-width=\"null\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M264.99999,296.00001L350.4996,296.00001Q378.99999,296.00001 378.99999,350.62563Q378.99999,405.25125 350.4996,405.25125L264.99999,405.25125L264.99999,296.00001z\" stroke=\"#e2e2e2ff\" id=\"SHP_174b6f1e-235f-4cc0-b18b-11f32e7601fc\" transform=\"rotate(-180 322,350.6256103515625) \"/>\n   </g>\n   <path fill=\"#e2e2e2ff\" stroke-width=\"null\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M361.3871,402.17746L385.38699,402.17746Q393.3871,402.17746 393.3871,420.28254Q393.3871,438.38762 385.38699,438.38762L361.3871,438.38762L361.3871,402.17746z\" id=\"SHP_fda3d42b-3168-4ba8-bd5d-7ed1700f3311\" transform=\"rotate(90 377.3870849609375,420.2825317382813) \" stroke=\"#e2e2e2ff\"/>\n  </g>\n  <path fill=\"#000000\" d=\"M168.92288,164.62599L168.92288,138.62599L234.49985,138.62599L264.2997,151.62557L234.49985,164.62515L168.92288,164.62599z\" id=\"SHP_9934cb99-cf81-4b29-a770-62b34f244512\" stroke=\"#000000\"/>\n  <text fill=\"#ffffff\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"200\" y=\"156\" id=\"svg_1bf8615c-9eba-4b80-82f4-ef25c0e88616\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">HP W1</text>\n  <path fill=\"#000000\" d=\"M1004.31158,607.00001L1004.31158,581.00001L1069.88855,581.00001L1099.6884,593.99959L1069.88855,606.99917L1004.31158,607.00001z\" stroke=\"#000000\" id=\"SHP_7abb7e99-d82d-4707-b184-e3cf211dd128\"/>\n  <text fill=\"#ffffff\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"1036\" y=\"598\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_385f3bc3-8521-4138-9183-c75389b264d2\">HP T1</text>\n  <path fill=\"#e2e2e2ff\" stroke-width=\"null\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M716.81129,296.00112L919.07398,296.00112L919.07398,363.69497L868.50877,406.0011L767.38203,406.0011L716.81682,363.69497L716.81129,296.00112z\" id=\"SHP_9d6e73f4-e24d-4f96-8f45-6092b4f1c269\" stroke=\"#e2e2e2ff\"/>\n  <g id=\"GXP_1d70fd59-8d25-4b4c-b47f-eac0f348ac7b\" type=\"svg-ext-gauge_progress\" font-size=\"14\" stroke-width=\"null\" font-family=\"sans-serif\" stroke=\"#e2e2e2ff\">\n   <rect stroke-width=\"null\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"A-GXP_0ab9fef9-4462-4e37-8102-fd180497950d\" x=\"300\" y=\"300\" width=\"50\" height=\"102\" fill=\"#7f7f7f\" stroke=\"#e2e2e2ff\"/>\n   <rect stroke-width=\"null\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"B-GXP_697a7108-6709-4e75-8200-8c6803e06c19\" x=\"300\" y=\"351\" width=\"50\" height=\"51\" fill=\"#5a81ef\" stroke=\"#e2e2e2ff\"/>\n   <foreignObject x=\"300\" y=\"300\" height=\"102\" width=\"50\" id=\"H-GXP_72d79c7d-a3a6-4881-bd7b-a9010486a361\" font-size=\"14\"/>\n  </g>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" x=\"394\" y=\"332\" id=\"svg_2667d080-a4f9-48bc-aa17-a2dc3d04b0ec\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">TANK</text>\n  <g id=\"VAL_4e6cb375-3222-4563-8e34-18f986fc77b1\" type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\">\n   <text stroke-width=\"0\" id=\"VAL_4e43c578-7b1a-4bff-8a1e-1d216863e6ef\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"394\" y=\"358\">##.##</text>\n  </g>\n  <g id=\"CPS_52f76a04-b6d0-4043-8c98-682a1438a83d\" type=\"svg-ext-compressor\" fill=\"#ffffff\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\">\n   <path id=\"fCPS_b2a83f2f-03fd-4f2f-8bd3-a03a0e7c3319\" d=\"M743.0985,313.427C744.926,315.569 746.065,317.6005 745.64,317.966C745.436,318.1445 744.892,317.9065 744.1185,317.303C743.3535,316.6995 742.427,315.7815 741.5515,314.753C739.724,312.611 738.585,310.5795 739.01,310.214C739.214,310.0355 739.758,310.2735 740.5315,310.877C741.2965,311.4805 742.223,312.3985 743.0985,313.427zM741.543,321.3065C742.4185,320.2695 743.3365,319.3515 744.093,318.7395C744.858,318.1275 745.402,317.8895 745.606,318.068C745.8185,318.238 745.674,318.816 745.198,319.666C744.7305,320.5245 743.9825,321.587 743.107,322.624C742.2315,323.661 741.3135,324.5875 740.557,325.191C739.792,325.803 739.248,326.041 739.044,325.871C738.8315,325.6925 738.976,325.1145 739.452,324.2645C739.9195,323.406 740.6675,322.3435 741.543,321.3065zM756.35,318A5.1,1.02 0 0 1 751.25,319.02A5.1,1.02 0 0 1 746.15,318A5.1,1.02 0 0 1 751.25,316.98A5.1,1.02 0 0 1 756.35,318M737.225,303.38L761.025,310.52M737.225,332.62L761.025,325.48M763.15,318A17,17 0 0 1 746.15,335A17,17 0 0 1 729.15,318A17,17 0 0 1 746.15,301A17,17 0 0 1 763.15,318z\" stroke=\"#000000\"/>\n  </g>\n  <g type=\"svg-ext-compressor\" fill=\"#ffffff\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\" id=\"CPS_f12207eb-717f-4824-a0b9-5bcaaaf33261\">\n   <path d=\"M813.44848,313.427C815.27598,315.569 816.41498,317.6005 815.98998,317.966C815.78598,318.1445 815.24198,317.9065 814.46848,317.303C813.70348,316.6995 812.77698,315.7815 811.90148,314.753C810.07398,312.611 808.93498,310.5795 809.35998,310.214C809.56398,310.0355 810.10798,310.2735 810.88148,310.877C811.64648,311.4805 812.57298,312.3985 813.44848,313.427zM811.89298,321.3065C812.76848,320.2695 813.68648,319.3515 814.44298,318.7395C815.20798,318.1275 815.75198,317.8895 815.95598,318.068C816.16848,318.238 816.02398,318.816 815.54798,319.666C815.08048,320.5245 814.33248,321.587 813.45698,322.624C812.58148,323.661 811.66348,324.5875 810.90698,325.191C810.14198,325.803 809.59798,326.041 809.39398,325.871C809.18148,325.6925 809.32598,325.1145 809.80198,324.2645C810.26948,323.406 811.01748,322.3435 811.89298,321.3065zM826.69998,318A5.1,1.02 0 0 1 821.59998,319.02A5.1,1.02 0 0 1 816.49998,318A5.1,1.02 0 0 1 821.59998,316.98A5.1,1.02 0 0 1 826.69998,318M807.57498,303.38L831.37498,310.52M807.57498,332.62L831.37498,325.48M833.49998,318A17,17 0 0 1 816.49998,335A17,17 0 0 1 799.49998,318A17,17 0 0 1 816.49998,301A17,17 0 0 1 833.49998,318z\" stroke=\"#000000\" id=\"fCPS_20c5b651-9d1a-496b-abdd-d3bd79a2bbab\"/>\n  </g>\n  <g type=\"svg-ext-compressor\" fill=\"#ffffff\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\" id=\"CPS_b0a31b9f-e5aa-47e4-8410-3884704f6dc1\">\n   <path d=\"M883.44848,313.427C885.27598,315.569 886.41498,317.6005 885.98998,317.966C885.78598,318.1445 885.24198,317.9065 884.46848,317.303C883.70348,316.6995 882.77698,315.7815 881.90148,314.753C880.07398,312.611 878.93498,310.5795 879.35998,310.214C879.56398,310.0355 880.10798,310.2735 880.88148,310.877C881.64648,311.4805 882.57298,312.3985 883.44848,313.427zM881.89298,321.3065C882.76848,320.2695 883.68648,319.3515 884.44298,318.7395C885.20798,318.1275 885.75198,317.8895 885.95598,318.068C886.16848,318.238 886.02398,318.816 885.54798,319.666C885.08048,320.5245 884.33248,321.587 883.45698,322.624C882.58148,323.661 881.66348,324.5875 880.90698,325.191C880.14198,325.803 879.59798,326.041 879.39398,325.871C879.18148,325.6925 879.32598,325.1145 879.80198,324.2645C880.26948,323.406 881.01748,322.3435 881.89298,321.3065zM896.69998,318A5.1,1.02 0 0 1 891.59998,319.02A5.1,1.02 0 0 1 886.49998,318A5.1,1.02 0 0 1 891.59998,316.98A5.1,1.02 0 0 1 896.69998,318M877.57498,303.38L901.37498,310.52M877.57498,332.62L901.37498,325.48M903.49998,318A17,17 0 0 1 886.49998,335A17,17 0 0 1 869.49998,318A17,17 0 0 1 886.49998,301A17,17 0 0 1 903.49998,318z\" stroke=\"#000000\" id=\"fCPS_4cbebf9a-8f37-4743-968d-e3da86da228c\"/>\n  </g>\n  <g id=\"VAL_83ffab8d-7b3a-4f75-8b19-cbefbeb0bed5\" type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"VAL_946ae922-1449-4f37-a8e1-9f5ed6e84140\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"748\" y=\"353\">##.##</text>\n  </g>\n  <g id=\"VAL_7f3c9a21-387a-45c3-9e5f-46548fb41231\" type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"VAL_90bd9e2c-21c4-4a78-b87f-d44f0fc372dc\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"817\" y=\"353\">##.##</text>\n  </g>\n  <g id=\"VAL_4a99178d-9d48-4cce-b69c-ae3783aa14f8\" type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"VAL_9ab0852e-4472-4106-9017-6f49fc9db55f\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"886\" y=\"353\">##.##</text>\n  </g>\n  <line fill=\"none\" stroke-width=\"4\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x1=\"376\" y1=\"436\" x2=\"376\" y2=\"698\" id=\"svg_749eaabe-5685-4afa-94dd-479b390fff35\" stroke=\"#000000\"/>\n  <line fill=\"none\" stroke-width=\"4\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x1=\"664\" y1=\"496\" x2=\"664\" y2=\"698\" id=\"svg_af3ea87b-db47-4f80-9ce2-58e5f1f6d68b\" stroke=\"#000000\"/>\n  <line fill=\"none\" stroke=\"#000000\" stroke-width=\"4\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x1=\"376\" y1=\"498\" x2=\"666\" y2=\"498\" id=\"svg_f8130f9c-0921-4242-9a85-b3440134eb98\"/>\n  <line fill=\"none\" stroke=\"#000000\" stroke-width=\"4\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x1=\"374\" y1=\"696\" x2=\"664\" y2=\"696\" id=\"svg_fba59f54-e751-40f5-bf26-1dbf9d57f9a1\"/>\n  <g id=\"VLA_8ca8d63a-e8b1-47ba-8f64-a8e98620dcee\" type=\"svg-ext-valve\" fill=\"#7f7f7f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" transform=\"rotate(90 375.72222900390625,462.00000000000006) \" stroke=\"#000000\">\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"tlVLA_04754b58-23af-46f4-ae9a-4943e9520d8a\" d=\"M360.22223,451.00001L375.22223,462.00001L360.22223,473.00001L360.22223,451.00001z\" stroke=\"#000000\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"trVLA_da150fad-4fcb-4eb0-8c33-7d90a2e88380\" d=\"M391.22223,473.00001L376.22223,462.00001L391.22223,451.00001L391.22223,473.00001z\" stroke=\"#000000\"/>\n  </g>\n  <g type=\"svg-ext-valve\" fill=\"#7f7f7f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" transform=\"rotate(90 815.5000000000001,453.00000000000006) \" stroke=\"#000000\" id=\"VLA_5634224b-08e9-476e-872c-665886ee30db\">\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M800,442.00001L815,453.00001L800,464.00001L800,442.00001z\" stroke=\"#000000\" id=\"tlVLA_95753f09-5e18-423a-8802-08240f83ac3f\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M831,464.00001L816,453.00001L831,442.00001L831,464.00001z\" stroke=\"#000000\" id=\"trVLA_5c22f99c-7b29-4b6a-a6cf-e1ff50b2dcc8\"/>\n  </g>\n  <g type=\"svg-ext-valve\" fill=\"#7f7f7f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" transform=\"rotate(90 332.00000000000006,255.00000000000003) \" stroke=\"#000000\" id=\"VLA_f1b60d2e-8dac-4d6e-8059-f72ca7da1314\">\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M316.5,244.00001L331.5,255.00001L316.5,266.00001L316.5,244.00001z\" stroke=\"#000000\" id=\"tlVLA_8070fcac-6230-4179-bc9f-584cf183cb78\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M347.5,266.00001L332.5,255.00001L347.5,244.00001L347.5,266.00001z\" stroke=\"#000000\" id=\"trVLA_33f608c1-b391-4db7-8e35-c044801a89f7\"/>\n  </g>\n  <g type=\"svg-ext-valve\" fill=\"#7f7f7f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" transform=\"rotate(90 406.00000000000006,255.00000000000003) \" stroke=\"#000000\" id=\"VLA_ae222e5f-d9b1-465e-97e2-fc2e8b6db886\">\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M390.5,244.00001L405.5,255.00001L390.5,266.00001L390.5,244.00001z\" stroke=\"#000000\" id=\"tlVLA_55228eba-b301-49c2-a55c-f5728bf96f51\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M421.5,266.00001L406.5,255.00001L421.5,244.00001L421.5,266.00001z\" stroke=\"#000000\" id=\"trVLA_4ac85848-d548-41e0-86cf-205c4faf88d8\"/>\n  </g>\n  <g type=\"svg-ext-valve\" fill=\"#7f7f7f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\" id=\"VLA_6a85480b-4f2e-46bd-a359-3ddae822b898\">\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M424,487.00001L439,498.00001L424,509.00001L424,487.00001z\" stroke=\"#000000\" id=\"tlVLA_d0c65737-78c5-4eda-92aa-dde748e6f0a3\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M455,509.00001L440,498.00001L455,487.00001L455,509.00001z\" stroke=\"#000000\" id=\"trVLA_ad61e904-1cfd-4043-a164-41a1b56ab5ec\"/>\n  </g>\n  <g type=\"svg-ext-valve\" fill=\"#7f7f7f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\" id=\"VLA_6b051259-26cd-4002-98c9-a3809029dffa\">\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M424,584.00001L439,595.00001L424,606.00001L424,584.00001z\" stroke=\"#000000\" id=\"tlVLA_76d4a358-9a70-464f-b3a4-28c5b5b6ac1d\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M455,606.00001L440,595.00001L455,584.00001L455,606.00001z\" stroke=\"#000000\" id=\"trVLA_6ee7df1e-7987-433f-a32d-68281c231e08\"/>\n  </g>\n  <g type=\"svg-ext-valve\" fill=\"#7f7f7f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\" id=\"VLA_db861d5f-6bbc-42da-bc8f-2912a6e3575f\">\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M422,685.00001L437,696.00001L422,707.00001L422,685.00001z\" stroke=\"#000000\" id=\"tlVLA_5e4dfc9a-04ff-4133-9311-e5a9a99c1c64\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M453,707.00001L438,696.00001L453,685.00001L453,707.00001z\" stroke=\"#000000\" id=\"trVLA_0cf56719-01c4-4fe2-9a81-5d711dcfed89\"/>\n  </g>\n  <line fill=\"none\" stroke-width=\"4\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x1=\"240\" y1=\"152\" x2=\"334\" y2=\"152\" id=\"svg_ee27b882-3400-4e0a-94f5-cfa6900664bb\" stroke=\"#000000\"/>\n  <line fill=\"none\" stroke-width=\"4\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x1=\"404\" y1=\"152\" x2=\"816\" y2=\"152\" id=\"svg_4c3317f0-42c4-4d60-89b6-c5e0f4ccc27f\" stroke=\"#000000\"/>\n  <path fill=\"#7f7f7f\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M317.70982,267.33267L317.64565,253.71403M310.28483,241.33267L324.95198,241.33267L324.95198,253.71403L310.28483,253.71403L310.28483,241.33267z\" id=\"SHP_1d487c92-d742-46b0-8669-aa78bc68e091\" transform=\"rotate(-90 317.618408203125,254.3326721191406) \" stroke=\"#000000\"/>\n  <path fill=\"#7f7f7f\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M418.56799,267.73437L418.50382,254.11573M411.143,241.73437L425.81015,241.73437L425.81015,254.11573L411.143,254.11573L411.143,241.73437z\" transform=\"rotate(90 418.47656250000006,254.73437500000003) \" stroke=\"#000000\" id=\"SHP_35b9e530-386f-4360-b89e-f7f01e5d6ecc\"/>\n  <g id=\"MTR_16843c86-5559-4366-a1b3-ce62e290ad7a\" type=\"svg-ext-motor\" fill=\"#cececeff\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\">\n   <ellipse stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"cMTR_0f9614e8-ad22-45a4-b762-486c3965d71f\" cx=\"576.95238\" cy=\"151\" rx=\"21.47619\" ry=\"22.45238\" stroke=\"#000000\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"sMTR_403e67fa-3b42-4d4b-891c-ba31af5cd3e8\" d=\"M576.95238,130.19048L597.90476,151.27381L576.95238,172.35714L576.95238,130.19048z\" fill=\"#000000\" stroke=\"null\"/>\n  </g>\n  <g type=\"svg-ext-motor\" fill=\"#cececeff\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\" id=\"MTR_ea17f635-1b44-4708-a6cc-7d9521210d68\">\n   <ellipse stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" cx=\"547.99999\" cy=\"497.99999\" rx=\"21.47619\" ry=\"22.45238\" stroke=\"#000000\" id=\"cMTR_09ef74ea-9429-4e4f-89fd-8dd65898d75e\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M547.99999,477.19047L568.95237,498.2738L547.99999,519.35713L547.99999,477.19047z\" fill=\"#000000\" stroke=\"null\" id=\"sMTR_223aaef7-40d1-4001-9de8-d4bd03397f6c\"/>\n  </g>\n  <g type=\"svg-ext-motor\" fill=\"#cececeff\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\" id=\"MTR_103ee2be-6f2a-40cf-a20e-784f07495540\">\n   <ellipse stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" cx=\"547.99999\" cy=\"593.99999\" rx=\"21.47619\" ry=\"22.45238\" stroke=\"#000000\" id=\"cMTR_429ea778-66c3-4cea-9d96-03765da96ef9\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M547.99999,573.19047L568.95237,594.2738L547.99999,615.35713L547.99999,573.19047z\" fill=\"#000000\" stroke=\"null\" id=\"sMTR_6757ba37-95e0-4f2e-90ce-0fe9d888d961\"/>\n  </g>\n  <g type=\"svg-ext-motor\" fill=\"#cececeff\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\" id=\"MTR_c5c1e898-e07c-41b9-bc3a-350772d0ab2d\">\n   <ellipse stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" cx=\"547.99999\" cy=\"695.99999\" rx=\"21.47619\" ry=\"22.45238\" stroke=\"#000000\" id=\"cMTR_7eee2774-7c88-41a8-8674-c5b0203f520f\"/>\n   <path stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M547.99999,675.19047L568.95237,696.2738L547.99999,717.35713L547.99999,675.19047z\" fill=\"#000000\" stroke=\"null\" id=\"sMTR_32dad38a-572e-410a-a31b-dca773f14c4d\"/>\n  </g>\n  <path fill=\"#ff0000\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M562.96185,383.73437L620.68019,383.73437Q639.91999,383.73437 639.91999,394.73437Q639.91999,405.73437 620.68019,405.73437L562.96185,405.73437L562.96185,383.73437z\" id=\"SHP_a0bc48dd-5381-4ff3-ac35-2ec84b3538db\" stroke=\"#ff0000\" transform=\"rotate(-180 601.44091796875,394.73437499999994) \"/>\n  <text fill=\"#ffffff\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"604\" y=\"400\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_974bda45-2dbc-46ab-9401-f345dac9ea16\">WH S1</text>\n  <path fill=\"#007fff\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" d=\"M986.02093,384L1043.73927,384Q1062.97907,384 1062.97907,395Q1062.97907,406 1043.73927,406L986.02093,406L986.02093,384z\" stroke=\"#007fff\" transform=\"rotate(-180 1024.5,395) \" id=\"SHP_ba31c907-643e-4ad5-8660-365f61f013a9\"/>\n  <text fill=\"#ffffff\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"1028\" y=\"400\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_12df374a-ca13-42d8-b925-a112d54c0b42\">CH S1</text>\n  <line fill=\"none\" stroke-width=\"4\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x1=\"854\" y1=\"396\" x2=\"992\" y2=\"396\" id=\"svg_905b673a-0be4-4f46-b4b1-b0d88996605c\" stroke=\"#007fff\"/>\n  <line fill=\"none\" stroke-width=\"4\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x1=\"638\" y1=\"396\" x2=\"776\" y2=\"396\" stroke=\"#ff0000\" id=\"svg_8b4bbf19-b973-46ef-8c2d-2236c8aa4a9e\"/>\n  <g id=\"EHS_1f1017b6-1d58-490b-a1de-734441a5d766\" type=\"svg-ext-exchanger\" fill=\"#ffffff\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" stroke=\"#000000\">\n   <path stroke-width=\"null\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"tEHS_9ba82cc1-e486-4f7d-a079-a1fb5b432035\" d=\"M781.04,363.05L781.04,401.05M854.96,363.05L854.96,401.05M781.04,367.8L854.96,367.8M781.04,372.55L854.96,372.55M781.04,377.3L854.96,377.3M781.04,382.05L854.96,382.05M781.04,386.8L854.96,386.8M781.04,391.55L854.96,391.55M781.04,396.3L854.96,396.3M774,363.05L862,363.05L862,401.05L774,401.05L774,363.05z\" stroke=\"#000000\"/>\n  </g>\n  <g id=\"VAL_8d3be0b8-84fb-485b-80fb-b18f99d62dd2\" type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"16\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"VAL_36a9767c-9ca0-4800-96a7-efde29eecbd5\" fill=\"#000000\" stroke=\"#000000\" font-size=\"16\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"692\" y=\"420\">##.##</text>\n  </g>\n  <g id=\"VAL_457d654f-c426-4dca-afe3-a0d9bb1990b0\" type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"16\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"VAL_ebe22248-63f7-400e-8b51-51ed62a448ba\" fill=\"#000000\" stroke=\"#000000\" font-size=\"16\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"936\" y=\"420\">##.##</text>\n  </g>\n  <g type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"16\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\" id=\"VAL_839bf3d7-32c4-4716-bd65-ce931acb254d\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" fill=\"#000000\" stroke=\"#000000\" font-size=\"16\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"724.45313\" y=\"616.5\" id=\"VAL_96c87cdd-058d-45b2-95b9-69d4050d5355\">##.##</text>\n  </g>\n  <g type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"16\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\" id=\"VAL_36eb85fa-5da4-4245-bf43-435044dfc1aa\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" fill=\"#000000\" stroke=\"#000000\" font-size=\"16\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"912.45313\" y=\"616.5\" id=\"VAL_2a066fbc-0ca2-41d3-8d5c-e1523e2ec1a9\">##.##</text>\n  </g>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"296\" y=\"232\" id=\"svg_fff4455c-597a-4ef3-be29-95961aac95c4\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">TW1</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"440\" y=\"232\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_812f584e-8f42-4f43-a458-691e1036680f\">TK1</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"342\" y=\"460\" id=\"svg_d3b44fb3-86be-4d03-8429-ba72f5a10e76\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">TA1</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"440\" y=\"480\" id=\"svg_ec8ff098-5bdc-47f5-b08f-57315a0550ae\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">Valve 1</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"440\" y=\"680\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_efa0786a-fe2b-43b3-9999-0868205b54e1\">Valve 3</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"440\" y=\"578\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_7ee9d385-b6f6-40e0-96ef-ba0af73e62aa\">Valve 2</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"550\" y=\"466\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_460af7cd-fef1-47b4-91ad-7c8eee2260ca\">Pump 1</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"550\" y=\"562\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_8921a908-6261-485a-b078-a8010ffa7efa\">Pump 2</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"550\" y=\"664\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_a3e2b3cc-842c-4cb6-ae64-3399278b951e\">Pump 3</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" x=\"758\" y=\"288\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_0de17ca7-e7ba-4f84-8fd2-978430a793c3\">Compressor</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"580\" y=\"118\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_e94343fa-f8b2-44d2-a31b-95ff10d30462\">Pump W</text>\n  <text id=\"svg_46faa1bd-49e4-454e-b5c0-302195a3e6f2\" fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"848\" y=\"454\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">TC1</text>\n  <text id=\"svg_1a339dd5-4b8c-49c0-89b2-3fd6874e8962\" xml:space=\"preserve\" text-anchor=\"start\" font-family=\"sans-serif\" font-size=\"26\" y=\"28\" x=\"4\" stroke-width=\"0\" stroke=\"#000000\" fill=\"#000000\">My SCADA</text>\n </g>\n</svg>"
+      },
+      {
+        "id": "v_1571824949373",
+        "name": "PlantView",
+        "profile": {
+          "width": 1200,
+          "height": 900,
+          "bkcolor": "#ffffffff"
+        },
+        "items": {
+          "VAL_c1427a6f-5d90-428d-9e9b-f601545f8cc1": {
+            "id": "VAL_c1427a6f-5d90-428d-9e9b-f601545f8cc1",
+            "type": "svg-ext-value",
+            "name": "R1",
+            "property": {
+              "events": [],
+              "variable": "Real 1",
+              "variableId": "SPS^~^Real 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " \u00b0C"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_d435cec7-5632-466c-869f-26a76dd82799": {
+            "id": "VAL_d435cec7-5632-466c-869f-26a76dd82799",
+            "type": "svg-ext-value",
+            "name": "B1",
+            "property": {
+              "events": [],
+              "variable": "Byte 1",
+              "variableId": "SPS^~^Byte 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " \u00b0C"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_90c24434-9cc4-40b2-94b5-bd53c2f43d67": {
+            "id": "VAL_90c24434-9cc4-40b2-94b5-bd53c2f43d67",
+            "type": "svg-ext-value",
+            "name": "B2",
+            "property": {
+              "events": [],
+              "variable": "Byte 2",
+              "variableId": "SPS^~^Byte 2",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " \u00b0C"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_ccbf65e9-abfc-4ca5-b5cb-701bc897c27c": {
+            "id": "VAL_ccbf65e9-abfc-4ca5-b5cb-701bc897c27c",
+            "type": "svg-ext-value",
+            "name": "B2",
+            "property": {
+              "events": [],
+              "variable": "Byte 2",
+              "variableId": "SPS^~^Byte 2",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " \u00b0C"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_0fe1a6c5-f1e7-4c1c-8b68-481015b3b2a7": {
+            "id": "VAL_0fe1a6c5-f1e7-4c1c-8b68-481015b3b2a7",
+            "type": "svg-ext-value",
+            "name": "B3",
+            "property": {
+              "events": [],
+              "variable": "Byte 3",
+              "variableId": "SPS^~^Byte 3",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " \u00b0C"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_63903efb-5136-436b-849a-eb928cbac8ff": {
+            "id": "VAL_63903efb-5136-436b-849a-eb928cbac8ff",
+            "type": "svg-ext-value",
+            "name": "B4",
+            "property": {
+              "events": [],
+              "variable": "Byte 4",
+              "variableId": "SPS^~^Byte 4",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " \u00b0C"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_f55fdb69-ed16-46a1-bf5c-2546ad659342": {
+            "id": "VAL_f55fdb69-ed16-46a1-bf5c-2546ad659342",
+            "type": "svg-ext-value",
+            "name": "R1",
+            "property": {
+              "events": [],
+              "variable": "Real 1",
+              "variableId": "SPS^~^Real 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " \u00b0C"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_21286674-cfd3-443e-9735-3bdded4a2e44": {
+            "id": "VAL_21286674-cfd3-443e-9735-3bdded4a2e44",
+            "type": "svg-ext-value",
+            "name": "W1",
+            "property": {
+              "events": [],
+              "variable": "Word 1",
+              "variableId": "SPS^~^Word 1",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " \u00b0C"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_186d7954-4944-447f-a7d7-37eca04cca55": {
+            "id": "VAL_186d7954-4944-447f-a7d7-37eca04cca55",
+            "type": "svg-ext-value",
+            "name": "I2",
+            "property": {
+              "events": [],
+              "variable": "Int 2",
+              "variableId": "SPS^~^Int 2",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80,
+                  "text": " A"
+                }
+              ]
+            },
+            "label": "Value"
+          },
+          "VAL_ef810f84-0616-48bc-b0f3-79df0f8caeb9": {
+            "id": "VAL_ef810f84-0616-48bc-b0f3-79df0f8caeb9",
+            "type": "svg-ext-value",
+            "name": "B5",
+            "property": {
+              "events": [],
+              "variable": "Byte 5",
+              "variableId": "SPS^~^Byte 5",
+              "variableSrc": "SPS",
+              "alarmId": "",
+              "alarmSrc": "",
+              "alarm": "",
+              "alarmColor": "",
+              "ranges": [
+                {
+                  "type": "unit",
+                  "min": 20,
+                  "max": 80
+                }
+              ]
+            },
+            "label": "Value"
+          }
+        },
+        "variables": {},
+        "svgcontent": "<svg width=\"1200\" height=\"900\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:svg=\"http://www.w3.org/2000/svg\">\n <g>\n  <title>Layer 1</title>\n  <g id=\"svg_751531d2-33a7-4ee1-a37f-8e94b18540ed\">\n   <metadata id=\"svg_7dc2ac0e-88fe-4ffd-8367-b302459d3322\">image/svg+xml</metadata>\n   <g id=\"svg_31965668-4537-4153-bb49-d8622b720807\" display=\"none\">\n    <g transform=\"matrix(0,1,-1,0,558.84174,417.27997) \" id=\"svg_54611790-c583-48c5-83cd-3d9e219ba3df\" display=\"inline\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M75.46003,-141.65826L83.92878,-141.65826L86.49128,-144.22076L84.02253,-150.22076L75.46003,-141.65826z\" id=\"svg_42eba66b-d08d-4a87-a9ed-5f2ddc118827\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M86.49128,-144.22076C98.92878,-144.22076 127.47701,-144.22076 127.47701,-144.22076L129.94576,-150.22076L84.02253,-150.22076L86.49128,-144.22076z\" id=\"svg_ef074c25-8f2b-4f8b-8ac8-c76689e8dd5f\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M127.46273,-144.22076L130.02523,-141.65826L138.49398,-141.65826L129.93148,-150.22076L127.46273,-144.22076z\" id=\"svg_6e5824ec-a304-4711-b7e5-f0d1853e20e7\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <path d=\"M482.15625,526.20593L498.05396,547.66143\" id=\"svg_a97cc680-eebe-4508-8353-569165f2819a\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M482.15625,526.20593L492.35439,551.80789\" id=\"svg_76f407f9-a425-4c84-be53-953a3210d4d7\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M294.25,693.46875L294.25,700.375L247.375,700.375L241.375,700.375L241.375,706.375L241.375,740L253.375,740L253.375,712.375L298.8125,712.375L298.8125,705.53125L306.125,705.53125L306.125,712.375L308.53125,712.375L308.53125,736.34375L314.53125,736.34375L314.53125,712.375L359.3125,712.375C374.64928,710.44961 396.0625,707.61304 396.0625,703.15625C376.01183,708.52881 360.09375,706 346.21875,700.375L311.09375,700.375L311.09375,693.46875L294.25,693.46875zM270.5625,700.9375L294.25,700.9375L294.25,711.8125L270.5625,711.8125L270.5625,700.9375zM321.65625,700.9375L339.5625,700.9375L339.5625,711.8125L321.65625,711.8125L321.65625,700.9375zM384.0625,723.25L384.0625,730.03125L396.0625,730.03125L396.0625,723.25L384.0625,723.25zM384.0625,730.03125L384.0625,750.25L376.75,750.25L376.75,756.25L384.0625,756.25L384.0625,839.40625L314.53125,839.40625L314.53125,817.875L317.53125,817.875L317.53125,804.75L314.53125,804.75L314.53125,790.09375L317.53125,790.09375L317.53125,776.96875L314.53125,776.96875L314.53125,756.25L359.75,756.25L359.75,750.25L314.53125,750.25L314.53125,747.09375L308.53125,747.09375L308.53125,750.25L300.25,750.25L300.25,756.25L308.53125,756.25L308.53125,776.96875L305.53125,776.96875L305.53125,790.09375L308.53125,790.09375L308.53125,804.75L305.53125,804.75L305.53125,817.875L308.53125,817.875L308.53125,839.40625L253.375,839.40625L253.375,793.125L241.375,793.125L241.375,845.40625L241.375,851.40625L247.375,851.40625L390.0625,851.40625L396.0625,851.40625L396.0625,845.40625L396.0625,778.875L384.0625,730.03125zM316.28125,839.9375L336.5,839.9375L336.5,850.8125L316.28125,850.8125L316.28125,839.9375zM355.71875,839.9375L375.875,839.9375L375.875,850.8125L355.71875,850.8125L355.71875,839.9375zM277.84375,845.46875L297.09375,845.46875L297.09375,850.8125L277.84375,850.8125L277.84375,845.46875z\" id=\"svg_776d9ce2-f13c-4683-b259-24f93adff930\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#b2b2b2\"/>\n    <g id=\"svg_5531f71c-3d7d-4daa-ac47-455019089504\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M294.5,39.65625L285.90625,48.25L294.34375,48.25L296.96875,45.65625L294.5,39.65625z\" id=\"svg_d568ebcc-2d1b-4e16-ae5d-144943a3d735\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M296.98397,45.64271C309.42147,45.64271 338.89309,45.64271 338.89309,45.64271L341.36184,39.64271L294.51522,39.64271L296.98397,45.64271z\" id=\"svg_0278bc91-d6c3-4ae4-8b4a-30e68066b05c\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M341.375,39.65625L338.90625,45.65625L341.5,48.25L349.96875,48.25L341.375,39.65625z\" id=\"svg_21e0ff0e-1a2b-4878-b131-b9f2a7d4c6f0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <path d=\"M311.03125,146L311.03125,173.03125L311.03125,177.53125L315.53125,177.53125L350.84375,177.53125L355.34375,177.53125L355.34375,158.03125L354.75,158.03125L354.75,165.0625L346.9375,165.0625L346.9375,158.03125L346.375,158.03125L346.375,168.53125L320.03125,168.53125L320.03125,146L311.03125,146z\" id=\"svg_b9ada4b5-daa7-41a9-8eb6-cf3ee4192ab4\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#b2b2b2\"/>\n    <path d=\"M592.46875,83.625L592.46875,146.03125L516.5,146.03125L516.5,158.03125L574.46875,158.03125L574.46875,160.71875L660.0625,160.71875L660.0625,158.03125L660.0625,148.71875L660.0625,146.03125L598.46875,146.03125L598.46875,83.625L592.46875,83.625z\" id=\"svg_37d3cdea-b2fe-4759-9853-d066deb4dd21\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M258.53125,127.125L258.53125,152.01875L258.53125,158.01875L264.53125,158.01875L295.34375,158.01875L295.34375,166.9875L319.52704,166.9875L311.01318,154.9875L300.4375,154.9875L300.4375,146.01875L270.53125,146.01875L270.53125,127.125L258.53125,127.125z\" id=\"svg_9f1ca180-cfdf-44f2-bf4f-4744f08abb2e\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M258.53125,48.25L258.53125,54.25L258.53125,84.78125L270.53125,84.78125L270.53125,60.25L294.34375,60.25L294.34375,48.25L264.53125,48.25L258.53125,48.25z\" id=\"svg_a05449d5-58e0-41dc-bac6-b18456655246\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M415,60.25L481.30625,60.25L481.30625,54.0625L493.1875,54.0625L493.1875,48.0625L483.03125,48.0625L483.03125,40.78125L495.28125,28.5L501.3125,28.5L501.3125,24.59375L527.5625,24.59375L527.5625,28.5L533.5625,28.5L545.8125,40.78125L545.8125,48.0625L535.65625,48.0625L535.65625,54.0625L546.15625,54.0625L546.15625,60.25L592.46875,60.25L592.46875,66.3125L598.46875,66.3125L598.46875,60.25L688.5,60.25L688.5,64.34375L700.5,64.34375L700.5,60.25L707.21875,60.25L707.21875,48.25L551.8125,48.25L551.8125,39.53125L551.8125,38.28125L550.9375,37.40625L536.90625,23.40625L536.03125,22.5L534.78125,22.5L514.40625,22.5L494.03125,22.5L492.78125,22.5L491.90625,23.40625L477.90625,37.40625L477.03125,38.28125L477.03125,39.53125L477.03125,48.25L341.5,48.25L341.5,60.25L386.75,60.25L386.75,128.34375L322.75,128.34375L322.75,39.65625L318.75,39.65625L318.75,130.34375L318.75,132.34375L320.75,132.34375L413,132.34375L415,132.34375L415,130.34375L415,60.25L415,59.6875L415,52.52053L411,52.52053L411,59.6875L411,60.25L411,128.34375L390.75,128.34375L390.75,60.25L411,60.25L411,59.6875L401.5625,59.6875L401.5625,48.8125L442.5,48.8125L442.5,59.6875L415,59.6875L415,60.25zM561.1875,48.8125L586.625,48.8125L586.625,59.6875L561.1875,59.6875L561.1875,48.8125zM618.625,48.8125L659.5625,48.8125L659.5625,59.6875L618.625,59.6875L618.625,48.8125z\" id=\"svg_2b62a034-4a0e-4612-84a9-1e599af96a7b\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M751.5,48.25L751.5,60.25L792.28125,60.25L792.28125,82.28125L804.28125,82.28125L806.875,84.84375L806.875,104.84375L700.5,104.84375L700.5,83.59375L688.5,83.59375L688.5,124.5L700.5,124.5L700.5,108.84375L806.875,108.84375L810,108.84375L812.875,108.84375L812.875,82.375L804.28125,73.78125L804.28125,54.25L804.28125,48.25L798.28125,48.25L751.5,48.25z\" id=\"svg_c0ed563c-73a5-4b08-99f9-6acd80bd4846\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M792.28125,131.21875L792.28125,148.71875L781.09375,148.71875L781.09375,158.59375L754.59375,158.59375L754.59375,148.71875L737,148.71875L737,158.59375L710.5,158.59375L710.5,148.71875L700.5,148.71875L700.5,143.71875L688.5,143.71875L688.5,148.71875L678.28125,148.71875L678.28125,160.71875L688.5,160.71875L688.5,176.21875L700.5,176.21875L700.5,160.71875L798.28125,160.71875L804.28125,160.71875L804.28125,154.71875L804.28125,131.21875L792.28125,131.21875z\" id=\"svg_5c1ed7a5-89db-4fdd-b8a2-939694103f38\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M432.28125,140.875L432.28125,146.03125L412.75,146.03125L412.75,154.84375L412.75,158.03125L412.75,171.8125L412.75,176.84375L412.75,180.8125L466.28125,180.8125L466.28125,191.21875L475.28125,191.21875L475.28125,180.8125L485.125,180.8125L485.125,171.8125L416.75,171.8125L416.75,158.03125L488.375,158.03125L488.375,146.03125L462.875,146.03125L462.875,140.875L454.15625,140.875L454.15625,146.03125L444.28125,146.03125L444.28125,140.875L432.28125,140.875z\" id=\"svg_a0d44823-8134-4c78-ac08-3a60dec00ebd\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M688.5,218L688.5,225.90625L678.25,225.90625L678.25,231.90625L688.5,231.90625L688.5,327.6875L678.25,327.6875L678.25,333.6875L688.5,333.6875L688.5,334.9375L688.5,337.65625L688.5,381.40625L688.5,385.84375L688.5,498.84375L688.5,501.21875L688.5,547.28125L688.5,549.75L688.5,625.125L678.28125,625.125L678.28125,637.125L688.5,637.125L688.5,655.90625L688.5,659.78125L688.5,708.53125L688.5,710.34375L688.5,735.125L709.28125,744.375L711.875,744.375L711.875,740.25L716.8125,740.25L716.8125,730.3125L739.96875,730.3125L739.96875,740.25L754.625,740.25L754.625,730.3125L781.75,730.3125L781.75,740.25L792.28125,740.25L792.28125,766.84375L786.3125,766.84375L786.3125,772.84375L792.28125,772.84375L796.1875,772.84375L804.28125,772.84375L806.84375,775.40625L806.84375,790.46875L780.1875,790.46875L780.1875,799.46875L806.84375,799.46875L806.84375,811L804.28125,813.53125L798.8125,813.53125L792.28125,820.0625L792.28125,839.5L768.34375,839.5L768.34375,818.3125L759.34375,818.3125L759.34375,839.5L751.875,839.5L751.875,834.03125L742.875,834.03125L742.875,839.5L735.875,839.5L735.875,834.03125L726.875,834.03125L726.875,839.5L700.5,839.5L700.5,799.46875L704.1875,799.46875L759.34375,799.46875L759.34375,804L768.34375,804L768.34375,794.96875L768.34375,790.46875L763.84375,790.46875L708.6875,790.46875L708.6875,771.125L688.5,762.1875L688.5,765.15625L688.5,770.84375L688.5,845.5L688.5,851.5L694.5,851.5L798.28125,851.5L804.28125,851.5L804.28125,845.5L804.28125,822.03125L811.96875,814.34375L812.84375,813.46875L812.84375,812.21875L812.84375,792.65625L812.84375,774.1875L812.84375,772.96875L811.96875,772.0625L804.28125,764.375L804.28125,734.25L804.28125,728.25L798.28125,728.25L700.5,728.25L700.5,708.53125L690.625,708.53125L690.625,659.78125L700.5,659.78125L700.5,547.28125L690.625,547.28125L690.625,501.21875L700.5,501.21875L700.5,381.40625L690.625,381.40625L690.625,337.65625L700.5,337.65625L700.5,218L688.5,218zM689.09375,242.9375L699.96875,242.9375L699.96875,264.6875L689.09375,264.6875L689.09375,242.9375zM689.09375,297.75L699.96875,297.75L699.96875,315.0625L689.09375,315.0625L689.09375,297.75zM689.09375,406.96875L699.96875,406.96875L699.96875,428.6875L689.09375,428.6875L689.09375,406.96875zM689.09375,453.53125L699.96875,453.53125L699.96875,475.28125L689.09375,475.28125L689.09375,453.53125zM512.90625,517.21875L512.90625,535.40625L500.15625,545.59375L482.15625,545.59375L482.15625,545.62495L482.15625,547.7187L482.15625,559.99995L482.15625,569.6562L482.15625,601.24995L494.15625,601.24995L494.15625,561.93745L520.21875,541.0937L521.90625,539.74995L521.90625,537.5937L521.90625,517.2187L512.90625,517.2187L512.90625,517.21875zM484.28125,547.71875L497.5,547.71875L484.28125,558.3125L484.28125,547.71875zM689.09375,567.0625L699.96875,567.0625L699.96875,584.34375L689.09375,584.34375L689.09375,567.0625zM689.09375,601L698.34375,601L698.34375,618.5L689.09375,618.5L689.09375,601zM574.46875,612.4375L574.46875,617.6875L571.5,617.6875L565.5,617.6875L565.5,623.6875L565.5,625.125L494.15625,625.125L494.15625,621.9375L482.15625,621.9375L482.15625,631.125L482.15625,637.125L488.15625,637.125L503.1875,637.125L503.1875,645.78125L515.1875,645.78125L515.1875,637.125L570.40625,637.125L570.40625,643.125L579.40625,643.125L579.40625,629.6875L608.4375,629.6875L608.4375,643.125L617.4375,643.125L617.4375,637.125L618.46875,637.125L652.4375,637.125L652.4375,730.21875L650.4375,730.21875L570.40625,730.21875L570.40625,742.21875L644.4375,742.21875L644.4375,777.53125L570.40625,777.53125L570.40625,789.53125L594.15625,789.53125L594.15625,822.40625L596.25,822.40625L596.25,789.53125L650.4375,789.53125L656.4375,789.53125L656.4375,783.53125L656.4375,739.59375L656.4375,736.21875L656.4375,730.21875L656.4375,637.125L659.5,637.125L659.5,625.125L620.96875,625.125L615.28125,619.4375L613.5,617.6875L611.03125,617.6875L586.46875,617.6875L586.46875,612.4375L574.46875,612.4375zM597.65625,778.0625L625.34375,778.0625L625.34375,788.9375L597.65625,788.9375L597.65625,778.0625zM689.0625,804.46875L699.9375,804.46875L699.9375,815.28125L689.0625,815.28125L689.0625,804.46875zM712.125,840.0625L726.875,840.0625L726.875,850.9375L712.125,850.9375L712.125,840.0625zM773.03125,840.0625L785.9375,840.0625L785.9375,850.9375L773.03125,850.9375L773.03125,840.0625zM744.75,845.5625L756.34375,845.5625L756.34375,850.9375L744.75,850.9375L744.75,845.5625z\" id=\"svg_4e83a15c-f2a3-4e04-a0d6-0596529a0b19\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#595959\"/>\n    <path d=\"M503.1875,726.03125L503.1875,730.21875L456.84375,730.21875L450.84375,730.21875L450.84375,736.21875L450.84375,783.53125L450.84375,789.53125L456.84375,789.53125L509.90625,789.53125L509.90625,822.40625L512.03125,822.40625L512.03125,789.53125L543.15625,789.53125L543.15625,777.53125L462.84375,777.53125L462.84375,742.21875L543.15625,742.21875L543.15625,730.21875L515.1875,730.21875L515.1875,726.03125L503.1875,726.03125zM472.03125,730.75L497.40625,730.75L497.40625,741.625L472.03125,741.625L472.03125,730.75zM480.65625,778.0625L508.34375,778.0625L508.34375,788.9375L480.65625,788.9375L480.65625,778.0625z\" id=\"svg_d5efcec0-238a-4dbb-950e-72c9a0a653b6\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#595959\"/>\n    <path d=\"M346.375,146.03125L346.375,158.03125L384.0625,158.03125L384.0625,171.8125L375.28125,171.8125L375.28125,183.8125L384.0625,183.8125L384.0625,195.8125L375.28125,195.8125L375.28125,207.8125L384.0625,207.8125L384.0625,601.125L352.21875,601.125L346.21875,601.125L346.21875,607.125L346.21875,700.375C360.09375,706 376.01183,708.52881 396.0625,703.15625L462.84375,703.15625L462.84375,700.15625L462.84375,668.75L450.84375,668.75L450.84375,684.21875L450.84375,694.15625L450.84375,697.125L396.0625,697.125L396.0625,694.15625L396.0625,684.21875L396.0625,668.75L384.0625,668.75L384.0625,685.71875L384.0625,694.15625L384.0625,698.625L358.21875,698.625L358.21875,694.15625L358.21875,685.71875L358.21875,613.125L384.0625,613.125L384.0625,648.59375L396.0625,648.59375L396.0625,637.12371L401.4375,637.12371L401.4375,625.12371L396.0625,625.12371L396.0625,617.5625L401.1875,617.5625L401.1875,611.5625L396.0625,611.5625L396.0625,602.9375L401.1875,602.9375L401.1875,596.9375L396.0625,596.9375L396.0625,566.25L444.09375,566.25L444.09375,579.3125L448.09375,579.3125L448.09375,566.25L448.09375,563.9375L448.09375,557.25L396.0625,557.25L396.0625,526.21875L401.625,526.21875L401.625,522.21875L396.0625,522.21875L396.0625,446.1875L405.875,446.1875L405.875,440.1875L396.0625,440.1875L396.0625,362.40625L429.1875,362.40625L429.1875,356.40625L396.0625,356.40625L396.0625,328.625L446.25,328.625L449.25,328.625L449.25,325.625L449.25,308.3125L443.25,308.3125L443.25,322.625L396.0625,322.625L396.0625,298.9375L446.25,298.9375L449.25,298.9375L449.25,295.9375L449.25,238.5L449.25,235.5L446.25,235.5L396.0625,235.5L396.0625,232L386.1875,232L386.1875,215.25L396.0625,215.25L396.0625,158.03125L399.46875,158.03125L399.46875,146.03125L396.0625,146.03125L390.0625,146.03125L387.8125,146.03125L346.375,146.03125zM358.5625,146.5625L378.3125,146.5625L378.3125,157.4375L358.5625,157.4375L358.5625,146.5625zM384.625,183.8125L395.5,183.8125L395.5,195.8125L384.625,195.8125L384.625,183.8125zM396.0625,241.5L443.25,241.5L443.25,292.9375L396.0625,292.9375L396.0625,241.5zM384.625,266.875L395.5,266.875L395.5,284.125L384.625,284.125L384.625,266.875zM384.625,302L395.5,302L395.5,318.125L384.625,318.125L384.625,302zM384.625,334.25L395.5,334.25L395.5,351.5L384.625,351.5L384.625,334.25zM384.625,375.5L395.5,375.5L395.5,392.75L384.625,392.75L384.625,375.5zM384.625,417L395.5,417L395.5,432.5L384.625,432.5L384.625,417zM384.625,451.125L395.5,451.125L395.5,464.125L384.625,464.125L384.625,451.125zM384.625,492.1875L395.5,492.1875L395.5,509.40625L384.625,509.40625L384.625,492.1875zM384.625,568.125L395.5,568.125L395.5,581.125L384.625,581.125L384.625,568.125zM444.09375,593.28125L444.09375,625.12371L411.53125,625.12371L411.53125,637.12371L450.84375,637.12371L450.84375,648.59375L462.84375,648.59375L462.84375,631.12371L462.84375,625.12371L456.84375,625.12371L448.09375,625.12371L448.09375,593.28125L444.09375,593.28125zM359.5,601.6875L376.71875,601.6875L376.71875,612.5625L359.5,612.5625L359.5,601.6875zM427.40625,640.625L438.28125,640.625L438.28125,659.65625L427.40625,659.65625L427.40625,640.625z\" id=\"svg_ee31bb4a-17b8-464b-b899-7e722ee08119\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#595959\"/>\n    <path d=\"M598.46875,114.28125L598.46875,145.96875L620.65625,145.96875L598.46875,114.28125zM605.59375,127.0625L614.3125,139.40625L611.125,141.625L602.40625,129.28125L605.59375,127.0625z\" id=\"svg_418869aa-a33b-4a51-81a9-3b56f2f5586f\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M466.28125,208.1875L466.28125,289.09375L466.28125,290.28125L466.875,291.34375L472.9375,301.8125L472.9375,356.40625L449.34375,356.40625L449.34375,362.40625L472.9375,362.40625L472.9375,440.1875L424.25,440.1875L424.25,446.1875L472.9375,446.1875L472.9375,522.21875L415.9375,522.21875L415.9375,526.21875L472.9375,526.21875L476.75,526.21875L481.9375,526.21875L481.9375,300.59375L481.9375,299.40625L481.34375,298.34375L475.28125,287.875L475.28125,208.1875L466.28125,208.1875z\" id=\"svg_f7dea9ae-9c4d-4615-8809-da25f41b7e90\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M537.34375,180.21875L537.34375,217.40625L521.8125,217.40625L517.3125,217.40625L512.8125,217.40625L512.8125,236.21875L521.8125,236.21875L521.8125,226.40625L541.84375,226.40625L546.34375,226.40625L546.34375,221.90625L546.34375,205.71875L574.46875,205.71875L574.46875,260.21875L569.09375,260.21875L563.09375,260.21875L563.09375,266.21875L563.09375,295L563.09375,301L569.09375,301L574.46875,301L574.46875,403.15625L569.09375,403.15625L563.09375,403.15625L563.09375,409.15625L563.09375,442.5L563.09375,448.5L569.09375,448.5L574.46875,448.5L574.46875,482.9375L517.3125,482.9375L512.8125,482.9375L512.8125,487.4375L512.8125,499.5625L521.8125,499.5625L521.8125,491.9375L574.46875,491.9375L574.46875,591.75L586.46875,591.75L586.46875,527.59375L659.5,527.59375L659.5,521.65625L586.46875,521.65625L586.46875,442.5L586.46875,436.5L580.46875,436.5L575.09375,436.5L575.09375,415.15625L580.46875,415.15625L586.46875,415.15625L586.46875,409.15625L586.46875,333.6875L659.5,333.6875L659.5,327.6875L586.46875,327.6875L586.46875,295L586.46875,289L580.46875,289L575.09375,289L575.09375,272.21875L580.46875,272.21875L586.46875,272.21875L586.46875,266.21875L586.46875,231.90625L659.5,231.90625L659.5,225.90625L586.46875,225.90625L586.46875,204.34375L583.5,204.34375L583.5,201.21875L583.5,180.21875L574.5,180.21875L574.5,196.71875L546.34375,196.71875L546.34375,180.21875L537.34375,180.21875zM523.21875,218L535.5625,218L535.5625,225.78125L523.21875,225.78125L523.21875,218zM542.71875,447.21875L551.59375,447.21875L551.59375,453.5625L542.71875,453.5625L542.71875,447.21875zM552.5625,447.21875L563.375,447.21875L563.375,453.5625L552.5625,453.5625L552.5625,447.21875zM569.375,447.21875L579.4375,447.21875L579.4375,453.5625L569.375,453.5625L569.375,447.21875zM580.34375,447.21875L588.59375,447.21875L588.59375,453.5625L580.34375,453.5625L580.34375,447.21875zM692.40625,483.875L692.40625,489.8125L723.1875,489.8125L723.1875,483.875L692.40625,483.875z\" id=\"svg_d7a532b5-02a9-4b0a-af47-16ae2cc3ef90\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#595959\"/>\n    <path d=\"M503.1875,671.59375L503.1875,697.75L515.1875,697.75L515.1875,671.59375L503.1875,671.59375z\" id=\"svg_575e8e5f-2819-4c83-bf23-ef1e80fa61e9\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#595959\"/>\n    <path d=\"M255.875,124.5L249.875,126.96875L258.53125,135.625L258.53125,127.15625L258.53125,127.12505L255.875,124.50005L255.875,124.5z\" id=\"svg_83a450af-9ebf-4b2d-907a-50a002c22418\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    <path d=\"M255.875,124.5C255.875,112.0625 255.875,87.4375 255.875,87.4375L249.875,84.96875L249.875,126.96875L255.875,124.5z\" id=\"svg_27bbbfc9-2bbc-4c92-b10e-f34f27890970\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    <path d=\"M258.53125,76.3125L249.875,84.96875L255.875,87.4375L258.53125,84.78125L258.53125,76.3125z\" id=\"svg_0a5124dd-804c-45cc-adb7-e7cf8db45777\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    <path d=\"M521.90625,539.75L520.21875,541.09375L512.90625,546.9375L512.90625,569.34375L494.15625,569.34375L494.15625,575.34375L512.90625,575.34375L517.3125,575.34375L521.90625,575.34375L521.90625,539.75z\" id=\"svg_e9cc1c35-d10a-4372-ada7-4666b5103b0b\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#b2b2b2\"/>\n    <g transform=\"matrix(0,1,1,0,-809.5162,148.90351) \" id=\"svg_bda1ac48-6f35-4f16-930c-79a970d1813f\" stroke-linejoin=\"round\" stroke-linecap=\"round\"/>\n    <path d=\"M481.3125,54.0625L481.3125,60.25L478.90625,60.25L478.90625,146.03125L484.90625,146.03125L484.90625,54.0625L481.3125,54.0625z\" id=\"svg_7c594804-e10f-4ec9-bfd9-a7883532bffd\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#b2b2b2\"/>\n    <path d=\"M544.8125,54.0625L524.90625,80.21875L524.28125,81.03125L524.28125,82.03125L524.28125,146.03125L530.28125,146.03125L530.28125,83.0625L547.625,60.25L546.15625,60.25L546.15625,54.0625L544.8125,54.0625z\" id=\"svg_d750275e-10b2-4692-8637-00a01a3397b2\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#b2b2b2\"/>\n    <path d=\"M512.8125,251.125L512.8125,482.9375L517.3125,482.9375L521.8125,482.9375L521.8125,251.125L512.8125,251.125zM513.40625,264.28125L521.21875,264.28125L521.21875,277.96875L513.40625,277.96875L513.40625,264.28125zM513.40625,325.5L521.21875,325.5L521.21875,339.1875L513.40625,339.1875L513.40625,325.5zM513.40625,386.6875L521.21875,386.6875L521.21875,400.375L513.40625,400.375L513.40625,386.6875zM513.40625,449.6875L521.21875,449.6875L521.21875,465.25L513.40625,465.25L513.40625,449.6875z\" id=\"svg_886a4f88-f14a-4ba7-a467-f50a8d15fed0\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#b2b2b2\"/>\n    <path d=\"M549.25,491.9375L549.25,558.09375L555.25,558.09375L555.25,491.9375L549.25,491.9375z\" id=\"svg_2c4e73c7-58ab-4ce7-935f-10dde7797e3f\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#b2b2b2\"/>\n    <path d=\"M549.25,569.84375L549.25,579.3125L549.25,582.3125L552.25,582.3125L574.46875,582.3125L574.46875,576.3125L555.25,576.3125L555.25,569.84375L549.25,569.84375z\" id=\"svg_7c6b620c-d976-42f3-983f-f7374708c1db\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#b2b2b2\"/>\n    <path d=\"M806.875,108.83661L806.875,128.67188L812.875,131.14063L812.87498,108.8367L806.875,108.83661z\" id=\"svg_d06f6552-df3c-4879-8789-31a634d1d0b7\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M806.875,128.65625L804.28125,131.21875L804.28125,131.24995L804.28125,139.7187L812.875,131.12495L806.875,128.6562L806.875,128.65625z\" id=\"svg_cacc15a0-e908-40e9-99d7-2dfbf6d3e907\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    <g id=\"svg_277e022b-989d-4fec-a5a7-831a6facabfd\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M707.40625,39.625L698.78125,48.25L707.21875,48.25L709.875,45.625L707.40625,39.625z\" id=\"svg_4c13cb9a-9bd2-49f9-abaa-3ea389bdd90b\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M709.88348,45.625C722.32098,45.625 748.8634,45.625 748.8634,45.625L751.33215,39.625L707.41473,39.625L709.88348,45.625z\" id=\"svg_4eee4ec8-f90d-44a9-9c89-5bce1d12ca1e\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M751.34375,39.625L748.875,45.625L751.5,48.25L759.96875,48.25L751.34375,39.625z\" id=\"svg_53e10296-253f-45a5-8ec8-0a0ac7a3c792\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <g transform=\"matrix(0,1,-1,0,558.84174,92.32122) \" id=\"svg_c2a51499-daf2-4d28-b55d-2326c048cc39\" display=\"inline\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M75.46003,-141.65826L83.89753,-141.65826L86.49128,-144.22076L84.02253,-150.22076L75.46003,-141.65826z\" id=\"svg_339f7a85-638e-40d8-84ac-1294bebc6e0a\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M86.49128,-144.22076C98.92878,-144.22076 123.15378,-144.22076 123.15378,-144.22076L125.62253,-150.22076L84.02253,-150.22076L86.49128,-144.22076z\" id=\"svg_0b8b29bb-201b-4c9f-a065-256e62be51d8\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M123.14753,-144.22076L125.67878,-141.65826L125.70998,-141.65826L134.17873,-141.65826L125.61623,-150.22076L123.14748,-144.22076L123.14753,-144.22076z\" id=\"svg_de5baf5b-6799-4b8b-84de-fd386658fea0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <g transform=\"matrix(0,1,-1,0,558.84174,253.72747) \" id=\"svg_01035e50-f2de-4a0d-b2dd-ae3d75207054\" display=\"inline\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M75.46003,-141.65826L83.92878,-141.65826L86.49128,-144.22076L84.02253,-150.22076L75.46003,-141.65826z\" id=\"svg_476328fb-d19e-4cae-ac4c-37bda91907e1\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M86.49128,-144.22076C98.92878,-144.22076 125.13056,-144.22076 125.13056,-144.22076L127.59931,-150.22076L84.02253,-150.22076L86.49128,-144.22076z\" id=\"svg_8e0f6088-bfcc-4816-9ddd-831d048484e6\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M125.11628,-144.22076L127.67878,-141.65826L136.14753,-141.65826L127.58503,-150.22076L125.11628,-144.22076z\" id=\"svg_2e077de1-dbd7-43d5-a46c-986a78d3273c\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <g transform=\"matrix(0,1,-1,0,558.84174,575.83702) \" id=\"svg_c3650d4c-d575-41fe-b78c-54f56769ad60\" display=\"inline\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M75.46003,-141.65826L83.92878,-141.65826L86.49128,-144.22076L84.02253,-150.22076L75.46003,-141.65826z\" id=\"svg_0542e545-b170-4ba7-b24a-447a570eaedd\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M86.49128,-144.22076C98.92878,-144.22076 130.13282,-144.22076 130.13282,-144.22076L132.60157,-150.22076L84.02253,-150.22076L86.49128,-144.22076z\" id=\"svg_ca72fb69-6cc8-4676-a579-a9be6395d339\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M130.11854,-144.22076L132.68104,-141.65826L141.14979,-141.65826L132.58729,-150.22076L130.11854,-144.22076z\" id=\"svg_ace48b82-3eea-4f76-99c3-8baa9c7dc510\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <rect width=\"3.00084\" height=\"6.18535\" x=\"583.48828\" y=\"180.22156\" id=\"svg_e50c0829-bd98-43ec-b3a8-3df432544d2a\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M270.53125,127.12511C281.97717,127.12511 290.99201,135.73934 290.99201,146.01847L270.53125,146.01847L270.53125,127.12511z\" id=\"svg_0bf73af7-7340-4843-9a60-9c0d50404be5\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M285.03416,138.19356A6.42018,6.42018 0 1 1 272.1938,138.19356A6.42018,6.42018 0 1 1 285.03416,138.19356z\" id=\"svg_be66a5ef-0c0e-48c4-a923-a219dd04fe29\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.14957\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M688.5,755.65625L688.5,762.1875L708.6875,771.125L708.6875,764.59375L688.5,755.65625z\" id=\"svg_47b1c9a3-99bc-4b2c-9342-b89557333169\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#b2b2b2\"/>\n    <path d=\"M688.5,735.125L688.5,741.6875L707.46875,750.125L708.0625,750.375L708.6875,750.375L716.84375,750.375L716.84375,769.84375L716.84375,772.84375L719.84375,772.84375L771.96875,772.84375L771.96875,766.84375L722.84375,766.84375L722.84375,747.375L722.84375,744.375L719.84375,744.375L709.28125,744.375L688.5,735.125z\" id=\"svg_d5f403b1-a13c-4bd1-b499-e386cb253af7\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#b2b2b2\"/>\n    <g transform=\"matrix(0,-1,1,0,6.235806,928.72291) \" id=\"svg_6113578c-892b-477c-962e-bdf62df811a6\" display=\"inline\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M144.41041,226.26419L141.94166,220.26419L127.09791,235.13919L135.56666,235.13919L144.41041,226.26419z\" id=\"svg_1e8a2467-e0cc-4b25-bbba-caf02f4f5863\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M144.42253,226.27924C156.86003,226.27924 179.92434,226.27924 179.92434,226.27924L182.39309,220.27924L141.95378,220.27924L144.42253,226.27924z\" id=\"svg_454256c4-fc9d-4fbb-b0d8-a5994d02f52a\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M197.19166,235.13919L182.37916,220.26419L179.91041,226.26419L188.72291,235.13919L188.75411,235.13919L197.19161,235.13919L197.19166,235.13919z\" id=\"svg_6a0bb851-9d6b-49f2-9c34-a9b54b04e291\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <path d=\"M226.51875,750.25L226.51875,756.25L283.25,756.25L283.25,750.25L226.51875,750.25z\" id=\"svg_95f4c1d4-67e8-44f4-8f61-61e314b2f99e\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#b2b2b2\"/>\n    <path d=\"M384.05859,730.03125L396.06347,778.875L413.875,778.875L413.875,730.03125L384.05859,730.03125z\" id=\"svg_0b74afcd-ab2d-4cb9-b598-7ebabbea0c94\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#595959\"/>\n    <path d=\"M415,126.84375L415,130.34375L415,132.34375L413,132.34375L412.75,132.34375L412.75,146.03125L419.5625,146.03125L419.5625,132.77467C419.5625,129.92343 417.16878,126.84375 415,126.84375z\" id=\"svg_fbdd9fe7-42ed-480d-a3de-8df331d8814c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M417.00425,146.03125C417.00425,146.03125 417.00425,136.57353 417.00425,134.09866C417.00425,131.62379 415,130.20957 415,130.20957\" id=\"svg_f568073b-33a3-4779-8420-444d9d73f3a7\" stroke-dashoffset=\"1.7\" stroke-dasharray=\"8, 4\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M546.34375,180.21865L574.5,180.21865\" id=\"svg_92b3d64d-7f1a-413a-b3ca-fe268a00169f\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M560.42187,180.21865L560.42187,196.71875\" id=\"svg_f7ab4bbe-dc5c-4425-808e-8ce6259ebc12\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M560.42187,180.21865L550.89553,196.71875\" id=\"svg_b401483e-9711-464c-9209-2c7b0b5eb6ae\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M560.42187,180.21865L546.34375,183.99087\" id=\"svg_e5999bdd-4ce2-4e4b-87a7-9a2b902c4bb7\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M560.42187,180.21865L546.34375,190.14666\" id=\"svg_e84f90f9-bc8f-4632-b460-897ac33f1e9a\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(-1,0,0,1,750.345,0) \" id=\"svg_1efdbe9d-5a21-48b5-9f1a-a3f89ea18140\">\n     <path d=\"M189.92187,180.21865L180.39553,196.71875\" id=\"svg_1c367d0e-3508-46cd-9296-39cdde356ac7\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M189.92187,180.21865L175.84375,183.99087\" id=\"svg_cfb10d60-f4cf-4eef-8f9d-a8ce8e1faf00\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M189.92187,180.21865L175.84375,190.14666\" id=\"svg_3992c80f-e73c-4f22-87f9-c15cd0ab3823\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M459.8726,180.8125C459.8726,180.8125 459.8726,191.62875 459.8726,195.0759C459.8726,198.52304 459.9343,208.20026 466.28125,211.26169\" id=\"svg_6fd54b13-7e67-4968-8ef7-f6352f499d1f\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M454.83446,180.8125C454.83446,180.8125 454.83446,191.53592 454.83446,195.15984C454.83446,198.78376 456.12139,207.91192 466.28125,215.50433C454.98167,210.01981 449.61955,198.73383 449.61955,195.10991C449.61955,191.48598 449.61955,180.8125 449.61955,180.8125\" id=\"svg_489846e7-f5cc-41e8-ac8d-60c4f5ec0aa0\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M474.89862,158.03125L474.89862,171.8125\" id=\"svg_6173c3a5-86ae-4caf-941e-e710e7cd1953\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M471.29862,158.03125L471.29862,171.8125\" id=\"svg_19cbfac8-190d-4e0f-b9e5-04ec3a828994\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M467.69862,158.03125L467.69862,171.8125\" id=\"svg_7fea9714-4a3c-4dce-b8b3-4007a677a56a\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M464.09862,158.03125L464.09862,171.8125\" id=\"svg_5fd8485f-df1e-4e21-b807-ea718e0ce62a\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M460.49862,158.03125L460.49862,171.8125\" id=\"svg_a8fed1f2-2697-4f7b-8f09-7cbabd2328e3\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M456.89862,158.03125L456.89862,171.8125\" id=\"svg_2cad380e-8be7-441b-bade-24190a76f54c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M453.29862,158.03125L453.29862,171.8125\" id=\"svg_8d9603b1-a818-4eca-b9c8-00283a85afbf\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M449.69862,158.03125L449.69862,171.8125\" id=\"svg_082f038a-072c-4499-af30-51100651aec8\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M446.09862,158.03125L446.09862,171.8125\" id=\"svg_0e00f8ce-0d59-4b52-840c-ce99f25772df\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M442.49862,158.03125L442.49862,171.8125\" id=\"svg_7e08726b-560c-41f3-b498-e60e0b60a4d1\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M472.9375,342.45593L472.9375,356.40625L459.5625,356.40625C459.5625,346.9378 463.40109,342.45593 472.9375,342.45593z\" id=\"svg_51179533-a917-4959-bd5b-d27dcf63c334\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(1,0,0,1.7952947,12.747465,-543.74957) \" id=\"svg_1e614e23-c316-4c82-9a7e-0634513e0bd7\">\n     <path d=\"M630.84059,596.79244L630.84059,610.57369\" id=\"svg_0a70ea14-1b0f-43dc-9710-8aa160a1d99d\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M627.24059,596.79244L627.24059,610.57369\" id=\"svg_de01df8e-34d8-409d-a6f5-b9cacbc84365\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M623.64059,596.79244L623.64059,610.57369\" id=\"svg_19626fca-06f6-4576-bf88-56fda0686437\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M620.04059,596.79244L620.04059,610.57369\" id=\"svg_cdb1d24e-de7e-4d5d-b7a4-54558b91f30c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M616.44059,596.79244L616.44059,610.57369\" id=\"svg_61eb11ff-5189-4853-993c-f56c2912b417\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M612.84059,596.79244L612.84059,610.57369\" id=\"svg_226078fb-2e42-40ea-b5a5-379c987769d5\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M609.24059,596.79244L609.24059,610.57369\" id=\"svg_227d9df3-ae37-49f3-83d0-6de90f3b8ad2\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M605.64059,596.79244L605.64059,610.57369\" id=\"svg_b5610de2-8a28-4cc4-b858-704ee52cfd57\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M602.04059,596.79244L602.04059,610.57369\" id=\"svg_bb6877b1-4934-43a9-9c55-a48e090aa292\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M598.44059,596.79244L598.44059,610.57369\" id=\"svg_15e9f4d7-1f7a-4f9e-82e3-cede38a31d37\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M634.44059,596.79244L634.44059,610.57369\" id=\"svg_ab5fed38-a992-400e-9866-6aa5502b7d3a\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M611.18804,581.20952L611.18804,552.41015L647.15566,552.41015\" id=\"svg_84d476a5-0909-45cf-aed0-009a80fd937f\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(0,1,-1.2773911,0,1076.7136,302.17693) \" id=\"svg_9f354e82-bf1a-49f8-9140-1ee41b076873\">\n     <path d=\"M275.825,465.44943L275.825,479.23068\" id=\"svg_258e34ad-0dec-4757-8a48-9ffcb198ff9b\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.88479\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M272.225,465.44943L272.225,479.23068\" id=\"svg_85b56cb9-f9a0-404c-b389-8e4b716ec997\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.88479\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M268.625,465.44943L268.625,479.23068\" id=\"svg_bc942f9d-bb14-4785-a48e-cfb6cc0b0c79\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.88479\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M265.025,465.44943L265.025,479.23068\" id=\"svg_abf880af-5709-40b3-88c9-411204e3658c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.88479\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M261.425,465.44943L261.425,479.23068\" id=\"svg_c15043a6-d1b2-4681-8fb4-a85a0c84d168\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.88479\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M257.825,465.44943L257.825,479.23068\" id=\"svg_d4a9b811-996b-4681-b29a-87fc74974ec9\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.88479\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M254.225,465.44943L254.225,479.23068\" id=\"svg_4ebd5bce-2fc4-4b5b-a470-e56047c21ad1\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.88479\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M250.625,465.44943L250.625,479.23068\" id=\"svg_4bed6510-b686-46f6-b3d7-bb89a12ae1cb\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.88479\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M247.025,465.44943L247.025,479.23068\" id=\"svg_72a77445-30fc-4957-abc5-f66fd72aef3e\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.88479\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M243.425,465.44943L243.425,479.23068\" id=\"svg_8299e69d-7fa8-4a92-898e-e49b8cebd742\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.88479\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M482.15625,545.59375L482.15625,526.20593L512.90625,526.20593\" id=\"svg_0b410986-2421-4a16-8ac1-be6e05fc4a65\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(0,1,-1.1940134,0,1008.21,303.02068) \" id=\"svg_a6bb7cca-569b-459d-bb69-4a65e003fa91\">\n     <path d=\"M261.425,455.32256L261.425,469.10381\" id=\"svg_0cd289d3-75f7-4c1b-965a-72a99ac1e680\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.91516\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M257.825,455.32256L257.825,469.10381\" id=\"svg_adfe9e27-0cc1-4984-b0ed-fd20d9388449\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.91516\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M254.225,455.32256L254.225,469.10381\" id=\"svg_c1b1625f-03cb-4ec9-90a5-2e3c59a3cc3a\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.91516\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M464.54862,545.60193L464.54862,578.00193\" id=\"svg_a5d1a93a-a6ce-4495-83d5-101eff0fff10\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(1,0,0,2.2513875,-37.66247,-819.90802) \" id=\"svg_dc60e5be-c753-4b09-a616-c0f6ee52285b\">\n     <path d=\"M485.75625,597.90985L485.75625,611.6911\" id=\"svg_96867b4e-00bf-4d64-a5e4-85699939ada6\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.66646\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M482.15625,597.90985L482.15625,611.6911\" id=\"svg_a42a880a-10ea-4f7d-b84a-128e10c8e3fb\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.66646\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M478.55625,597.90985L478.55625,611.6911\" id=\"svg_f2dab761-bb91-4986-91ab-954cc2d62c9b\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.66646\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M474.95625,597.90985L474.95625,611.6911\" id=\"svg_8760f291-c606-48f1-af1e-5809d0bfe2ab\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.66646\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M411.65625,637.12109L414.80062,645.29037L406.71269,665.96789L396.0625,668.75337\" id=\"svg_91475802-f19f-4eff-bd7a-b3a007bff3e5\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M253.375,740L253.375,750.25\" id=\"svg_033d0c7d-335f-4c56-93bc-20859b8b13bc\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(1,0,0,1.2950287,-266.97809,-52.607644) \" id=\"svg_99b4c99e-3f94-4998-b74f-54beaccaabd2\" display=\"inline\">\n     <path d=\"M623.64059,590.70712L623.64059,604.48837\" id=\"svg_5ef5a38f-4e9f-448b-aeed-dbf3ea2d6d46\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M620.04059,590.70712L620.04059,604.48837\" id=\"svg_786b01ba-c020-45b9-a5e1-a8f8bc583d0b\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M616.44059,590.70712L616.44059,604.48837\" id=\"svg_e89ac0d9-8bb1-4295-b2d6-b16eeb39acda\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M612.84059,590.70712L612.84059,604.48837\" id=\"svg_78fa6df3-0bb6-4c1a-84a4-e3d3fdfe2760\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M609.24059,590.70712L609.24059,604.48837\" id=\"svg_5e64fdf9-c478-422f-be7d-0ef9e3ff2575\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M605.64059,590.70712L605.64059,604.48837\" id=\"svg_81c7e44c-1d47-4cf0-b915-79d55418b57d\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M602.04059,590.70712L602.04059,604.48837\" id=\"svg_adba2f55-00b1-4a29-b861-5ed36dda50b5\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M598.44059,590.70712L598.44059,604.48837\" id=\"svg_22c182f5-eaa9-450c-8e18-c1343103728c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M331.4625,730.22213L314.53125,712.375\" id=\"svg_63ff8c05-e356-4fc8-bab4-eddfdcc88442\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M331.4625,730.22213L325.04946,712.375\" id=\"svg_bdfbb4b2-a4a6-4842-8083-626f85ce1dd3\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M331.4625,730.22213L314.52812,723.11128\" id=\"svg_bcfeb783-8319-4983-8efa-3adc2d135032\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M356.6625,730.22213L314.53125,730.22213\" id=\"svg_ad7e6544-379c-42dd-bb99-09ea46b97fac\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(-0.08914169,-0.99601896,0.99601896,-0.08914169,-596.23762,971.74807) \" id=\"svg_f07647d1-d622-4967-866f-7febc82f6b82\" stroke-dashoffset=\"0\" stroke-dasharray=\"2.99999999, 2.99999999\" stroke-miterlimit=\"4\" stroke=\"#000000\">\n     <path d=\"M157.86767,945.53692L141.7354,928.53199\" id=\"svg_8132f097-673b-42b8-9f4f-860f78173092\" stroke-dashoffset=\"0\" stroke-dasharray=\"2.99999999, 2.99999999\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M157.86767,945.53692L152.12302,929.54987\" id=\"svg_d36a8245-2dce-4384-9639-b203a902417a\" stroke-dashoffset=\"0\" stroke-dasharray=\"2.99999999, 2.99999999\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M396.0625,703.33315L396.0625,723.2574\" id=\"svg_3ccf8c41-752d-421b-9e18-c1c0eec3e60d\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M388.05417,707.67523L388.05417,723.2574\" id=\"svg_e6075402-c739-4d2f-801b-45efb9cdfb14\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M384.05,708.59226L384.05,723.2574\" id=\"svg_df36e1bb-f700-4cb4-8d7f-cc77bceb3aa3\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M392.05834,706.4157L392.05834,723.2574\" id=\"svg_211d4862-00ca-453f-ba21-2a71dc0d6103\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(0,1,-5.9590391,0,4059.0743,415.88989) \" id=\"svg_27e6ed56-1aab-42ca-9cc0-adb7ed55916f\" display=\"inline\">\n     <path d=\"M406.50934,581.4582L406.50934,595.23945\" id=\"svg_5ed89712-42f9-4fba-be3d-5a695fa22e64\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.40965\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M402.90934,581.4582L402.90934,595.23945\" id=\"svg_0c2a4ee4-dbe6-410d-9ec2-d24beb123227\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.40965\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M399.30934,581.4582L399.30934,595.23945\" id=\"svg_c9173f22-9b7a-4aca-8267-653a213d65bb\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.40965\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M395.70934,581.4582L395.70934,595.23945\" id=\"svg_e49d48e6-0428-4ecd-b726-704fb5fca5bd\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.40965\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M392.10934,581.4582L392.10934,595.23945\" id=\"svg_6e333afa-97ae-482a-83a4-1af2a1a90c63\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.40965\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M388.50934,581.4582L388.50934,595.23945\" id=\"svg_bfd2dad4-e7b6-4779-a6cc-9943f0eb2362\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.40965\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M384.90934,581.4582L384.90934,595.23945\" id=\"svg_70b61e44-5561-4eaf-95f4-fc17a9eeb58d\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.40965\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,1,-2.3265297,0,1928.3552,380.24691) \" id=\"svg_e9c3362a-9e81-4e6d-b77c-506352c1af56\" display=\"inline\">\n     <path d=\"M395.70934,532.9204L395.70934,546.70165\" id=\"svg_6c18a853-86a0-4e64-9ef9-f2af365fc229\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.65561\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M392.10934,532.9204L392.10934,546.70165\" id=\"svg_9bfdaf30-5dac-4d1c-b32b-b469174114f1\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.65561\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M388.50934,532.9204L388.50934,546.70165\" id=\"svg_81c9d42e-6f2c-4395-9a0f-c3a8f55c843f\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.65561\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M384.90934,532.9204L384.90934,546.70165\" id=\"svg_910d3dd1-e603-4921-b598-43f99c7c534c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.65561\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(-1,0,0,-1.2449041,927.24059,1549.6854) \" id=\"svg_be96aa78-cfeb-4ea6-a50f-a172b3e6ad12\" display=\"inline\">\n     <path d=\"M238.74059,637.82355L238.74059,649.0443\" id=\"svg_57230067-6329-4d8b-a43f-6455607245df\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.89626\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M235.14059,636.54329L235.14059,647.758\" id=\"svg_86b2aa9c-1214-43f6-bc87-627a03a91e96\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.89626\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M231.54059,635.26305L231.52499,646.46612\" id=\"svg_ac31e235-fa95-4776-9148-c8b8a9f7eff0\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.89626\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M482.15625,526.20593L505.36889,541.37892\" id=\"svg_cd9f4a04-a3a9-4d60-9ac7-92f3ee72ee56\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(0,1,-2.6791374,0,1906.6553,380.24691) \" id=\"svg_4b8b807d-e3db-47c7-b31b-1782ab0b5f3d\" display=\"inline\">\n     <path d=\"M395.70934,543.40004L395.70934,557.18129\" id=\"svg_f7e3efd0-fc37-4b1e-8f86-8dcaef61722d\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61095\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M392.10934,543.40004L392.10934,557.18129\" id=\"svg_186ed773-fb40-4d5c-95e7-fbe24b589411\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61095\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M388.50934,543.40004L388.50934,557.18129\" id=\"svg_82d0725c-b372-48d2-9204-587065b98958\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61095\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M384.90934,543.40004L384.90934,557.18129\" id=\"svg_84d53a94-a1de-4b26-944a-40d300e5e15b\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61095\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g id=\"svg_9e232aaa-5ca8-41bf-b66e-a908e03f69e8\">\n     <path d=\"M611.18804,577.61015L586.44663,577.61015\" id=\"svg_f89dd120-6517-4afa-90bb-1106dfdee8fd\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.18804,574.01015L586.44663,574.01015\" id=\"svg_8b0194b6-dba9-4eb7-8969-750eac41c068\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.18804,570.41015L586.44663,570.41015\" id=\"svg_1fa2fb75-719d-43c2-9e37-57f6e9af9c75\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.18804,566.81015L586.44663,566.81015\" id=\"svg_ba141051-ddf7-4caf-983b-56f2586e0e99\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.18804,563.21015L586.44663,563.21015\" id=\"svg_1b6b0f07-6ee1-4ced-8eba-8af27e619118\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.18804,559.61015L586.44663,559.61015\" id=\"svg_a77d6853-6a51-452f-87b9-03820d55781c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.18804,556.01015L586.44663,556.01015\" id=\"svg_311d8c38-b419-44fe-a536-7b6409ad7494\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.18804,552.41015L586.44663,552.41015\" id=\"svg_46ab188d-8ad4-4384-bd10-25efc36e9a09\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.18804,581.21326L586.44663,581.21326\" id=\"svg_5f0376f3-6112-4cf1-8f58-5e1d2fa70627\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n   </g>\n   <g id=\"svg_76b22ba1-1230-4d74-a0b9-5c41d4f8eded\" display=\"none\">\n    <path d=\"M442.51197,54.51516L414.99635,54.51516\" id=\"svg_56d78c0f-a497-4ade-aa63-c0eb1c000a5e\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M442.51197,52.51516L415.00025,52.51516\" id=\"svg_0b0b8799-e4f7-4d83-a375-14f30aa04c0c\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(0.62137405,0,0,1,241.53106,0) \" id=\"svg_d2cb116d-d11b-450c-911c-e321e82d7c6c\">\n     <g id=\"svg_98edd2e8-cea4-4324-9e01-2a45ab61f0ad\" stroke-width=\"1.2686\" stroke=\"#000000\" fill=\"none\">\n      <path d=\"M555.39157,54.51516L514.45407,54.51516\" id=\"svg_d4e02e2c-7881-4fb6-8dd6-401b7d998488\" stroke-miterlimit=\"4\" stroke-width=\"1.2686\" stroke=\"#000000\" fill=\"none\"/>\n      <path d=\"M555.39157,52.51516L514.45407,52.51516\" id=\"svg_cb4c1a89-f47a-414a-aa25-c8e9990294da\" stroke-miterlimit=\"4\" stroke-width=\"1.2686\" stroke=\"#000000\" fill=\"none\"/>\n     </g>\n    </g>\n    <g id=\"svg_a45d147d-eda9-41cf-8589-ac1fb4b4b486\">\n     <g id=\"svg_6ecc89f5-aa04-410c-8bf7-20077697506b\" stroke=\"#000000\" fill=\"none\">\n      <path d=\"M659.57447,54.51516L618.63697,54.51516\" id=\"svg_14482978-a342-49b1-ab48-893b16584e63\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n      <path d=\"M659.57447,52.51516L618.63697,52.51516\" id=\"svg_7cd35afa-1e20-4d41-97c9-e3a32ab8289b\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n     </g>\n    </g>\n    <g transform=\"matrix(-0.48244275,0,0,-1,297.43864,262.8) \" id=\"svg_28370907-96b2-4f47-8ce4-8047ea53b1d0\">\n     <g id=\"svg_795df321-858e-4c1a-a2bf-6e41e4f619f4\" stroke-width=\"1.43972\" stroke=\"#000000\" fill=\"none\">\n      <path d=\"M-126.72136,111.07766L-167.65886,111.07766\" id=\"svg_b160d377-4c7f-406a-a771-5d5fcd5e71a3\" stroke-miterlimit=\"4\" stroke-width=\"1.43972\" stroke=\"#000000\" fill=\"none\"/>\n      <path d=\"M-126.72136,109.07766L-167.65886,109.07766\" id=\"svg_808f9bc8-ba93-4d6b-827a-8abbea3c3b38\" stroke-miterlimit=\"4\" stroke-width=\"1.43972\" stroke=\"#000000\" fill=\"none\"/>\n     </g>\n    </g>\n    <g transform=\"matrix(0,0.53085054,-1,0,591.81248,156.38736) \" id=\"svg_85f8796f-400c-4cef-bb75-d0a3b52bd0a0\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M203.98667,-102.45359L163.04917,-102.45359\" id=\"svg_5e5e56cf-217e-4b6d-b9e3-bfe56b51841e\" stroke-miterlimit=\"4\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M203.98667,-104.45359L163.04917,-104.45359\" id=\"svg_56fa8d45-fcf1-48d0-aab5-d91f04483459\" stroke-miterlimit=\"4\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.42289531,-1,0,591.81248,234.53614) \" id=\"svg_e3020b8b-eb74-4ad5-b419-201a0f5d6df8\" stroke-width=\"1.53774\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M190.38666,-102.45359L149.44916,-102.45359\" id=\"svg_369f90a7-f7fd-4c13-8aac-2c4f262621ca\" stroke-miterlimit=\"4\" stroke-width=\"1.53774\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M190.38666,-104.45359L149.44916,-104.45359\" id=\"svg_6568708d-8459-4aa6-b3f2-d97cccdb3efd\" stroke-miterlimit=\"4\" stroke-width=\"1.53774\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.53085054,-1,0,591.81248,320.40468) \" id=\"svg_3b353eec-3d72-4688-b767-c4f05a4e31cf\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M203.98667,-102.45359L163.04917,-102.45359\" id=\"svg_704edcab-a8af-4387-8501-bbc1e08c6c95\" stroke-miterlimit=\"4\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M203.98667,-104.45359L163.04917,-104.45359\" id=\"svg_40a276bb-d068-48fe-8f67-cdb6efd5992b\" stroke-miterlimit=\"4\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.53085054,-1,0,591.81248,366.98534) \" id=\"svg_d58bb9b2-950a-4a98-b4d1-897f6a3ab308\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M203.98667,-102.45359L163.04917,-102.45359\" id=\"svg_c36996b4-2b3e-4aa2-967b-c51604ef90b1\" stroke-miterlimit=\"4\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M203.98667,-104.45359L163.04917,-104.45359\" id=\"svg_a80a330f-c4dd-4673-8d81-c4f3781f1bf2\" stroke-miterlimit=\"4\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.4224536,-1,0,591.81248,503.95925) \" id=\"svg_352f0b31-bf39-4da5-98a2-657fade5c168\" stroke-width=\"1.53855\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M190.31674,-102.45359L149.37924,-102.45359\" id=\"svg_8451db18-2a86-468b-a31b-9b972839d0ec\" stroke-miterlimit=\"4\" stroke-width=\"1.53855\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M190.31674,-104.45359L149.37924,-104.45359\" id=\"svg_3d0e1a21-89a7-49ff-bf78-fd3b57fd684b\" stroke-miterlimit=\"4\" stroke-width=\"1.53855\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(-0.43772542,0,0,1,249.00704,652.10969) \" id=\"svg_50cb640d-e931-4536-b2be-001cb122dcb4\" stroke-width=\"1.51147\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M-165.94857,54.51516L-206.88607,54.51516\" id=\"svg_a5edee81-0042-46c4-9965-bb3b8b2e6707\" stroke-miterlimit=\"4\" stroke-width=\"1.51147\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M-165.94857,52.51516L-206.88607,52.51516\" id=\"svg_e6e84cac-b13d-4087-a658-6cfdaf356a49\" stroke-miterlimit=\"4\" stroke-width=\"1.51147\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(-0.57806716,0,0,1,234.04025,652.10969) \" id=\"svg_69eda053-578b-4a02-80b2-79366baa364f\" stroke-width=\"1.31526\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M-63.20255,54.51516L-104.14005,54.51516\" id=\"svg_f8b0fcdf-6d49-4a19-9e16-cde09936bd5a\" stroke-miterlimit=\"4\" stroke-width=\"1.31526\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M-63.20255,52.51516L-104.14005,52.51516\" id=\"svg_a7a795d1-e068-4a9e-bd6c-48692179e479\" stroke-miterlimit=\"4\" stroke-width=\"1.31526\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0.49386211,0,0,-1,24.204271,956.18593) \" id=\"svg_4a5cbf73-efa5-4ac0-b01a-74e2912ef9aa\" stroke-width=\"1.42297\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M632.36669,111.07766L591.42919,111.07766\" id=\"svg_7c4ae641-69e6-43df-bf59-b2e581170b4e\" stroke-miterlimit=\"4\" stroke-width=\"1.42297\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M632.36669,109.07766L591.42919,109.07766\" id=\"svg_9f9d679f-3bf8-4f2d-8c26-7e1f424fe214\" stroke-miterlimit=\"4\" stroke-width=\"1.42297\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0.49278256,0,0,-1,63.859016,956.18593) \" id=\"svg_b3ee67b4-8d53-4017-84b0-d4ab0be63fa1\" stroke-width=\"1.42453\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M633.18844,111.07766L592.25094,111.07766\" id=\"svg_7e2ccb87-772c-4a13-9be9-88cc3df7686b\" stroke-miterlimit=\"4\" stroke-width=\"1.42453\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M633.18844,109.07766L592.25094,109.07766\" id=\"svg_309a8e1b-b8e2-4c36-9eb5-5f96afc8fdce\" stroke-miterlimit=\"4\" stroke-width=\"1.42453\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.293433,1,0,122.28517,148.60947) \" id=\"svg_7aa4d3e5-7bb6-4795-9aec-341eb9e86283\" display=\"inline\" stroke-width=\"1.84606\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M160.88136,268.04641L119.94386,268.04641\" id=\"svg_74903048-6284-4683-922f-8b1df3d0fd40\" stroke-miterlimit=\"4\" stroke-width=\"1.84606\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M160.88136,266.04641L119.94386,266.04641\" id=\"svg_0f07281a-e15b-4dc7-93dd-01872b89d813\" stroke-miterlimit=\"4\" stroke-width=\"1.84606\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.42099237,1,0,122.28517,204.10031) \" id=\"svg_679e7579-2f62-4dee-9193-2ae45b496587\" display=\"inline\" stroke-width=\"1.54121\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M190.08444,268.04641L149.14694,268.04641\" id=\"svg_0359af01-9b90-4aa5-81d1-2beee9432835\" stroke-miterlimit=\"4\" stroke-width=\"1.54121\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M190.08444,266.04641L149.14694,266.04641\" id=\"svg_31251be8-619d-4f34-ab34-9fd8265f3371\" stroke-miterlimit=\"4\" stroke-width=\"1.54121\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.39389313,1,0,122.28517,245.08753) \" id=\"svg_9c940a25-3b7e-42ce-aee5-7fd3ff48acfb\" display=\"inline\" stroke-width=\"1.59335\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M185.46263,268.04641L144.52513,268.04641\" id=\"svg_773a85e2-4f52-433e-8352-adba3baa534b\" stroke-miterlimit=\"4\" stroke-width=\"1.59335\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M185.46263,266.04641L144.52513,266.04641\" id=\"svg_e47ffdb9-518d-4441-ae76-bb1f0dc2ac38\" stroke-miterlimit=\"4\" stroke-width=\"1.59335\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.42099237,1,0,122.28517,271.4753) \" id=\"svg_b16cd889-a172-45b8-a741-241ccef0d428\" display=\"inline\" stroke-width=\"1.54121\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M190.08444,268.04641L149.14694,268.04641\" id=\"svg_e273079e-f604-4ee2-a752-bfc6307430e4\" stroke-miterlimit=\"4\" stroke-width=\"1.54121\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M190.08444,266.04641L149.14694,266.04641\" id=\"svg_5898ac66-2ac2-4024-87e9-37ae59a1e3b1\" stroke-miterlimit=\"4\" stroke-width=\"1.54121\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.42099237,1,0,122.28517,312.7253) \" id=\"svg_a5f1840f-83cd-47a8-89c0-593e478393bd\" display=\"inline\" stroke-width=\"1.54121\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M190.08444,268.04641L149.14694,268.04641\" id=\"svg_b8404057-28bf-474f-a890-df9fe2cb7e91\" stroke-miterlimit=\"4\" stroke-width=\"1.54121\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M190.08444,266.04641L149.14694,266.04641\" id=\"svg_541468a0-39ab-4410-9ed8-2a52d10fdaf8\" stroke-miterlimit=\"4\" stroke-width=\"1.54121\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.37824429,1,0,122.28517,363.47277) \" id=\"svg_b0f4d0ff-6386-415a-9fe9-23eaf168ca44\" display=\"inline\" stroke-width=\"1.62597\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M182.49219,268.04641L141.55469,268.04641\" id=\"svg_dbafbf2d-4d1d-4307-8f34-9e29ed0929e5\" stroke-miterlimit=\"4\" stroke-width=\"1.62597\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M182.49219,266.04641L141.55469,266.04641\" id=\"svg_e068bfcc-43c3-48c9-ad6c-ff198de7d0e5\" stroke-miterlimit=\"4\" stroke-width=\"1.62597\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.3168156,1,0,122.28517,410.88629) \" id=\"svg_eb4f4849-c688-42c2-8db5-7e2ae646c01f\" display=\"inline\" stroke-width=\"1.77663\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M167.99473,268.04641L127.05723,268.04641\" id=\"svg_24f089a2-9a9a-43b6-9455-f66c55711e76\" stroke-miterlimit=\"4\" stroke-width=\"1.77663\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M167.99473,266.04641L127.05723,266.04641\" id=\"svg_11d43782-3c30-404d-9a21-1aee33fd6757\" stroke-miterlimit=\"4\" stroke-width=\"1.77663\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.3168156,1,0,122.28517,527.88629) \" id=\"svg_8de4cac2-afb6-49d7-a204-26c078ff6ded\" stroke-width=\"1.77663\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M167.99473,268.04641L127.05723,268.04641\" id=\"svg_9882e54f-d11c-4341-80da-ef650360a558\" stroke-miterlimit=\"4\" stroke-width=\"1.77663\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M167.99473,266.04641L127.05723,266.04641\" id=\"svg_c88b81e8-33d9-4f9a-8665-92b47dd6827b\" stroke-miterlimit=\"4\" stroke-width=\"1.77663\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.42045257,1,0,122.28517,429.51883) \" id=\"svg_8f021d7d-0cfb-4cd7-9f3e-1c753a11f428\" display=\"inline\" stroke-width=\"1.5422\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M189.9981,268.04641L149.0606,268.04641\" id=\"svg_f8b2eaf2-624f-482c-9aa4-b2f72d79ae2b\" stroke-miterlimit=\"4\" stroke-width=\"1.5422\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M189.9981,266.04641L149.0606,266.04641\" id=\"svg_bbdce18b-6c85-4e1d-8481-0fa98df61178\" stroke-miterlimit=\"4\" stroke-width=\"1.5422\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.46490716,1,0,84.47267,576.73236) \" id=\"svg_0866afdb-9d4a-4546-9582-15dfb398f081\" display=\"inline\" stroke-width=\"1.46662\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M196.42993,268.04641L155.49243,268.04641\" id=\"svg_96da9025-37c4-4983-9a94-a8227401de7e\" stroke-miterlimit=\"4\" stroke-width=\"1.46662\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M196.42993,266.04641L155.49243,266.04641\" id=\"svg_93938010-aa23-4ef1-ada4-0fc97f0739ee\" stroke-miterlimit=\"4\" stroke-width=\"1.46662\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(-0.42063237,0,0,1,286.45593,552.87483) \" id=\"svg_71ae8053-ed45-462f-b314-f24c06886ab5\" stroke-width=\"1.54187\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M-183.14633,54.51516L-224.08383,54.51516\" id=\"svg_d5af09db-26c6-452e-90ad-7a7d826cb13b\" stroke-miterlimit=\"4\" stroke-width=\"1.54187\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M-183.14633,52.51516L-224.08383,52.51516\" id=\"svg_de3af7fc-e6b2-48ad-b099-7e1e881d6ec9\" stroke-miterlimit=\"4\" stroke-width=\"1.54187\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0.61999758,0,0,1,152.66841,681.94933) \" id=\"svg_916da530-6def-437f-8988-58f8f12a1d46\" stroke-width=\"1.27\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M556.0535,54.51516L515.116,54.51516\" id=\"svg_7c6825a8-22f4-4d44-aedb-0936afc11719\" stroke-miterlimit=\"4\" stroke-width=\"1.27\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M556.0535,52.51516L515.116,52.51516\" id=\"svg_30f99cf9-8e2f-47d5-a31e-4c20ddbf336d\" stroke-miterlimit=\"4\" stroke-width=\"1.27\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(-0.6761343,0,0,-1,469.34621,894.32023) \" id=\"svg_0ef040e1-4831-4d57-808a-c82f511556a6\" stroke-width=\"1.21614\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(-0.6761343,0,0,-1,586.34621,894.32023) \" id=\"svg_b3fe05f5-f785-4619-8459-af80f229192e\" stroke-width=\"1.21614\" stroke=\"#000000\" fill=\"none\"/>\n    <g id=\"svg_8fa09d6d-0c09-4763-a21a-780e87349710\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M517.31483,449.68811L517.31483,465.25752\" id=\"svg_3295dbb1-272c-41d8-a49d-a281e32d73de\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M517.31483,386.68811L517.31483,400.38253\" id=\"svg_366a2a75-f702-4569-a9d9-28152906a6ae\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M517.31483,325.48811L517.31483,339.18253\" id=\"svg_b6afc4e6-4f51-4252-9ec5-0f75c24b45ff\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M517.31483,264.28811L517.31483,277.98253\" id=\"svg_d83b45cb-24a0-4f39-88d4-8800d97a8bc3\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(0,0.71801002,-0.40732576,0,412.26837,-31.456465) \" id=\"svg_e43c8f29-18c0-4dc1-a446-6f96178a9ec9\" display=\"inline\" stroke-linejoin=\"round\" stroke=\"#000000\">\n     <path d=\"M294.36605,-1.13872L294.36605,39.79878\" id=\"svg_00aa376b-3467-480c-bf5c-7bcf9bd5b9a3\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-width=\"1.84911\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M288.92855,39.79878L299.80355,39.79878L299.80355,-1.13872L288.92855,-1.13872L288.92855,39.79878z\" id=\"svg_0579d5f5-cbfb-4044-b5e3-ea0ae06a99a1\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-width=\"1.84911\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M299.79922,32.58721L288.91828,32.58721\" id=\"svg_aecf0d85-a13d-4731-b2d9-1d36a1b92e82\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-width=\"1.84911\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M410.99662,54.51516L401.55874,54.51516\" id=\"svg_3b2dd85b-7b2b-4055-885a-48e279c3d6a2\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M410.99628,52.51516L401.56125,52.51516\" id=\"svg_356fe5d9-0324-4c21-acc2-0ece349c7cf4\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(0.39389313,0,0,0.71551724,248.99439,191.12215) \" id=\"svg_6ae6694c-5cd0-4fbf-857c-6f0edfb6734a\" display=\"inline\" stroke-width=\"1.88365\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M727.56725,43.2708L696.2453,43.2708\" id=\"svg_be1e45c2-1801-4935-93d4-7997836e47fc\" stroke-miterlimit=\"4\" stroke-width=\"1.88365\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M727.56725,41.2708L696.2453,41.2708\" id=\"svg_32be0c52-4005-4030-a99f-8ef49ff38846\" stroke-miterlimit=\"4\" stroke-width=\"1.88365\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0.47045416,0,0,-1,-9.1792274,956.18756) \" id=\"svg_adf1b723-5d2f-4a44-8377-bf7b8f706e64\" display=\"inline\" stroke-width=\"1.45795\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M651.03044,109.07766L610.09294,109.07766\" id=\"svg_13612022-bd84-469d-80d2-d066430abf91\" stroke-miterlimit=\"4\" stroke-width=\"1.45795\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,-0.26374531,1,0,426.71876,900.60614) \" id=\"svg_1fec535e-9056-4f22-82d1-be8879ae0bc6\" display=\"inline\" stroke-width=\"1.94719\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M364.49133,268.04641L323.55383,268.04641\" id=\"svg_2b5d32c8-686c-4ab3-9335-68aeb978ff0f\" stroke-miterlimit=\"4\" stroke-width=\"1.94719\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M364.49133,266.04641L323.55383,266.04641\" id=\"svg_1c9cbd7d-0c70-45a6-bd1f-8e47fcac315c\" stroke-miterlimit=\"4\" stroke-width=\"1.94719\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(-0.36030534,0,0,-1,619.55404,956.32094) \" id=\"svg_4e14c78e-a57d-4ef8-b909-afd96ce064cb\" display=\"inline\" stroke-width=\"1.66596\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M-256.88525,111.07766L-297.82275,111.07766\" id=\"svg_b07c475a-23d6-4bf8-a8bf-5c650d637e51\" stroke-miterlimit=\"4\" stroke-width=\"1.66596\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M-256.88525,109.07766L-297.82275,109.07766\" id=\"svg_3142d859-ca25-4edf-9147-f47924364b1d\" stroke-miterlimit=\"4\" stroke-width=\"1.66596\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(-0.31526717,0,0,-1,668.89878,956.32094) \" id=\"svg_271ac66a-a3d7-442e-b8f9-ad69ef6603ed\" display=\"inline\" stroke-width=\"1.78099\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M-330.3349,111.07766L-371.2724,111.07766\" id=\"svg_866626ab-6f8d-466b-9163-2545d6a3d132\" stroke-miterlimit=\"4\" stroke-width=\"1.78099\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M-330.3349,109.07766L-371.2724,109.07766\" id=\"svg_31dd41a9-ea5f-4330-8d35-2370aca75b30\" stroke-miterlimit=\"4\" stroke-width=\"1.78099\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M744.76128,847.24328L756.35503,847.24328\" id=\"svg_e5dcb16f-c3a9-4345-9a7c-6fef36959fc2\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n   </g>\n   <g id=\"svg_edddc37b-bc81-4572-a449-5a83f6a30c42\" display=\"none\">\n    <text x=\"738.04193\" y=\"787.49292\" id=\"svg_5d94fcdf-b9de-405a-a65c-ba5dc19a3723\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"738.04193\" y=\"787.49292\" id=\"svg_30f7c458-8efc-44f3-9851-df67b8069e2e\">I</tspan>\n    </text>\n    <text x=\"737.72992\" y=\"815.18091\" id=\"svg_8052d4ce-62f0-45d5-9a2f-28b2ebc78e15\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"737.72992\" y=\"815.18091\" id=\"svg_df6512ca-7542-4298-bd8b-217d3abf9b92\">R</tspan>\n    </text>\n    <text x=\"738.04633\" y=\"760.5929\" id=\"svg_c7f54f11-fef8-42e8-8767-a22233bc58b7\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"738.04633\" y=\"760.5929\" id=\"svg_011da37e-cb8d-4bfe-a37f-1d9e1138953a\">Q</tspan>\n    </text>\n    <text x=\"557.54169\" y=\"764.79889\" id=\"svg_4128286a-258d-457d-a5d7-5fdf712361ba\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"557.54169\" y=\"764.79889\" id=\"svg_bdd8aeb2-47db-4381-a8cd-89716be149f3\">A</tspan>\n    </text>\n    <text x=\"557.54169\" y=\"674.27283\" id=\"svg_7c9a33ad-895f-4521-8d87-34fddbb2ac9c\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"557.54169\" y=\"674.27283\" id=\"svg_d3ef38c7-6ef0-4144-b2ee-6fb692c6cbe7\">B</tspan>\n    </text>\n    <text x=\"422.34564\" y=\"723.77283\" id=\"svg_6902baf8-921a-427f-bd1d-95ed177ebb0c\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"422.34564\" y=\"723.77283\" id=\"svg_279d91f8-848f-4ac3-844b-581edb0418e0\">I</tspan>\n    </text>\n    <text x=\"422.34564\" y=\"674.27283\" id=\"svg_5536cdc3-2f4a-4046-89d0-2f0179d05293\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"422.34564\" y=\"674.27283\" id=\"svg_d40f00c1-65ad-420d-8ba8-d856c0c1b3c3\">N</tspan>\n    </text>\n    <text x=\"422.34564\" y=\"605.27283\" id=\"svg_1173a510-9e18-4cfb-b583-062afa495806\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"422.34564\" y=\"605.27283\" id=\"svg_fa4c80a3-3845-4a01-a23a-d40be2313922\">M</tspan>\n    </text>\n    <text x=\"370.24561\" y=\"674.27283\" id=\"svg_17f67a1c-1ed5-4fee-98d9-067aaa55f3f3\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"370.24561\" y=\"674.27283\" id=\"svg_5fbf9415-a839-4259-afe0-2c5c9352d037\">M</tspan>\n    </text>\n    <text x=\"370.24561\" y=\"741.77271\" id=\"svg_827a814e-c2d3-45aa-abee-ba456c4d4b4f\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"370.24561\" y=\"741.77271\" id=\"svg_b93c617d-5d47-4abb-869f-bfe9d505ea76\">C</tspan>\n    </text>\n    <text x=\"370.24561\" y=\"802.07288\" id=\"svg_529d2705-f25f-4e5a-b9c4-fe34aa3a741e\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"370.24561\" y=\"802.07288\" id=\"svg_2d2a1a01-8185-445b-9b18-7bebbc81e238\">O</tspan>\n    </text>\n    <text x=\"265.84562\" y=\"802.07288\" id=\"svg_8b49c020-1814-43c2-bcd0-2ba909f1199d\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"265.84562\" y=\"802.07288\" id=\"svg_44f93828-a417-45ff-9fb9-8dbee476be1e\">P</tspan>\n    </text>\n    <text x=\"464.1456\" y=\"605.27283\" id=\"svg_c3fc5c1d-5ff0-4d81-8117-18785eb68550\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"464.1456\" y=\"605.27283\" id=\"svg_d3087544-dcb5-49f2-bbab-ff3a27ae0fde\">I</tspan>\n    </text>\n    <text x=\"634.24567\" y=\"605.27283\" id=\"svg_25c1e3ca-8212-4077-99ba-d268ae55944b\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"634.24567\" y=\"605.27283\" id=\"svg_9d3ada76-d8db-4960-b77b-62b9b702dcd1\">C</tspan>\n    </text>\n    <text x=\"422.34564\" y=\"541.3728\" id=\"svg_bdb6e3e5-0904-468d-ab31-9940596ff2dd\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"422.34564\" y=\"541.3728\" id=\"svg_78e82512-29c2-41c2-bc87-a261fb53ca8d\">I</tspan>\n    </text>\n    <text x=\"464.1456\" y=\"541.3728\" id=\"svg_40409740-487d-490f-a1d2-22115ba3fc68\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"464.1456\" y=\"541.3728\" id=\"svg_93e6abb4-2ede-4d13-a9f2-4f2c2bfbb195\">C</tspan>\n    </text>\n    <text x=\"634.24567\" y=\"434.27283\" id=\"svg_d3e544bf-fbb2-48c3-9e85-109ecdb861de\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"634.24567\" y=\"434.27283\" id=\"svg_e9683b3b-9639-4c08-832f-ef30eed6d0a6\">D</tspan>\n    </text>\n    <text x=\"634.24567\" y=\"290.27283\" id=\"svg_a56cc0f5-c76c-4ccf-8401-4db04d7b244f\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"634.24567\" y=\"290.27283\" id=\"svg_6f6eea78-4d7d-4e77-8821-b37e523b6691\">E</tspan>\n    </text>\n    <text x=\"422.34564\" y=\"487.3728\" id=\"svg_7c267bc4-8ea7-495f-a570-dbac1e4944e1\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"422.34564\" y=\"487.3728\" id=\"svg_9da261e6-fb66-475b-9743-19640e15ba83\">L</tspan>\n    </text>\n    <text x=\"422.34564\" y=\"411.77283\" id=\"svg_82515f05-6a46-4027-86d1-3c47bedc68c1\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"422.34564\" y=\"411.77283\" id=\"svg_c3883ef2-1dc0-41a0-81a0-509b74739ce6\">K</tspan>\n    </text>\n    <text x=\"634.24567\" y=\"206.57288\" id=\"svg_444c7724-a562-4c57-a57e-01ea008a84bc\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"634.24567\" y=\"206.57288\" id=\"svg_21cf5d46-82af-4fbe-9e82-e1e88c494f5f\">F</tspan>\n    </text>\n    <text x=\"422.34564\" y=\"206.57288\" id=\"svg_e7dd3b53-7a3c-4dbb-949c-0eebeaf853e8\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"422.34564\" y=\"206.57288\" id=\"svg_f5a2ac67-b6e6-49c5-a380-c45463c19909\">I</tspan>\n    </text>\n    <text x=\"504.04999\" y=\"108.58096\" id=\"svg_b6c3e4f1-d7de-45a3-8083-b50283496db2\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"504.04999\" y=\"108.58096\" id=\"svg_74d07d64-489c-4a16-bb90-91a54971d9d0\">I</tspan>\n    </text>\n    <text x=\"558.94998\" y=\"108.58096\" id=\"svg_117632c8-4019-4541-bedf-f6adb3f14245\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\">\n     <tspan x=\"558.94998\" y=\"108.58096\" id=\"svg_1ea0fa49-195b-4e05-91c8-ac00a1fccb63\">H</tspan>\n    </text>\n    <text x=\"646.25\" y=\"108.58096\" id=\"svg_a0363437-9db5-4d63-8515-7c31c5fbc577\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"745.25\" y=\"135.58096\" id=\"svg_f6b66f5b-b9f1-4c4c-b696-324250b6197e\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n   </g>\n   <g id=\"svg_39b816bd-470d-478c-8828-5932d5a2e8c5\" display=\"inline\">\n    <path d=\"M567.87626,797.61969L570.0404,789.5318L570.0404,789.5318L570.0404,789.5318L564.04798,789.5318L564.04798,789.5318L562.68253,794.62863\" id=\"svg_046babea-69da-4c41-9ff1-964e2a3867c0\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\"/>\n    <path d=\"M567.87626,797.61969L558.06534,805.15623L556.49638,799.37127L562.68253,794.62863L567.87626,797.61969z\" id=\"svg_d14fbfdb-5d32-4602-8830-ff46ed61ead0\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\"/>\n    <path d=\"M549.70016,805.16553L539.8667,797.64092L545.04517,794.62353L551.20928,799.36458L549.70016,805.16553z\" id=\"svg_5e44e1d0-fbe9-44b1-a4f5-992912f673d3\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\"/>\n    <path d=\"M556.49638,799.37127L551.20928,799.36427L549.70016,805.16522L558.06534,805.15622L556.49638,799.37127z\" id=\"svg_b49bab9d-b1a3-4832-a652-ee2f850ecf67\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\"/>\n    <path d=\"M543.68268,789.5318L545.04517,794.62353L539.8667,797.64092L537.69026,789.5318L537.69026,789.5318L543.68268,789.5318z\" id=\"svg_4b308898-6f13-46c0-963f-597f7c315e2d\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\"/>\n    <g transform=\"matrix(1.03375,0,0,2.5662797,-63.135239,-961.36707) \" id=\"svg_f3eafe96-21b8-4cff-99b8-121f770b076e\" display=\"inline\">\n     <path d=\"M624.79254,605.20482L624.79254,613.25999\" id=\"svg_4f10a645-abb7-4ec5-8171-7ef1046bdefa\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61396\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M621.19254,605.2033L621.19254,613.25999\" id=\"svg_4a856d32-0670-4e5f-b8b0-0c08636e7438\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61396\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M617.59254,605.2033L617.59254,613.25999\" id=\"svg_f29c9e1c-3eb3-44dc-9bb7-4fcd6b8d28f3\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61396\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M613.99254,604.4099L613.99254,615.30636\" id=\"svg_fc2665f3-f260-47fd-ad2a-240ada77eeb8\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61396\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M610.39254,604.4099L610.39254,615.30636\" id=\"svg_e27ff9fa-db97-4d75-a711-e63fea544426\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61396\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M606.79254,604.4099L606.79254,615.30636\" id=\"svg_05793fa7-d441-41a9-af70-8d1e798981ae\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61396\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M603.19254,604.4099L603.19254,615.30636\" id=\"svg_9b0a3386-d9f3-4f1e-b2c6-5d4653733d5c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61396\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M599.59254,604.4099L599.59254,615.30636\" id=\"svg_99b5da21-db1a-44c7-b923-530156725b5e\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61396\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M595.99254,604.4099L595.99254,615.30636\" id=\"svg_7ffe9249-8e47-47bf-80e9-81ce6f03b9a8\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61396\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M592.39254,604.4099L592.39254,615.30636\" id=\"svg_f80d96e0-b0b1-4993-b8ed-8d2c9c651ddf\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61396\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M628.39254,605.20482L628.39254,613.25999\" id=\"svg_43841c1f-8f23-4bf1-801b-fe85ffd7d947\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61396\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g id=\"svg_35bddc86-d713-4313-a2ba-e626d398eb85\">\n     <g id=\"svg_9c788038-af89-47b9-a79c-011db0343a4f\">\n      <path d=\"M812.875,82.34375L806.875,84.8125L806.875,108.84375L806.875,113.65625L806.875,128.6875L812.875,131.15625L812.875,113.65625L812.875,108.84375L812.875,82.34375z\" id=\"svg_11223820-1a5f-4d09-b667-abd90372f4a2\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n      <path d=\"M806.875,128.65625L804.28125,131.21875L804.28125,131.24995L804.28125,139.7187L812.875,131.12495L806.875,128.6562L806.875,128.65625z\" id=\"svg_712851f0-a16f-4073-85db-d92cd496d361\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     </g>\n     <g transform=\"matrix(1,0,0,-1,0,270.05496) \" id=\"svg_d1467206-f034-407b-b2eb-a196a5d236bd\">\n      <path d=\"M806.875,185.21875L804.28125,187.78125L804.28125,187.81245L804.28125,196.2812L812.875,187.68745L806.875,185.2187L806.875,185.21875z\" id=\"svg_11787d77-6d7f-4f1b-b2d1-9149c3cdfb6a\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     </g>\n    </g>\n    <g id=\"svg_2732c2b1-f418-4570-9157-5726d2d30063\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M707.40625,39.625L698.78125,48.25L707.21875,48.25L709.875,45.625L707.40625,39.625z\" id=\"svg_0749c378-401c-4f30-8d99-13709b855c12\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M709.88348,45.625C722.32098,45.625 748.8634,45.625 748.8634,45.625L751.33215,39.625L707.41473,39.625L709.88348,45.625z\" id=\"svg_b4b23989-b24f-4874-b370-44ed35a71d80\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M751.34375,39.625L748.875,45.625L751.5,48.25L759.96875,48.25L751.34375,39.625z\" id=\"svg_87f0f993-2e6d-4e28-8d94-2101918d4e97\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <g id=\"svg_a41d33ec-e43a-4f02-9168-ca73628fd1d6\" display=\"inline\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\">\n     <path d=\"M493.80809,28.71731C506.24559,28.71731 539.05314,28.71731 539.05314,28.71731L541.52189,22.71731L491.33934,22.71731L493.80809,28.71731z\" id=\"svg_321153ac-149a-4209-b02b-fe7c7d195cee\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\"/>\n     <path d=\"M539.05314,28.71731L546.4465,36.12375L554.91142,36.12755L541.52189,22.71728L539.05314,28.71731z\" id=\"svg_172ee7d8-f027-4c5e-9a69-e6d350aea5c1\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\"/>\n     <path d=\"M491.33934,22.71731L477.90169,36.12661L486.37962,36.12801L493.80809,28.71732L491.33934,22.71731z\" id=\"svg_104cf81f-f948-4c1c-8561-2ed9391a8ddb\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\"/>\n     <path d=\"M546.4375,36.125L546.4375,48.15625L554.90625,48.15625L554.90625,36.125L546.4375,36.125z\" id=\"svg_8c335643-28ea-4006-b0db-b91ddaf8f98f\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\"/>\n     <path d=\"M477.90625,36.125L477.90625,48.0625L486.375,48.0625L486.375,36.125L477.90625,36.125z\" id=\"svg_2c515f11-5119-4241-8fc5-48b698eab86d\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\"/>\n    </g>\n    <g transform=\"matrix(0,1,-1,0,558.84174,417.27997) \" id=\"svg_aa05e4cf-0d2d-4b5f-9e71-84044fb30799\" display=\"inline\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M75.46003,-141.65826L83.92878,-141.65826L86.49128,-144.22076L84.02253,-150.22076L75.46003,-141.65826z\" id=\"svg_53bbe2bf-3968-4f62-b481-eefcabe13bdb\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M86.49128,-144.22076C98.92878,-144.22076 127.47701,-144.22076 127.47701,-144.22076L129.94576,-150.22076L84.02253,-150.22076L86.49128,-144.22076z\" id=\"svg_81227bd2-b367-4b84-9c75-ca4a039d2922\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M127.46273,-144.22076L130.02523,-141.65826L138.49398,-141.65826L129.93148,-150.22076L127.46273,-144.22076z\" id=\"svg_97c7a197-2388-4c52-8729-233e3ba354b6\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <path d=\"M258.53125,127.125L258.53125,154.71875L258.53125,160.71875L264.53125,160.71875L269.75,160.71875L269.75,172.875L315.75,172.875L315.75,160.71875L350.71875,160.71875L384.0625,160.71875L384.0625,601.125L352.21875,601.125L346.21875,601.125L346.21875,607.125L346.21875,700.375L311.09375,700.375L311.09375,693.46875L294.25,693.46875L294.25,700.375L247.375,700.375L241.375,700.375L241.375,706.375L241.375,740L253.375,740L253.375,712.375L264.25,712.375L264.25,717.21875L275.6875,717.21875L275.6875,712.375L286.3125,712.375L286.3125,717.21875L297.78125,717.21875L297.78125,712.375L308.53125,712.375L308.53125,758.84375L314.53125,758.84375L314.53125,754.4375L365.78125,754.4375L365.78125,750.3125L314.53125,750.3125L314.53125,712.375L353.75,712.375L358.21875,712.375L369.78125,712.375L369.78125,706.4375L358.21875,706.4375L358.21875,703.15625L358.21875,700.375L358.21875,678.71875L369.78125,678.71875L369.78125,672.78125L358.21875,672.78125L358.21875,613.125L372.09375,613.125L376.125,617.15625L379.3125,613.9375L383.0625,617.6875L379.84375,620.875L384.0625,625.09375L384.0625,672.78125L378.34375,672.78125L378.34375,678.71875L384.0625,678.71875L384.0625,685.71875L396.0625,685.71875L396.0625,637.125L401.625,637.125L401.625,625.125L396.0625,625.125L396.0625,569.34375L401.625,569.34375L401.625,565.34375L396.0625,565.34375L396.0625,526.21875L401.625,526.21875L401.625,522.21875L396.0625,522.21875L396.0625,445.96875L401.625,445.96875L401.625,441.96875L396.0625,441.96875L396.0625,389.71875L472.9375,389.71875L472.9375,397.53125L468.875,397.53125L468.875,406.5625L472.9375,406.5625L472.9375,413.28125L468.875,413.28125L468.875,422.3125L472.9375,422.3125L472.9375,441.96875L415.9375,441.96875L415.9375,445.96875L472.9375,445.96875L472.9375,522.21875L415.9375,522.21875L415.9375,526.21875L472.9375,526.21875L472.9375,565.75L415.9375,565.75L415.9375,569.34375L472.9375,569.34375L472.9375,573.6875L468.875,573.6875L468.875,582.78125L472.9375,582.78125L472.9375,592.625L468.875,592.625L468.875,601.6875L472.9375,601.6875L472.9375,604.8125L481.9375,604.8125L481.9375,569.34375L516.65625,569.34375L516.65625,582.375L522.59375,582.375L522.59375,519.125L516.65625,519.125L516.65625,522.625L499.71875,522.625L499.71875,526.21875L516.65625,526.21875L516.65625,565.75L481.9375,565.75L481.9375,526.21875L486.34375,526.21875L486.34375,522.625L481.9375,522.625L481.9375,436.40625L473.53125,436.40625L473.53125,427.53125L481.9375,427.53125L481.9375,381.15625L472.9375,381.15625L472.9375,385.71875L396.0625,385.71875L396.0625,322.21875L472.9375,322.21875L472.9375,332.71875L468.875,332.71875L468.875,341.78125L472.9375,341.78125L472.9375,353.4375L468.875,353.4375L468.875,362.46875L472.9375,362.46875L472.9375,370.8125L481.9375,370.8125L481.9375,313.65625L472.9375,313.65625L472.9375,318.21875L396.0625,318.21875L396.0625,255.46875L472.9375,255.46875L472.9375,267.03125L468.875,267.03125L468.875,276.0625L472.9375,276.0625L472.9375,285.9375L468.875,285.9375L468.875,294.96875L472.9375,294.96875L472.9375,303.3125L481.9375,303.3125L481.9375,184.25L486.75,184.25L486.75,180.25L481.9375,180.25L472.9375,180.25L468.125,180.25L468.125,184.25L472.9375,184.25L472.9375,251.46875L443.78125,251.46875L443.78125,184.25L458.40625,184.25L458.40625,180.25L443.78125,180.25L439.78125,180.25L439.78125,184.25L439.78125,251.46875L396.0625,251.46875L396.0625,160.71875L426.0625,160.71875L426.0625,184.25L427.3125,184.25L430.0625,184.25L431.71875,184.25L431.71875,180.25L430.0625,180.25L430.0625,160.71875L430.0625,157.1875L430.0625,148.71875L371.21875,148.71875L270.53125,148.71875L270.53125,127.125L258.53125,127.125zM384.625,164.4375L395.5,164.4375L395.5,176.4375L384.625,176.4375L384.625,164.4375zM537.34375,180.21875L537.34375,180.24995L531.9375,180.24995L531.9375,184.24995L537.34375,184.24995L537.34375,217.4062L521.8125,217.4062L521.8125,184.24995L521.8125,181.81245L521.8125,180.24995L504.4375,180.24995L504.4375,184.24995L512.8125,184.24995L512.8125,482.93745L512.8125,483.8437L512.8125,487.43745L512.8125,499.56245L521.8125,499.56245L521.8125,491.93745L574.46875,491.93745L574.46875,576.31245L555.25,576.31245L555.25,569.8437L549.25,569.8437L549.25,579.31245L549.25,582.31245L552.25,582.31245L574.46875,582.31245L574.46875,591.74995L586.46875,591.74995L586.46875,527.5937L659.5,527.5937L659.5,521.6562L586.46875,521.6562L586.46875,442.49995L586.46875,436.49995L580.46875,436.49995L575.09375,436.49995L575.09375,415.1562L580.46875,415.1562L586.46875,415.1562L586.46875,409.1562L586.46875,333.68745L659.5,333.68745L659.5,327.68745L586.46875,327.68745L586.46875,294.99995L586.46875,257.2187L586.46875,256.5937L586.46875,234.4062L586.46875,233.7187L586.46875,230.2187L586.46875,180.2187L574.5,180.2187L574.5,196.7187L546.34375,196.7187L546.34375,180.2187L537.34375,180.2187L537.34375,180.21875zM551.28125,197.3125L565.09375,197.3125L565.09375,205.125L551.28125,205.125L551.28125,197.3125zM546.34375,205.71875L574.46875,205.71875L574.46875,224.21875L569.09375,224.21875L563.09375,224.21875L563.09375,230.21875L563.09375,295L563.09375,301L569.09375,301L574.46875,301L574.46875,403.15625L569.09375,403.15625L563.09375,403.15625L563.09375,409.15625L563.09375,442.5L563.09375,448.5L569.09375,448.5L574.46875,448.5L574.46875,482.9375L521.8125,482.9375L521.8125,226.40625L541.84375,226.40625L546.34375,226.40625L546.34375,221.90625L546.34375,205.71875zM525.375,218L535.90625,218L535.90625,225.78125L525.375,225.78125L525.375,218zM405.59375,206L416.46875,206L416.46875,223.25L405.59375,223.25L405.59375,206zM596.0625,222.125L601.4375,222.125L606.84375,222.125L606.84375,244.3125L601.4375,244.3125L596.0625,244.3125L596.0625,222.125zM534.375,252L542.1875,252L542.1875,265.6875L534.375,265.6875L534.375,252zM384.625,270.5L395.5,270.5L395.5,304.625L384.625,304.625L384.625,270.5zM663.15625,307L670.96875,307L670.96875,320.6875L663.15625,320.6875L663.15625,307zM534.375,321.15625L545.25,321.15625L545.25,354.59375L534.375,354.59375L534.375,321.15625zM663.15625,368.1875L670.96875,368.1875L670.96875,381.875L663.15625,381.875L663.15625,368.1875zM534.375,387.6875L545.25,387.6875L545.25,409.5L534.375,409.5L534.375,387.6875zM663.15625,431.1875L670.96875,431.1875L670.96875,446.75L663.15625,446.75L663.15625,431.1875zM384.625,464.625L395.5,464.625L395.5,493.8125L384.625,493.8125L384.625,464.625zM800.34375,450.78125L813.71875,450.78125L813.71875,457.125L800.34375,457.125L800.34375,450.78125zM821.5,450.78125L827.8125,450.78125L827.8125,457.125L821.5,457.125L821.5,450.78125zM833.78125,450.78125L840.09375,450.78125L840.09375,457.125L833.78125,457.125L833.78125,450.78125zM843.53125,450.78125L850.625,450.78125L850.625,457.125L843.53125,457.125L843.53125,450.78125zM956.8125,488.21875L956.8125,494.15625L987.59375,494.15625L987.59375,488.21875L956.8125,488.21875zM663.15625,495.65625L674.03125,495.65625L674.03125,522.78125L663.15625,522.78125L663.15625,495.65625zM663.15625,543.6875L674.03125,543.6875L674.03125,562.09375L663.15625,562.09375L663.15625,543.6875zM625.34375,592.4375L636.21875,592.4375L636.21875,611.46875L625.34375,611.46875L625.34375,592.4375zM662.59375,662.3125L662.59375,673L656.875,673L656.875,678.9375L662.59375,678.9375L662.59375,716.875L656.875,716.875L656.875,721L662.59375,721L662.59375,736.75L656.875,736.75L656.875,740.9375L662.59375,740.9375L662.59375,805.96875L593.0625,805.96875L593.0625,796.125L596.0625,796.125L596.0625,784.8125L593.0625,784.8125L593.0625,768.34375L596.0625,768.34375L596.0625,757.03125L593.0625,757.03125L593.0625,740.9375L644.3125,740.9375L644.3125,736.75L587.0625,736.75L587.0625,745.34375L584.0625,745.34375L584.0625,756.65625L587.0625,756.65625L587.0625,773.125L584.0625,773.125L584.0625,784.4375L587.0625,784.4375L587.0625,805.96875L531.90625,805.96875L531.90625,759.6875L519.90625,759.6875L519.90625,811.96875L519.90625,817.96875L525.90625,817.96875L668.59375,817.96875L674.59375,817.96875L674.59375,811.96875L674.59375,742.5L692.5625,742.5L692.5625,696.78125L674.59375,696.78125L674.59375,662.3125L662.59375,662.3125zM600.1875,667.5L618.09375,667.5L618.09375,678.375L600.1875,678.375L600.1875,667.5zM667.15625,701.90625L686.53125,701.90625L686.53125,733.1875L667.15625,733.1875L667.15625,701.90625zM687.125,707.59375L691.9375,707.59375L691.9375,723.8125L687.125,723.8125L687.125,707.59375zM550.0625,806.5L568.71875,806.5L568.71875,817.375L550.0625,817.375L550.0625,806.5zM599.3125,806.5L619.53125,806.5L619.53125,817.375L599.3125,817.375L599.3125,806.5zM638.75,806.5L655.3125,806.5L655.3125,817.375L638.75,817.375L638.75,806.5z\" id=\"svg_1d4e565c-f048-4d35-89f1-2add0360cf7b\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <g id=\"svg_1dbb6cd6-61b4-4702-947a-82dc08b73aac\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M294.5,39.65625L285.90625,48.25L294.34375,48.25L296.96875,45.65625L294.5,39.65625z\" id=\"svg_b699005a-9359-4e42-9f32-b90b9196cf4f\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M296.98397,45.64271C309.42147,45.64271 338.89309,45.64271 338.89309,45.64271L341.36184,39.64271L294.51522,39.64271L296.98397,45.64271z\" id=\"svg_687aea45-c347-4238-86b5-65fdd650e9e8\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M341.375,39.65625L338.90625,45.65625L341.5,48.25L349.96875,48.25L341.375,39.65625z\" id=\"svg_2d6a7623-39c3-45aa-88d8-03514c605683\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <path d=\"M258.53125,48.25L258.53125,54.25L258.53125,84.78125L270.53125,84.78125L270.53125,60.25L294.34375,60.25L294.34375,48.25L264.53125,48.25L258.53125,48.25z\" id=\"svg_37cf31df-c125-4a74-939e-56dc04cdada9\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M383.5625,59.6875L383.5625,48.8125L442.5,48.8125L442.5,59.6875L383.5625,59.6875zM546.449,60.25L707.21875,60.25L707.21875,48.25L546.449,48.15625L546.449,60.25zM341.5,48.25L341.5,60.25L486.364,60.25L486.364,48.0625L341.5,48.25zM599.725,48.8125L659.5625,48.8125L659.5625,59.6875L599.725,59.6875L599.725,48.8125z\" id=\"svg_3a462e5b-a73e-4768-9c0c-146f66c4c1bd\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#595959\"/>\n    <path d=\"M751.5,48.25L751.5,60.25L792.28125,60.25L792.28125,82.28125L804.28125,82.28125L804.28125,73.78125L804.28125,54.25L804.28125,48.25L798.28125,48.25L751.5,48.25z\" id=\"svg_aec515f0-1c01-4005-85e2-8759ab8649f4\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M792.28125,131.21875L792.28125,148.71875L678.28125,148.71875L678.28125,160.71875L688.5,160.71875L688.5,176.21875L700.5,176.21875L700.5,160.71875L798.28125,160.71875L804.28125,160.71875L804.28125,154.71875L804.28125,131.21875L792.28125,131.21875z\" id=\"svg_118cbdf7-06bd-4266-91a4-aa208c12bfc4\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M445.375,148.71875L445.375,160.71875L488.84375,160.71875L501.34375,160.71875L531.625,160.71875L544.8125,160.71875L658.65625,160.71875L658.65625,148.71875L531.625,148.71875L531.625,153.65625L501.34375,153.65625L501.34375,148.71875L445.375,148.71875z\" id=\"svg_5619a30e-9575-49b9-b667-456b2df25434\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#595959\"/>\n    <path d=\"M688.5,218L688.5,327.6875L678.25,327.6875L678.25,333.6875L688.5,333.6875L688.5,334.9375L688.5,337.65625L690.625,337.65625L700.5,337.65625L700.5,218L688.5,218zM689.09375,242.9375L699.96875,242.9375L699.96875,264.6875L689.09375,264.6875L689.09375,242.9375zM689.09375,297.75L699.96875,297.75L699.96875,315.0625L689.09375,315.0625L689.09375,297.75zM688.5,381.40625L688.5,385.84375L688.5,498.84375L688.5,501.21875L690.625,501.21875L700.5,501.21875L700.5,381.40625L690.625,381.40625L688.5,381.40625zM689.09375,406.96875L699.96875,406.96875L699.96875,428.6875L689.09375,428.6875L689.09375,406.96875zM689.09375,453.53125L699.96875,453.53125L699.96875,475.28125L689.09375,475.28125L689.09375,453.53125zM688.5,547.28125L688.5,549.75L688.5,625.125L678.25,625.125L678.25,637.125L688.5,637.125L688.5,655.90625L688.5,659.78125L690.625,659.78125L700.5,659.78125L700.5,547.28125L690.625,547.28125L688.5,547.28125zM689.09375,567.0625L699.96875,567.0625L699.969,584.34375L689.09375,584.34375L689.09375,567.0625zM516.65625,599.49375L516.65625,625.125L481.93125,625.125L481.93125,617.78125L472.94375,617.78125L472.94375,625.125L424.03125,625.125L424.03125,637.125L482.15625,637.125L488.78125,637.125L516.65625,637.125L516.65625,709.78125L522.59375,709.78125L522.59375,637.125L527.0625,637.125L527.0625,625.125L522.59375,625.125L522.59375,599.49375L516.65625,599.49375zM683.15625,601L694.0315,601L694.0315,618.5L683.15625,618.5L683.15625,601zM402.03125,610.93125L402.03125,616.18125L376.8125,616.18125L376.8125,623.61875L368,623.61875L368,635.61875L487.0625,635.61875L487.0625,623.61875L414.03125,623.61875L414.03125,610.93125L402.03125,610.93125zM676.5,708.53125L676.5,710.34375L676.5,740.25L780.28125,740.25L780.28125,766.84375L780.28125,772.84375L784.1875,772.84375L792.28125,772.84375L792.28125,734.25L792.28125,728.25L786.28125,728.25L688.5,728.25L688.5,708.53125L678.625,708.53125L676.5,708.53125zM290.25,632.61875L290.25,640.15L290.25,644.61875L290.25,691.93125L302.25,691.93125L302.25,644.61875L357.25,644.61875L358.78125,642.775L361.78125,639.15C361.78125,639.15 366.03125,633.9 366.65625,633.025C366.72635,632.9268 366.8459,632.75082 366.9375,632.61875L365.96875,632.61875L363.96875,632.61875L290.25,632.61875zM520.78125,730.75L560.65625,730.75L560.65625,741.625L520.78125,741.625L520.78125,730.75zM352.1875,635.11875C350.16607,636.49413 347.84595,637.81807 347.25,638.24375C346.375,638.86875 342.5,643.11875 342.5,643.11875C342.5,643.11875 341.21472,644.37542 340.1875,645.4L340.1875,681.15L352.1875,681.15L352.1875,641.4625L352.1875,638.0875L352.1875,635.11875zM384.25,667.025L384.25,672.7125L384.25,747.36875L384.25,753.36875L390.25,753.36875L494.03125,753.36875L500.03125,753.36875L500.03125,747.36875L500.03125,715.4L488.03125,715.4L488.03125,721.93125L488.03125,741.36875L396.25,741.36875L396.25,667.025L384.25,667.025zM407.875,741.93125L422.625,741.93125L422.625,752.80625L407.875,752.80625L407.875,741.93125zM468.78125,741.93125L481.6875,741.93125L481.6875,752.80625L468.78125,752.80625L468.78125,741.93125zM440.5,747.43125L452.09375,747.43125L452.09375,752.80625L440.5,752.80625L440.5,747.43125z\" id=\"svg_a681e0c0-031e-4d6f-ae4e-185e66ed5e8f\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#595959\"/>\n    <path d=\"M516.65625,723.71875L516.65625,730.21875L456.84375,730.21875L450.84375,730.21875L450.84375,736.21875L450.84375,779.28125L462.84375,779.28125L462.84375,742.21875L519.09375,742.21875L519.09375,789.53125L531.125,789.53125L531.125,742.21875L531.125,737.75L531.125,730.21875L522.59375,730.21875L522.59375,723.71875L516.65625,723.71875zM469.34375,730.75L511.8125,730.75L511.8125,741.625L469.34375,741.625L469.34375,730.75z\" id=\"svg_3367c568-4767-4a43-8464-8398b205cb4d\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#595959\"/>\n    <path d=\"M255.875,124.5L249.875,126.96875L258.53125,135.625L258.53125,127.15625L258.53125,127.12505L255.875,124.50005L255.875,124.5z\" id=\"svg_e4825b16-ab10-497f-872a-feb09b5af04d\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    <path d=\"M255.875,124.5C255.875,112.0625 255.875,87.4375 255.875,87.4375L249.875,84.96875L249.875,126.96875L255.875,124.5z\" id=\"svg_fe870a50-0372-4074-8b3b-bec36c1ffd0a\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    <path d=\"M258.53125,76.3125L249.875,84.96875L255.875,87.4375L258.53125,84.78125L258.53125,76.3125z\" id=\"svg_adfaab42-c70a-48cf-9f73-660bb7862765\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    <g transform=\"matrix(0,1,1,0,-809.5162,148.90351) \" id=\"svg_4fc0656b-c3dd-4587-b83e-dad44dccccbe\" stroke-linejoin=\"round\" stroke-linecap=\"round\"/>\n    <path d=\"M549.25,491.9375L549.25,558.09375L555.25,558.09375L555.25,491.9375L549.25,491.9375z\" id=\"svg_1d8c3d60-deb1-4a1f-aede-10536663bb0b\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    <g transform=\"matrix(0,1,-1,0,558.84174,92.32122) \" id=\"svg_c802755b-8a1c-478d-99ed-e8e32af7f7ae\" display=\"inline\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M75.46003,-141.65826L83.89753,-141.65826L86.49128,-144.22076L84.02253,-150.22076L75.46003,-141.65826z\" id=\"svg_6d42c8c7-97cd-4e7d-a652-45ddb2788d21\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M86.49128,-144.22076C98.92878,-144.22076 123.15378,-144.22076 123.15378,-144.22076L125.62253,-150.22076L84.02253,-150.22076L86.49128,-144.22076z\" id=\"svg_198ace98-6672-40f6-aebe-6780b9bcd1d5\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M123.14753,-144.22076L125.67878,-141.65826L125.70998,-141.65826L134.17873,-141.65826L125.61623,-150.22076L123.14748,-144.22076L123.14753,-144.22076z\" id=\"svg_8fb1e407-0ead-4d55-9d33-4359d5718a36\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <g transform=\"matrix(0,1,-1,0,558.84174,253.72747) \" id=\"svg_13dd3946-713e-4f66-a2a2-6726a143b6fd\" display=\"inline\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M75.46003,-141.65826L83.92878,-141.65826L86.49128,-144.22076L84.02253,-150.22076L75.46003,-141.65826z\" id=\"svg_42655a21-c803-4c60-920a-1ee4affdbd2d\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M86.49128,-144.22076C98.92878,-144.22076 125.13056,-144.22076 125.13056,-144.22076L127.59931,-150.22076L84.02253,-150.22076L86.49128,-144.22076z\" id=\"svg_b8bae498-da31-41cc-9845-8af50754f187\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M125.11628,-144.22076L127.67878,-141.65826L136.14753,-141.65826L127.58503,-150.22076L125.11628,-144.22076z\" id=\"svg_c32d945b-845d-4a64-aaee-4ab28d47b66d\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <g transform=\"matrix(0,1,-1,0,558.84174,575.83702) \" id=\"svg_2e89976e-79dd-40ce-a3ab-4d5ceb44a310\" display=\"inline\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M75.46003,-141.65826L83.92878,-141.65826L86.49128,-144.22076L84.02253,-150.22076L75.46003,-141.65826z\" id=\"svg_b01040c0-42fd-4a75-962a-36d8240f9201\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M86.49128,-144.22076C98.92878,-144.22076 130.13282,-144.22076 130.13282,-144.22076L132.60157,-150.22076L84.02253,-150.22076L86.49128,-144.22076z\" id=\"svg_4feb96fa-6fc5-4401-a0e3-dae9c848deeb\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M130.11854,-144.22076L132.68104,-141.65826L141.14979,-141.65826L132.58729,-150.22076L130.11854,-144.22076z\" id=\"svg_c3753c38-54b2-4d29-90f3-4eb4b6d53eee\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <g transform=\"matrix(0,-1,1,0,6.235806,928.72291) \" id=\"svg_93c6e953-9285-4caa-9ba3-9b5c23c859d0\" display=\"inline\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M144.41041,226.26419L141.94166,220.26419L127.09791,235.13919L135.56666,235.13919L144.41041,226.26419z\" id=\"svg_817f23a4-68c8-42cc-aa99-2e6cabf64221\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M144.42253,226.27924C156.86003,226.27924 179.92434,226.27924 179.92434,226.27924L182.39309,220.27924L141.95378,220.27924L144.42253,226.27924z\" id=\"svg_20b0db49-cbec-42d0-8b69-a5cf92231903\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M197.19166,235.13919L182.37916,220.26419L179.91041,226.26419L188.72291,235.13919L188.75411,235.13919L197.19161,235.13919L197.19166,235.13919z\" id=\"svg_6d140011-090c-41dc-b8d0-0d64f479a77b\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <path d=\"M546.34375,180.21865L574.5,180.21865\" id=\"svg_a2adf966-0959-4624-b457-ccca859804b6\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M560.42187,180.21865L560.42187,196.71875\" id=\"svg_e955d6aa-5633-4020-b1c7-c9255601a487\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M560.42187,180.21865L550.89553,196.71875\" id=\"svg_b984ba13-db78-4615-aa01-8845b7a352cb\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M560.42187,180.21865L546.34375,183.99087\" id=\"svg_9235e7e3-cb3d-4b4a-83c4-9abfc129c7e0\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M560.42187,180.21865L546.34375,190.14666\" id=\"svg_fee3fef5-dcbe-42ce-b2cd-47e0d5fed552\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(-1,0,0,1,750.345,0) \" id=\"svg_28b0c8a0-f9e0-4c85-982f-42ba0f6aea2e\">\n     <path d=\"M189.92187,180.21865L180.39553,196.71875\" id=\"svg_e6c252d0-ddb5-47c5-81d7-dd1d2413da23\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M189.92187,180.21865L175.84375,183.99087\" id=\"svg_5137edcd-142a-46f5-b6a5-8fde4abaabb1\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M189.92187,180.21865L175.84375,190.14666\" id=\"svg_446eefe7-33c6-49eb-91dc-fb142fe3dcff\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M472.91862,562.14715L454.18957,562.14715\" id=\"svg_dad60607-16d2-4c88-8896-8ac2bbea84a3\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M472.91862,558.54715L454.18957,558.54715\" id=\"svg_3111a696-1b14-4dc7-b0c0-dc71ba7d4145\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M472.91862,554.94715L454.18957,554.94715\" id=\"svg_99ac66f3-e56b-41e2-b1b9-73fb04cbd5d4\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M472.91862,551.34715L454.18957,551.34715\" id=\"svg_5a7bcc9d-e7a4-4209-8f9d-2c3d79e463b5\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(1,0,0,1.2950287,-266.97809,-32.52592) \" id=\"svg_a58956c7-4976-4583-9d4e-9d325c389470\" display=\"inline\">\n     <path d=\"M623.64059,590.70712L623.64059,604.48837\" id=\"svg_aa0c4569-4d52-4248-8d60-ffd590eeb6f6\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M620.04059,590.70712L620.04059,604.48837\" id=\"svg_bded2345-2a56-43d6-9082-6f32ad0db9d7\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M616.44059,590.70712L616.44059,604.48837\" id=\"svg_6f611217-bb16-476e-8042-e60fbb4d4dd0\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M612.84059,590.70712L612.84059,604.48837\" id=\"svg_40ad3a59-63fb-4308-ab50-f3bdae3f659c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M609.24059,590.70712L609.24059,604.48837\" id=\"svg_13a0a9c7-e4fa-4c32-b767-2a0ff9285b21\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M605.64059,590.70712L605.64059,604.48837\" id=\"svg_c4a2cf0e-0bb5-4b9a-ba3b-fa86d424bb79\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M602.04059,590.70712L602.04059,604.48837\" id=\"svg_e397d4d9-93ef-4fed-88fb-2f520d0ba22c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M598.44059,590.70712L598.44059,604.48837\" id=\"svg_14f65f1e-12e2-4b31-ab66-3c3d6c7590b8\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.87874\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M331.4625,731.49713L314.53125,713.65\" id=\"svg_a56cab8b-9476-4589-aa3f-2a561c3b035c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M331.4625,731.49713L314.52812,724.38628\" id=\"svg_48e25b61-284c-4de0-b82c-73a82133ae1e\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M331.45156,731.49713L314.53125,731.49713\" id=\"svg_9a984bf6-13a2-489e-a39f-fc98f0fbe6af\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(0,1,-2.3265297,0,1928.3552,380.24691) \" id=\"svg_b982f37e-451f-4efc-9683-25c43b58bbfc\" display=\"inline\">\n     <path d=\"M395.70934,532.9204L395.70934,546.70165\" id=\"svg_6afe32d4-5f80-4266-9fdb-d2ddcd48587c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.65561\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M392.10934,532.9204L392.10934,546.70165\" id=\"svg_98567b62-606e-4159-b39f-a03611b9c7e7\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.65561\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M388.50934,532.9204L388.50934,546.70165\" id=\"svg_aea0d2c5-e02b-4f14-86e4-05a6d37d490a\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.65561\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M384.90934,532.9204L384.90934,546.70165\" id=\"svg_74b8ba01-0e9e-4496-95f7-26dc3bfff601\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.65561\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M565.09748,201.21928L551.29521,201.21928\" id=\"svg_dcec1be5-baf9-42b9-9792-1af9e9ff5c36\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(0,1,-1,0,662.623,680.87999) \" id=\"svg_264cbc9b-a12f-4ba1-9056-86dda915190f\" display=\"inline\" stroke-linejoin=\"round\" stroke-linecap=\"round\">\n     <path d=\"M83.49362,-141.65826L91.96237,-141.65826L94.52487,-144.22076L92.05612,-150.22076L83.49362,-141.65826z\" id=\"svg_ff8175ed-d231-4937-944a-7dbb16f1c8ec\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M94.52487,-144.22076C106.96237,-144.22076 130.13282,-144.22076 130.13282,-144.22076L132.60157,-150.22076L92.05612,-150.22076L94.52487,-144.22076z\" id=\"svg_e8e1d36e-9d85-4087-a4f7-e71e073f4b25\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n     <path d=\"M130.11854,-144.22076L132.68104,-141.65826L141.14979,-141.65826L132.58729,-150.22076L130.11854,-144.22076z\" id=\"svg_3669d13d-a9b1-4d04-9f6b-9609ee034563\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    </g>\n    <rect width=\"5.87772\" height=\"12.55899\" x=\"783.65363\" y=\"-543.68365\" transform=\"matrix(0,1,-1,0,0,0) \" id=\"svg_5d306770-ed07-474e-86de-3d262881673a\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\"/>\n    <g transform=\"matrix(0,1,-2.6791374,0,1906.6553,380.24691) \" id=\"svg_4e602d9b-3ca4-4d47-84a6-1e918dcead5b\" display=\"inline\">\n     <path d=\"M395.70934,543.40004L395.70934,557.18129\" id=\"svg_ea415a72-d171-4ed1-8eee-c463e92ff1d8\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61095\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M392.10934,543.40004L392.10934,557.18129\" id=\"svg_7100eeb0-ee21-4537-aaf3-6af2c0bf2f62\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61095\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M388.50934,543.40004L388.50934,557.18129\" id=\"svg_d2ee28f4-c96a-4c0a-91b9-ea5b9db0858c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61095\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M384.90934,543.40004L384.90934,557.18129\" id=\"svg_2aedf7e4-7874-4496-a9aa-f5d79d5690a5\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.61095\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(1,0,0,1.7952947,12.747465,-543.74957) \" id=\"svg_5461a4b7-62cb-432d-9360-ab72d3a0ba71\" display=\"inline\">\n     <path d=\"M630.84059,596.79244L630.84059,610.57369\" id=\"svg_5cde11ca-1435-4db9-8a43-d987b3fa1934\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M627.24059,596.79244L627.24059,610.57369\" id=\"svg_35ba224c-d0c9-4648-8267-3fad2a523577\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M623.64059,596.79244L623.64059,610.57369\" id=\"svg_5a44975f-88df-48f1-ab54-02f5e392abc9\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M620.04059,596.79244L620.04059,610.57369\" id=\"svg_9d877652-71d9-46aa-b067-de62387fd992\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M616.44059,596.79244L616.44059,610.57369\" id=\"svg_c4cdaba5-d919-4f41-b413-795408402bf4\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M612.84059,596.79244L612.84059,610.57369\" id=\"svg_84abc7ec-22d2-4647-a1a0-22bd802b4f99\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M609.24059,596.79244L609.24059,610.57369\" id=\"svg_613b452c-6760-4d57-97b0-ebe8836c4f95\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M605.64059,596.79244L605.64059,610.57369\" id=\"svg_044d5fd6-d385-4a25-ac79-49d788b3e61e\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M602.04059,596.79244L602.04059,610.57369\" id=\"svg_9ed5b481-4aa5-4bc4-96f7-f211bfbeac40\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M598.44059,596.79244L598.44059,610.57369\" id=\"svg_7733a801-7709-46d2-a10b-2d39d0e0e683\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M634.44059,596.79244L634.44059,610.57369\" id=\"svg_16d49808-6e70-4639-8c3c-3c8965a2bcea\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M481.9365,546.12769L516.65627,546.12769\" id=\"svg_f0046f04-206d-42e1-af51-3685ea6284bd\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M499.71826,526.21315L499.71826,546.1193\" id=\"svg_cb46cbae-3202-4604-8248-cdab3770e03d\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M516.65358,536.34582L499.71441,546.12565\" id=\"svg_5421cbb8-a404-4b63-923a-8794ea66afd4\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M516.65127,555.90415L499.71441,546.12565\" id=\"svg_57118e14-9f31-4496-8389-771f19f2b626\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M511.21429,526.21267L499.71441,546.12565\" id=\"svg_99e2f71b-6a5b-4d9c-9ac7-e6b3bf193ebf\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M508.19444,565.75119L499.71441,546.12565\" id=\"svg_28ec7d6a-f3e8-4308-94d4-def67e1e6ba1\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M491.65394,565.74008L499.71441,546.12565\" id=\"svg_5a8f4922-1af3-4d95-a77a-df04150b223e\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M481.93611,556.39122L499.71441,546.12565\" id=\"svg_078c4cc1-745e-4f93-8fc5-67e05ef5970a\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g id=\"svg_6ea25048-ab95-4136-b639-71ec88fb4dff\">\n     <path d=\"M454.18676,526.2188L454.18676,565.74294\" id=\"svg_a59c67ea-3767-4564-93e4-cc5bfc7081a9\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M450.58676,526.2188L450.58676,546.11055\" id=\"svg_dec5b47e-707a-468a-841d-022c78dc59f2\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M446.98676,526.2188L446.98676,546.11055\" id=\"svg_f5a79d32-660a-416c-b04b-5b9deaa674d7\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M443.38676,526.2188L443.38676,546.11055\" id=\"svg_c0651f79-dd1c-497b-b4d0-7b181ad0fb5e\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M439.78676,526.2188L439.78676,546.11055\" id=\"svg_ba0d6a68-2472-4ee6-871e-6043ba5bee0c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M436.18676,526.2188L436.18676,546.11055\" id=\"svg_e6bd618e-aee0-4d3d-a402-abb9c1dc170d\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M432.58676,526.2188L432.58676,546.11055\" id=\"svg_992ada51-cb5e-4b92-84f6-88e81595bd18\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M428.98685,526.2188L428.98685,546.11055\" id=\"svg_42bd9e5e-0f05-4af3-93a0-ab7c62328be1\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M425.38685,526.2188L425.38685,546.11055\" id=\"svg_f81f987f-018a-4e6d-a484-9ebefd165051\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M421.78685,526.2188L421.78685,565.74294\" id=\"svg_0468551f-c417-4c70-b523-d7521c3e1d29\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <path d=\"M454.17555,546.11713L421.79173,546.11713\" id=\"svg_51ed1598-77bf-494e-99a7-e1e68bc2761e\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(0.9990527,0,0,1,0.40349046,0) \" id=\"svg_81aa4c2f-1e94-4ea7-91c0-e54d64607559\">\n     <path d=\"M611.3637,577.61015L586.62229,577.61015\" id=\"svg_b815a51c-40ec-44c5-b09c-42062e3d3ed2\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.00047\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.3637,574.01015L586.62229,574.01015\" id=\"svg_2edcbcf7-db0c-4267-8d6d-8438dc8cdc3f\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.00047\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.3637,570.41015L586.62229,570.41015\" id=\"svg_84922268-2021-419f-983b-011034b50f40\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.00047\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.3637,566.81015L586.62229,566.81015\" id=\"svg_ebc18b4d-bac4-4c8f-b18e-e124514210c2\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.00047\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.3637,563.21015L586.62229,563.21015\" id=\"svg_51f8c902-376e-4234-bb2f-9573992863c8\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.00047\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.3637,559.61015L586.62229,559.61015\" id=\"svg_c03a7675-2614-40a3-9600-fa8e3b6e23dc\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.00047\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.3637,556.01015L586.62229,556.01015\" id=\"svg_5a6b256f-5b34-484a-b53f-28aeb88c1d14\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.00047\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.3637,552.41015L586.62229,552.41015\" id=\"svg_20b45d4e-782b-4b60-b9bb-5f01e6797bb6\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.00047\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.3637,581.21326L586.62229,581.21326\" id=\"svg_41e845e9-8f7d-4b06-91a1-e7bb883bc215\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.00047\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.3637,591.75209L586.62229,591.75209\" id=\"svg_f595681b-2963-4753-8891-cf9c338bbedd\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.00047\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.3637,588.27709L586.62229,588.27709\" id=\"svg_88457011-95c6-4b78-a6fc-80ad3005a810\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.00047\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M611.3637,584.73959L586.62229,584.73959\" id=\"svg_fec01992-8eb9-4b2e-8f71-d760d7125bb9\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"1.00047\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <rect width=\"34.64661\" height=\"46.15284\" x=\"611.86417\" y=\"553.31085\" id=\"svg_e1808132-3352-4e06-8e10-d85e712bcbc3\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-width=\"2.5\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(1,0,0,1.7952947,12.747465,-471.03725) \" id=\"svg_7dd17ffc-6422-4740-a8af-e47c7d4d9ff5\" display=\"inline\">\n     <path d=\"M630.84059,596.79244L630.84059,610.57369\" id=\"svg_8dcd8b7b-25b4-45d3-91c2-6c2f63a77e4b\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M627.24059,596.79244L627.24059,610.57369\" id=\"svg_b237f6e8-28ad-4d52-a98c-03aa3d036268\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M623.64059,596.79244L623.64059,610.57369\" id=\"svg_f22f2b5d-5c46-4ed0-a317-629e8e63bbb7\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M620.04059,596.79244L620.04059,610.57369\" id=\"svg_23fdad94-b791-4650-a6ef-254461cc3bd6\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M616.44059,596.79244L616.44059,610.57369\" id=\"svg_eed1b992-e769-467e-83ae-7c782bd31eb4\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M612.84059,596.79244L612.84059,610.57369\" id=\"svg_b1062051-30e7-46b2-b004-1a353b961b88\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M609.24059,596.79244L609.24059,610.57369\" id=\"svg_f90b4058-89f7-4ddd-9a26-85ad86365f32\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M605.64059,596.79244L605.64059,610.57369\" id=\"svg_992e8d0f-e7a9-41e2-bd31-c1f97d4c9196\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M602.04059,596.79244L602.04059,610.57369\" id=\"svg_d04ccdbd-5b4d-47c3-a0e2-518b86ea06f1\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M598.44059,596.79244L598.44059,610.57369\" id=\"svg_20be4e44-b04b-4666-81da-d8c84b460a8f\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M634.44059,596.79244L634.44059,610.57369\" id=\"svg_a863d3ba-e294-45f6-8940-cf42dd6c9ba3\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke-width=\"0.74633\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <rect width=\"34.64661\" height=\"46.15284\" x=\"611.86417\" y=\"553.31085\" id=\"svg_ecc5d074-b0b3-4eec-8501-2e494bbb8064\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-width=\"1.5\" stroke=\"#808080\" fill=\"none\"/>\n    <path d=\"M360.63525,728.5L335.40625,728.5L335.40625,712.375L331.46875,712.375L331.46875,728.5L331.46875,732.4375L335.40625,732.4375L360.63525,732.4375\" id=\"svg_8496988a-62c6-40f7-b074-03f766993dd6\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    <path d=\"M331.4625,731.49397L314.53125,749.3411\" id=\"svg_eae66059-eeb3-416b-b5e3-2221e5d604ff\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M331.4625,731.49397L314.52812,738.60482\" id=\"svg_18d9ef2c-6153-4591-959e-d0330eff8b34\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M331.4625,731.49713L324.58071,712.37601\" id=\"svg_c2e698e8-86f5-4af6-9465-dddebf33e404\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M331.4625,731.49497L324.69524,750.29788\" id=\"svg_0344e2da-6d81-423b-8949-b002439cf700\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n    <rect width=\"5.87772\" height=\"12.66836\" x=\"783.65363\" y=\"-576.71881\" transform=\"matrix(0,1,-1,0,0,0) \" id=\"svg_612b09ba-1eac-474f-a300-881b615d199c\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#ffffff\"/>\n    <rect width=\"5.87772\" height=\"5.98867\" x=\"783.65363\" y=\"-543.68365\" transform=\"matrix(0,1,-1,0,0,0) \" id=\"svg_5250c038-8c55-493c-bd13-04cf89d1393f\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#595959\"/>\n    <rect width=\"5.87772\" height=\"5.98477\" x=\"783.65363\" y=\"-570.03522\" transform=\"matrix(0,1,-1,0,0,0) \" id=\"svg_6010721a-2836-4abe-8381-0f5d10d4c67a\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill-rule=\"nonzero\" fill=\"#595959\"/>\n    <path d=\"M549.25053,582.3125L549.25053,589.71875L551.72553,589.71875L551.72553,582.3125L549.25053,582.3125z\" id=\"svg_61dd85cd-6284-4629-98e1-01727dc1c8ff\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"#ffffff\"/>\n    <path d=\"M549.25391,589.71869L574.46094,589.71869\" id=\"svg_608e938d-fc52-41e7-8621-0ffa05a6fe91\" stroke-dashoffset=\"0\" stroke-miterlimit=\"4\" stroke-linejoin=\"round\" stroke-linecap=\"round\" stroke=\"#000000\" fill=\"none\"/>\n   </g>\n   <g id=\"svg_098e99ff-e7ff-4e9b-acb5-223878918320\" display=\"inline\">\n    <path d=\"M442.51197,54.51516L383.49635,54.51516\" id=\"svg_d3d55e4b-1606-4a0d-b749-83d4bfbcc1cf\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M442.51197,52.51516L383.50471,52.51516\" id=\"svg_5730b573-cd7a-487f-9b1f-b13a1946b685\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(1.4728439,0,0,1,95.417739,0) \" id=\"svg_a9784a5b-9be9-4ec9-aef1-ff66d412b287\">\n     <g id=\"svg_dbd76ce2-d7eb-4059-8110-c45ed72805e0\" stroke-width=\"0.82399\" stroke=\"#000000\" fill=\"none\">\n      <path d=\"M383.03905,54.51516L342.10155,54.51516\" id=\"svg_0e42c7c8-5e5a-47d0-bb24-14d77bdfbd4d\" stroke-miterlimit=\"4\" stroke-width=\"0.82399\" stroke=\"#000000\" fill=\"none\"/>\n      <path d=\"M383.03905,52.51516L342.10155,52.51516\" id=\"svg_ae60b47c-d8a8-4263-aca9-f847458c077f\" stroke-miterlimit=\"4\" stroke-width=\"0.82399\" stroke=\"#000000\" fill=\"none\"/>\n     </g>\n    </g>\n    <g transform=\"matrix(0,0.53085054,-1,0,591.81248,156.38736) \" id=\"svg_a99e0748-0841-4944-9f7b-8adb47e18443\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M203.98667,-102.45359L163.04917,-102.45359\" id=\"svg_b6d9914b-e691-4feb-9f24-d104d54767ba\" stroke-miterlimit=\"4\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M203.98667,-104.45359L163.04917,-104.45359\" id=\"svg_c18a4669-dbf8-476c-852f-22722423bd86\" stroke-miterlimit=\"4\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.42289531,-1,0,591.81248,234.53614) \" id=\"svg_53f32559-6d94-4ac0-bae6-8d069f119ac6\" stroke-width=\"1.53774\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M190.38666,-102.45359L149.44916,-102.45359\" id=\"svg_d4e664a6-392f-4f52-ba66-10f9d9a0e45c\" stroke-miterlimit=\"4\" stroke-width=\"1.53774\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M190.38666,-104.45359L149.44916,-104.45359\" id=\"svg_d129e069-eb7d-4d66-92ae-20e8fe7a6761\" stroke-miterlimit=\"4\" stroke-width=\"1.53774\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.53085054,-1,0,591.81248,320.40468) \" id=\"svg_61ba8d31-77aa-4c01-9870-48fdbee5a703\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M203.98667,-102.45359L163.04917,-102.45359\" id=\"svg_a9d6a655-305c-4f06-9db1-ec2aa5237720\" stroke-miterlimit=\"4\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M203.98667,-104.45359L163.04917,-104.45359\" id=\"svg_25bdb691-e649-4c71-a957-37f4295c9824\" stroke-miterlimit=\"4\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.53085054,-1,0,591.81248,366.98534) \" id=\"svg_66d408af-a5f9-4278-a66b-47c517e2e0da\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M203.98667,-102.45359L163.04917,-102.45359\" id=\"svg_474c39d2-856b-43ba-98d5-af714cad750e\" stroke-miterlimit=\"4\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M203.98667,-104.45359L163.04917,-104.45359\" id=\"svg_e7f7509f-0969-4bbc-875f-ab66ae3b5611\" stroke-miterlimit=\"4\" stroke-width=\"1.3725\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.4224536,-1,0,591.81248,503.95925) \" id=\"svg_93d4f13a-e04f-4bb3-9413-b4e78d4e84f0\" stroke-width=\"1.53855\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M190.31674,-102.45359L149.37924,-102.45359\" id=\"svg_e3c0d73f-4471-461c-b508-9748f5d36c83\" stroke-miterlimit=\"4\" stroke-width=\"1.53855\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M190.31674,-104.45359L149.37924,-104.45359\" id=\"svg_2c97aa75-936f-46bb-a246-a7128de1d7ca\" stroke-miterlimit=\"4\" stroke-width=\"1.53855\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0.49386211,0,0,-1,28.829271,956.18593) \" id=\"svg_0fa6bb05-75fd-4ccf-87bf-d08261c372f9\" stroke-width=\"1.42297\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M632.36669,111.07766L591.42919,111.07766\" id=\"svg_680ebcfe-0873-4d27-a6e2-2d53eefc83f3\" stroke-miterlimit=\"4\" stroke-width=\"1.42297\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M632.36669,109.07766L591.42919,109.07766\" id=\"svg_cb9180ff-5b6b-4c8c-87a6-0623650f0845\" stroke-miterlimit=\"4\" stroke-width=\"1.42297\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0.40881309,0,0,-1,86.461166,956.18593) \" id=\"svg_b82c5105-3880-4d39-afa8-c9b0d5e804d6\" stroke-width=\"1.564\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M710.40302,111.07766L669.46552,111.07766\" id=\"svg_e6925f22-5baf-44b0-b724-7b70cdec444a\" stroke-miterlimit=\"4\" stroke-width=\"1.564\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M710.40302,109.07766L669.46552,109.07766\" id=\"svg_0e1a9fc6-a733-48ac-b301-57d279927ba7\" stroke-miterlimit=\"4\" stroke-width=\"1.564\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.293433,1,0,122.28517,129.07564) \" id=\"svg_6ad73287-0b69-48c2-86f9-9bef02513726\" display=\"inline\" stroke-width=\"1.84606\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M160.88136,268.04641L119.94386,268.04641\" id=\"svg_3f9b0a66-1883-41fe-b8e0-800ebafd096d\" stroke-miterlimit=\"4\" stroke-width=\"1.84606\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M160.88136,266.04641L119.94386,266.04641\" id=\"svg_1d3e337b-5863-42d6-90da-27799d546f7d\" stroke-miterlimit=\"4\" stroke-width=\"1.84606\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.42099237,1,0,122.28517,155.48672) \" id=\"svg_c2a444e9-4ef1-49df-a861-d93e241b199b\" display=\"inline\" stroke-width=\"1.54121\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M190.08444,268.04641L149.14694,268.04641\" id=\"svg_72898cd9-dd5e-48e9-ba1f-39c09a6cf8bf\" stroke-miterlimit=\"4\" stroke-width=\"1.54121\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M190.08444,266.04641L149.14694,266.04641\" id=\"svg_8c08e200-51d4-4561-883b-33f7539a8212\" stroke-miterlimit=\"4\" stroke-width=\"1.54121\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.8386687,1,0,122.28517,117.22866) \" id=\"svg_117f93c6-8b3c-4bfa-ab2a-27e19e1c9f61\" display=\"inline\" stroke-width=\"1.09196\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M223.54036,268.04641L182.60286,268.04641\" id=\"svg_749af01d-bd09-4677-9b74-188d6067bb22\" stroke-miterlimit=\"4\" stroke-width=\"1.09196\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M223.54036,266.04641L182.60286,266.04641\" id=\"svg_4000e6e2-ad50-41a2-8aec-7ee4cc8e348e\" stroke-miterlimit=\"4\" stroke-width=\"1.09196\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.53801804,1,0,122.28517,317.94964) \" id=\"svg_2704e8cc-4144-4814-a62f-d39c7b1be751\" display=\"inline\" stroke-width=\"1.36333\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M204.69635,268.04641L163.75885,268.04641\" id=\"svg_9f2e3700-eb30-4d30-b51c-d245a7acbc23\" stroke-miterlimit=\"4\" stroke-width=\"1.36333\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M204.69635,266.04641L163.75885,266.04641\" id=\"svg_2f10f3f3-2ee4-4e3f-b0a3-8440968c8ed1\" stroke-miterlimit=\"4\" stroke-width=\"1.36333\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.72056818,1,0,122.28517,336.80298) \" id=\"svg_72cdc7b6-28d6-4f90-b5d4-971ce8842194\" display=\"inline\" stroke-width=\"1.17805\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M218.01342,268.04641L177.07592,268.04641\" id=\"svg_2e57f65d-8ae2-463a-8506-c562fcfc6e8f\" stroke-miterlimit=\"4\" stroke-width=\"1.17805\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M218.01342,266.04641L177.07592,266.04641\" id=\"svg_f26f3470-a7a2-41c1-9cba-48ea4631acf3\" stroke-miterlimit=\"4\" stroke-width=\"1.17805\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.45269346,1,0,122.28517,507.43008) \" id=\"svg_f8cf7bab-201f-4603-b6b3-1eaa37fe30af\" stroke-width=\"1.48627\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M194.78863,268.04641L153.85113,268.04641\" id=\"svg_a2d1a8d1-f7bf-4bdc-b0fc-b52e1ea72da7\" stroke-miterlimit=\"4\" stroke-width=\"1.48627\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M194.78863,266.04641L153.85113,266.04641\" id=\"svg_6127ca1e-9a3b-44aa-93a7-557998900a4b\" stroke-miterlimit=\"4\" stroke-width=\"1.48627\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.66874961,1,0,122.28517,412.47165) \" id=\"svg_b695a082-9392-4439-8cad-6f2b2110ffcc\" display=\"inline\" stroke-width=\"1.22284\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M214.97222,268.04641L174.03472,268.04641\" id=\"svg_fe6fa6e8-c3ad-4f76-9237-d1d2a177096c\" stroke-miterlimit=\"4\" stroke-width=\"1.22284\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M214.97222,266.04641L174.03472,266.04641\" id=\"svg_037c7f85-9547-4c6f-96eb-2715e630f58d\" stroke-miterlimit=\"4\" stroke-width=\"1.22284\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.47406747,1,0,84.47267,551.31326) \" id=\"svg_d1bca18c-22c3-40e9-811d-b5f4ffbf1783\" display=\"inline\" stroke-width=\"1.45238\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M197.6054,268.04641L156.6679,268.04641\" id=\"svg_524ff34f-c522-477d-8e43-010acd95a697\" stroke-miterlimit=\"4\" stroke-width=\"1.45238\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M197.6054,266.04641L156.6679,266.04641\" id=\"svg_8a111079-8bec-46d2-ae8a-c0141ae3705e\" stroke-miterlimit=\"4\" stroke-width=\"1.45238\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(-0.6761343,0,0,-1,469.34621,894.32023) \" id=\"svg_cc9d3122-6855-40f6-a954-e55f6ca3ac71\" stroke-width=\"1.21614\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(-0.6761343,0,0,-1,586.34621,894.32023) \" id=\"svg_23efc52c-291e-462b-bc15-f31c77e2b4c4\" stroke-width=\"1.21614\" stroke=\"#000000\" fill=\"none\"/>\n    <g id=\"svg_423dc2ca-3ea5-4f67-b136-f7580e198737\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M517.31483,449.68811L517.31483,465.25752\" id=\"svg_52d7aaff-0f7a-4447-b6f7-18eef6a6cef1\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M517.31483,386.68811L517.31483,400.38253\" id=\"svg_5922b740-7101-4dc0-8f74-67807b7e41fb\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M517.31483,325.48811L517.31483,339.18253\" id=\"svg_446f389e-e8a4-41e6-a306-ba6b4fc3e1eb\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <path d=\"M517.31483,264.28811L517.31483,277.98253\" id=\"svg_f3a1bab3-0f18-4bca-b8eb-5d479f1ca50b\" stroke-miterlimit=\"4\" stroke=\"#000000\" fill=\"none\"/>\n    <g transform=\"matrix(0.39389313,0,0,0.71551724,248.99439,191.12215) \" id=\"svg_b5b62885-5f3a-4904-a908-90cf8014194e\" display=\"inline\" stroke-width=\"1.88365\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M727.56725,43.2708L696.2453,43.2708\" id=\"svg_0e0d97a7-3442-4c07-a502-eff29041d777\" stroke-miterlimit=\"4\" stroke-width=\"1.88365\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M727.56725,41.2708L696.2453,41.2708\" id=\"svg_139cfec4-3c54-44e9-868f-b63d815fc241\" stroke-miterlimit=\"4\" stroke-width=\"1.88365\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(-0.36030534,0,0,-1,619.55404,956.32094) \" id=\"svg_45b2bb6f-b2c6-47f3-ad3c-107a7e667ae0\" display=\"inline\" stroke-width=\"1.66596\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M-256.88525,111.07766L-297.82275,111.07766\" id=\"svg_12c7e5a5-b182-42ba-96d1-808397b37a2b\" stroke-miterlimit=\"4\" stroke-width=\"1.66596\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M-256.88525,109.07766L-297.82275,109.07766\" id=\"svg_1f640ff0-aaf8-4356-ac28-1e3c176f1e92\" stroke-miterlimit=\"4\" stroke-width=\"1.66596\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(-0.31526717,0,0,-1,668.89878,956.32094) \" id=\"svg_8ae7fa13-6a60-468b-ab90-3944dc1a0578\" display=\"inline\" stroke-width=\"1.78099\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M-330.3349,111.07766L-371.2724,111.07766\" id=\"svg_55c33c10-82bc-4445-b153-9e37407e1130\" stroke-miterlimit=\"4\" stroke-width=\"1.78099\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M-330.3349,109.07766L-371.2724,109.07766\" id=\"svg_ec99b1ca-f7ec-4d8c-a3b0-37e7a09e9454\" stroke-miterlimit=\"4\" stroke-width=\"1.78099\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.82034809,1,0,122.28517,190.40806) \" id=\"svg_aa54aa52-116d-42d5-8bf8-bb8e4986aff2\" display=\"inline\" stroke-width=\"1.10408\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M222.7873,268.04641L181.8498,268.04641\" id=\"svg_09704854-a6b8-4def-bae6-ef922259fcf7\" stroke-miterlimit=\"4\" stroke-width=\"1.10408\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M222.7873,266.04641L181.8498,266.04641\" id=\"svg_4d86c854-3257-415c-a1f0-6546401b7d13\" stroke-miterlimit=\"4\" stroke-width=\"1.10408\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0.46027432,0,0,-1,-13.342369,956.18593) \" id=\"svg_360db56e-1c68-4544-917b-b4cd50b6db1e\" stroke-width=\"1.47398\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M659.73931,111.07766L618.80181,111.07766\" id=\"svg_019a7e7b-f731-4b9d-a3c8-7f86c6b16773\" stroke-miterlimit=\"4\" stroke-width=\"1.47398\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M659.73931,109.07766L618.80181,109.07766\" id=\"svg_97b01475-22a3-43d2-b59f-499d04131917\" stroke-miterlimit=\"4\" stroke-width=\"1.47398\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(1.0351145,0,0,-1,60.048156,846.99994) \" id=\"svg_cf33c904-5000-45c5-bc64-f25e8ab916f6\" stroke-width=\"0.98289\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M436.2277,111.07766L395.2902,111.07766\" id=\"svg_2aca700f-c2a4-43cf-97c6-f7aa0a26e817\" stroke-miterlimit=\"4\" stroke-width=\"0.98289\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M436.2277,109.07766L395.2902,109.07766\" id=\"svg_5da8781b-2646-4a7e-a629-3e18d425375b\" stroke-miterlimit=\"4\" stroke-width=\"0.98289\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0.97681867,0,0,-1,197.92134,846.99994) \" id=\"svg_2278ce62-f705-444d-8cf9-6e9d4d55dd35\" stroke-width=\"1.0118\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M446.9082,111.07766L405.9707,111.07766\" id=\"svg_497b8d13-05f4-44b7-aad7-1d28231e3d1b\" stroke-miterlimit=\"4\" stroke-width=\"1.0118\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M446.9082,109.07766L405.9707,109.07766\" id=\"svg_56d90e18-a041-4aba-bdb3-0ea6a3c3c073\" stroke-miterlimit=\"4\" stroke-width=\"1.0118\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n    <g transform=\"matrix(0,0.42893091,-1,0,591.81248,536.3224) \" id=\"svg_1ac7a340-798a-4d4f-ade5-bd9ccd84c27b\" stroke-width=\"1.52688\" stroke=\"#000000\" fill=\"none\">\n     <path d=\"M191.32768,-102.45359L150.90535,-102.45359\" id=\"svg_25b8c639-9fbe-449a-9dcc-ba5dddc9c03f\" stroke-miterlimit=\"4\" stroke-width=\"1.52688\" stroke=\"#000000\" fill=\"none\"/>\n     <path d=\"M191.32768,-104.45359L150.90535,-104.45359\" id=\"svg_1e6c4f84-cf7d-439a-87c5-62b52230f738\" stroke-miterlimit=\"4\" stroke-width=\"1.52688\" stroke=\"#000000\" fill=\"none\"/>\n    </g>\n   </g>\n   <g id=\"svg_8dc43162-f2d6-4eab-8134-69505da6fb69\" display=\"inline\">\n    <text x=\"752.44672\" y=\"802.07288\" id=\"svg_9e1bbc74-80fa-476a-9122-5126ab68b4de\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"371.24561\" y=\"650.27283\" id=\"svg_f9e7beb7-6592-4703-873a-a3d4ea9ebcc2\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"371.24561\" y=\"741.77271\" id=\"svg_158f3020-850e-4b74-b6a2-578f6a944093\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"371.24561\" y=\"802.07288\" id=\"svg_7f65193a-6c68-445f-893b-67a4644f9d65\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"276.84562\" y=\"802.07288\" id=\"svg_7efb77d0-b8b2-461f-9b56-b2fced0ea272\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"628.8457\" y=\"581.87219\" id=\"svg_520fa844-9cd5-411c-93cb-90ba250e675e\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"628.8457\" y=\"422.74854\" id=\"svg_d1ee25cb-37b1-49ff-82ac-0dd2fd50b0fd\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"628.8457\" y=\"292.24863\" id=\"svg_37cff389-b250-47e3-95c4-bf4d7b3164a1\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"416.94568\" y=\"206.57288\" id=\"svg_4ded7b15-243a-44c5-adfb-4f68d0cdc72b\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"499.72192\" y=\"108.58096\" id=\"svg_247810b2-a178-450c-9df9-48ce970206c1\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"457.84564\" y=\"206.57288\" id=\"svg_f5c73e38-d1a6-4d01-9d68-63334e1ee6e9\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"436.74567\" y=\"292.07285\" id=\"svg_74a48658-7a9e-41dc-9a83-58ba61561160\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"436.74567\" y=\"358.67282\" id=\"svg_ab549ca4-d14c-4401-9504-7c9050a92347\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"436.74567\" y=\"422.57275\" id=\"svg_0cc2afb1-0143-4212-87ad-4906f45948ca\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"436.74567\" y=\"487.3728\" id=\"svg_d8685f6c-f9b9-4e86-afea-a931795f558d\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"436.74567\" y=\"561.89612\" id=\"svg_1ce2b84d-4d2a-4eb8-84e4-3d64e415d0d6\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"436.74567\" y=\"605.27283\" id=\"svg_b8b07fd5-b3bc-4a57-ba2d-05d861541e36\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"496.53149\" y=\"605.27283\" id=\"svg_e32782b4-a9a1-430f-977b-d83b24c75d11\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"496.53149\" y=\"188.06848\" id=\"svg_37e3d355-5233-437c-820c-7cf1304af006\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"436.74567\" y=\"687.77283\" id=\"svg_f5d32dc9-6906-408f-87d2-3364fc44df6c\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"605.24567\" y=\"687.77283\" id=\"svg_682dc443-8b84-4347-b7c1-0379158b7692\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n    <text x=\"496.53149\" y=\"358.8486\" id=\"svg_d1f98365-199a-4f0d-bcf4-748e1737c82b\" xml:space=\"preserve\" font-family=\"Liberation Sans\" fill=\"#000000\" text-anchor=\"middle\" font-weight=\"normal\" font-style=\"normal\" font-size=\"18px\"/>\n   </g>\n  </g>\n  <line id=\"svg_433ce0ff-aea5-48ff-8132-38557a3894b3\" y2=\"578\" x2=\"824\" y1=\"578\" x1=\"636\" stroke-linecap=\"null\" stroke-linejoin=\"null\" stroke-dasharray=\"null\" stroke-width=\"2\" stroke=\"#000000\" fill=\"none\"/>\n  <rect fill=\"#4fa6ffff\" x=\"816\" y=\"542\" width=\"112\" height=\"80\" id=\"svg_4ace4d45-a0ce-431d-bbd8-a2a678ab7f87\"/>\n  <text xml:space=\"preserve\" text-anchor=\"start\" font-family=\"sans-serif\" font-size=\"26\" y=\"28\" x=\"4\" stroke-width=\"0\" stroke=\"#000000\" fill=\"#000000\" id=\"svg_1a339dd5-4b8c-49c0-89b2-3fd6874e8962\">My Plant</text>\n  <rect fill=\"#e7e7e7ff\" x=\"532\" y=\"658\" width=\"60\" height=\"44\" id=\"svg_ec3a13f1-6d02-46df-817d-976700a89e36\" stroke=\"#bfbfbf\"/>\n  <text fill=\"#000000\" stroke=\"#3f3f3f\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"562\" y=\"676\" id=\"svg_97a244cc-a2a8-4ebb-9696-7c913344b934\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">Room F</text>\n  <g id=\"VAL_c1427a6f-5d90-428d-9e9b-f601545f8cc1\" type=\"svg-ext-value\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"VAL_62dccc75-63ed-47aa-948b-75dce5429220\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"562\" y=\"694\">##.##</text>\n  </g>\n  <g id=\"VAL_22dab659-12c0-42ea-9548-fbc9e8cbe82e\" type=\"svg-ext-value\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\"/>\n  <rect fill=\"#e7e7e7ff\" x=\"364\" y=\"82\" width=\"60\" height=\"44\" stroke=\"#bfbfbf\" id=\"svg_5f473d86-d05d-4b28-8367-0b52613e76b7\"/>\n  <text fill=\"#000000\" stroke=\"#3f3f3f\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"394\" y=\"100\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_f78e8917-7a42-4800-ab4c-f83d9c24acbc\">Room A</text>\n  <g type=\"svg-ext-value\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\" id=\"VAL_d435cec7-5632-466c-869f-26a76dd82799\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"394.5\" y=\"118\" id=\"VAL_781ef423-12ac-4535-a067-2c7931245908\">##.##</text>\n  </g>\n  <rect fill=\"#e7e7e7ff\" x=\"402\" y=\"266\" width=\"60\" height=\"44\" stroke=\"#bfbfbf\" id=\"svg_1cf881bb-4671-4c98-8165-4fa3951f33fc\"/>\n  <text fill=\"#000000\" stroke=\"#3f3f3f\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"432\" y=\"284\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_9aefda04-a485-4ed1-a995-75b53cead5b9\">Room B</text>\n  <g type=\"svg-ext-value\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\" id=\"VAL_90c24434-9cc4-40b2-94b5-bd53c2f43d67\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"432.5\" y=\"302\" id=\"VAL_7ea671cb-fae2-463a-b55d-227681719b9d\">##.##</text>\n  </g>\n  <rect fill=\"#e7e7e7ff\" x=\"402\" y=\"332\" width=\"60\" height=\"44\" stroke=\"#bfbfbf\" id=\"svg_2e5ec2d7-66a0-441a-aa77-0e9c4b82f6b6\"/>\n  <text fill=\"#000000\" stroke=\"#3f3f3f\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"432\" y=\"350\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_e26ea84c-25f0-4d9e-9a0b-f44a977c56a1\">Room C</text>\n  <g type=\"svg-ext-value\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\" id=\"VAL_0fe1a6c5-f1e7-4c1c-8b68-481015b3b2a7\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"432.5\" y=\"368\" id=\"VAL_cc0b973f-2777-45b4-9fe9-2b3d02d986b8\">##.##</text>\n  </g>\n  <rect fill=\"#e7e7e7ff\" x=\"402\" y=\"460\" width=\"60\" height=\"44\" stroke=\"#bfbfbf\" id=\"svg_72ed881b-e289-4861-abbe-bb299c03aa29\"/>\n  <text fill=\"#000000\" stroke=\"#3f3f3f\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"432\" y=\"478\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_ed36c139-12c9-4823-8601-0ff4c6569b52\">Room D</text>\n  <g type=\"svg-ext-value\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\" id=\"VAL_f55fdb69-ed16-46a1-bf5c-2546ad659342\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"432.5\" y=\"496\" id=\"VAL_511ca830-df6e-4606-9e3d-f5503e8d0482\">##.##</text>\n  </g>\n  <rect fill=\"#e7e7e7ff\" x=\"614\" y=\"238\" width=\"60\" height=\"44\" stroke=\"#bfbfbf\" id=\"svg_906a9d1c-41b3-4ea9-9bff-1f8670f85a4e\"/>\n  <text fill=\"#000000\" stroke=\"#3f3f3f\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"644\" y=\"256\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_00462a5d-7bb3-4a8e-8309-01fc1da859b7\">Room H</text>\n  <g type=\"svg-ext-value\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\" id=\"VAL_ccbf65e9-abfc-4ca5-b5cb-701bc897c27c\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"644.5\" y=\"274\" id=\"VAL_75303630-cead-4512-9dbc-ea51fed20a84\">##.##</text>\n  </g>\n  <rect fill=\"#e7e7e7ff\" x=\"594\" y=\"404\" width=\"60\" height=\"44\" stroke=\"#bfbfbf\" id=\"svg_6566bb48-d318-46b7-ab7e-0edf643c2d39\"/>\n  <text fill=\"#000000\" stroke=\"#3f3f3f\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"624\" y=\"422\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_752694a3-6ae4-4b0c-b406-ebfd78cca3c6\">Room G</text>\n  <g type=\"svg-ext-value\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\" id=\"VAL_63903efb-5136-436b-849a-eb928cbac8ff\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"624.5\" y=\"440\" id=\"VAL_6124ea0e-a742-4597-9746-0dcc7e72c3b1\">##.##</text>\n  </g>\n  <rect fill=\"#e7e7e7ff\" x=\"424\" y=\"658\" width=\"60\" height=\"44\" stroke=\"#bfbfbf\" id=\"svg_794e84a3-507e-43bb-9642-07fefb6cd3a7\"/>\n  <text fill=\"#000000\" stroke=\"#3f3f3f\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"454\" y=\"676\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" id=\"svg_1c342cc9-9f50-4e23-b7e4-38753598dd61\">Room E</text>\n  <g type=\"svg-ext-value\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"middle\" id=\"VAL_21286674-cfd3-443e-9735-3bdded4a2e44\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" fill=\"#3f3f3f\" stroke=\"#3f3f3f\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\" x=\"454.5\" y=\"694\" id=\"VAL_14a71111-ef7e-4ead-b2a9-ce77582038ce\">##.##</text>\n  </g>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" x=\"870\" y=\"560\" id=\"svg_529fe67e-a0a0-4f14-aabb-73adc23ddead\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">Elevator</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"844\" y=\"586\" id=\"svg_a9d51b46-bcd8-4ba3-b488-5641830b316a\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">Stage</text>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" x=\"848\" y=\"610\" id=\"svg_c2a97912-0311-4ae8-b228-3ccbf94c7f75\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">Current</text>\n  <g id=\"VAL_ef810f84-0616-48bc-b0f3-79df0f8caeb9\" type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"end\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"VAL_8d001d16-526b-4824-8925-35cf2215c3af\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"end\" xml:space=\"preserve\" x=\"920\" y=\"586\">##.##</text>\n  </g>\n  <g id=\"VAL_186d7954-4944-447f-a7d7-37eca04cca55\" type=\"svg-ext-value\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" stroke-width=\"0\" font-family=\"sans-serif\" text-anchor=\"end\">\n   <text stroke-width=\"0\" stroke-dasharray=\"null\" stroke-linejoin=\"null\" stroke-linecap=\"null\" id=\"VAL_4ca4c574-efb7-4487-b688-b307ac3fbb26\" fill=\"#000000\" stroke=\"#000000\" font-size=\"14\" font-family=\"sans-serif\" text-anchor=\"end\" xml:space=\"preserve\" x=\"920\" y=\"610\">##.##</text>\n  </g>\n </g>\n</svg>"
+      },
+      {
+        "id": "v_1571825012326",
+        "name": "View_Dialog",
+        "profile": {
+          "width": 340,
+          "height": 230,
+          "bkcolor": "#d8d8d8ff"
+        },
+        "items": {},
+        "variables": {},
+        "svgcontent": "<svg width=\"340\" height=\"230\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:svg=\"http://www.w3.org/2000/svg\" xmlns:html=\"http://www.w3.org/1999/xhtml\">\n <g>\n  <title>Layer 1</title>\n  <text fill=\"#000000\" stroke=\"#000000\" stroke-width=\"0\" x=\"170\" y=\"94\" id=\"svg_f56d2440-c9b8-4da8-b492-900c61264998\" font-size=\"29\" font-family=\"sans-serif\" text-anchor=\"middle\" xml:space=\"preserve\">My Dialog (Modal)</text>\n  <g id=\"CPS_5a8e2feb-3cef-4d9c-8ad3-6e9f3bb5dd70\" type=\"svg-ext-compressor\" fill=\"#ffffff\" stroke=\"#000000\" font-size=\"22\" font-family=\"sans-serif\" text-anchor=\"middle\" transform=\"rotate(-90 100.00000762939455,169.00001525878906) \">\n   <path id=\"pCPS_17955e90-e181-4c5f-a6f3-746602f6c037\" d=\"M90,151.8L118,160.2M90,186.2L118,177.8M94,169L106,169M106,163L106,175M120,169A20,20 0 0 1 100,189A20,20 0 0 1 80,169A20,20 0 0 1 100,149A20,20 0 0 1 120,169z\"/>\n  </g>\n  <g text-anchor=\"right\" font-family=\"sans-serif\" font-size=\"14\" stroke=\"#000000\" fill=\"#FFFFFF\" type=\"svg-ext-html_button\" id=\"HXB_81ed9e32-08be-40a2-97a8-12df81a98e32\">\n   <rect id=\"svg_45671941-b7ef-4f8f-a2b3-e8d20da54f53\" stroke=\"#000000\" fill=\"#ff0000\" height=\"24\" width=\"80\" y=\"156\" x=\"186\" stroke-width=\"0\"/>\n   <foreignObject id=\"H-HXB_37cac8d7-98f4-4522-8745-beaa89a7e526\" width=\"80\" height=\"24\" y=\"156\" x=\"186\">\n    <BUTTON style=\"width: 100%; height: 100%; background-color: rgb(255, 0, 0);\" class=\"md-btn  md-btn-raised\" id=\"B-HXB_37cac8d7-98f4-4522-8745-beaa89a7e526\">button</BUTTON>\n   </foreignObject>\n  </g>\n </g>\n</svg>"
+      },
+      {
+        "id": "v_1573047881338",
+        "name": "View_Window",
+        "profile": {
+          "width": 240,
+          "height": 200,
+          "bkcolor": "#eaeaeaff"
+        },
+        "items": {},
+        "variables": {},
+        "svgcontent": "<svg width=\"240\" height=\"200\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:svg=\"http://www.w3.org/2000/svg\" xmlns:html=\"http://www.w3.org/1999/xhtml\">\n <g>\n  <title>Layer 1</title>\n  <text xml:space=\"preserve\" text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"22\" id=\"svg_beb9e55e-4900-4f7d-9f04-667a1c453bb4\" y=\"68\" x=\"122\" stroke-width=\"0\" stroke=\"#000000\" fill=\"#000000\">My Window (Show)</text>\n  <g text-anchor=\"middle\" font-family=\"sans-serif\" font-size=\"22\" stroke=\"#000000\" fill=\"#ffffff\" type=\"svg-ext-motor\" id=\"MTR_6f3556b0-0355-411e-b505-b88f39dae091\">\n   <ellipse ry=\"20.5\" rx=\"20.5\" cy=\"147\" cx=\"72\" id=\"cMTR_e849e44f-3c98-47a6-a72d-786faeb7b68b\"/>\n   <path fill=\"#000000\" d=\"M72,128L92,147.25L72,166.5L72,128z\" id=\"sMTR_71f18c1a-de9f-4e72-8ea1-317f6f7cf8d6\"/>\n  </g>\n  <g text-anchor=\"right\" font-family=\"sans-serif\" font-size=\"14\" stroke=\"#000000\" fill=\"#ff0000\" type=\"svg-ext-html_button\" id=\"HXB_fd9f2931-f67a-4afe-9077-b787f9021064\">\n   <rect id=\"svg_5afb67b4-6ac1-4945-9c9e-d5cf8a493fa1\" stroke=\"#000000\" fill=\"#007fff\" height=\"24\" width=\"80\" y=\"134\" x=\"130\" stroke-width=\"0\"/>\n   <foreignObject id=\"H-HXB_2ed59f34-63ba-4f10-a795-0b7e0168c4ab\" width=\"80\" height=\"24\" y=\"134\" x=\"130\">\n    <BUTTON style=\"width: 100%; height: 100%; background-color: rgb(0, 127, 255);\" class=\"md-btn  md-btn-raised\" id=\"B-HXB_2ed59f34-63ba-4f10-a795-0b7e0168c4ab\">button</BUTTON>\n   </foreignObject>\n  </g>\n </g>\n</svg>"
+      }
+    ],
+    "layout": {
+      "start": "v_1571818530964",
+      "navigation": {
+        "mode": "fix",
+        "type": "inline",
+        "items": [
+          {
+            "icon": "home",
+            "view": "v_1571818530964",
+            "link": "",
+            "text": "Home"
+          },
+          {
+            "icon": "dashboard",
+            "view": "v_1571818563529",
+            "link": "",
+            "text": "Dashboard"
+          },
+          {
+            "icon": "explore",
+            "text": "Plant",
+            "view": "v_1571824949373",
+            "link": ""
+          }
+        ]
+      },
+      "header": {}
+    }
+  },
+  "version": "1.00",
+  "name": "",
+  "charts": [
+    {
+      "id": "5674a998-b453433c",
+      "name": "Compressor A",
+      "lines": [
+        {
+          "id": "Byte 1",
+          "name": "Byte 1",
+          "device": "SPS",
+          "color": "#4484ef"
+        },
+        {
+          "id": "ns=2;s=Demo.Static.Scalar.Byte",
+          "name": "ns=2;s=Demo.Static.Scalar.Byte",
+          "device": "OPC UA",
+          "color": "#ef0909"
+        }
+      ]
+    },
+    {
+      "id": "f66c7d82-5ad2469d",
+      "name": "Pumps",
+      "lines": [
+        {
+          "id": "Word 4",
+          "name": "Word 4",
+          "device": "SPS",
+          "color": "#4484ef"
+        },
+        {
+          "id": "Word 3",
+          "name": "Word 3",
+          "device": "SPS",
+          "color": "#ef0909"
+        },
+        {
+          "id": "Word 2",
+          "name": "Word 2",
+          "device": "SPS",
+          "color": "#00b050"
+        },
+        {
+          "id": "Word 1",
+          "name": "Word 1",
+          "device": "SPS",
+          "color": "#ffd04a"
+        }
+      ]
+    },
+    {
+      "id": "bc04d48f-3b6242a2",
+      "name": "Pump A",
+      "lines": [
+        {
+          "id": "Byte 2",
+          "name": "Byte 2",
+          "device": "SPS",
+          "color": "#4484ef"
+        },
+        {
+          "id": "Int 1",
+          "name": "Int 1",
+          "device": "SPS",
+          "color": "#ef0909"
+        }
+      ]
+    }
+  ],
+  "server": {
+    "name": "Fuxa Server",
+    "id": "0",
+    "type": "FuxaServer",
+    "property": {}
+  }
+}

--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -45,6 +45,7 @@ import type {
   InstalledPack,
   ResolvedPackDeviceType,
   RtuConfig,
+  SensorConfig,
   FluidType
 } from '@otforge/schema'
 import { ScadaCanvas } from './canvas/ScadaCanvas'
@@ -904,7 +905,10 @@ export default function App() {
    * before the next React Flow re-render cycle completes.
    */
   const handleDeviceChange = useCallback(
-    (nodeId: string, changes: { ipAddress?: string; label?: string; rtuConfig?: RtuConfig }) => {
+    (
+      nodeId: string,
+      changes: { ipAddress?: string; label?: string; rtuConfig?: RtuConfig; sensor?: SensorConfig }
+    ) => {
       setScenario(prev => {
         if (!prev) return prev
         const existing = prev.devices.devices[nodeId]

--- a/packages/app/src/renderer/src/canvas/DeviceNode.tsx
+++ b/packages/app/src/renderer/src/canvas/DeviceNode.tsx
@@ -181,7 +181,11 @@ export const DeviceNode = memo(function DeviceNode({ data, selected }: NodeProps
 
         {/* ISA-5.1 device icon, colored by zone — sized to fill the cell */}
         <div className="device-node-icon" style={{ color: zoneColor }}>
-          <DeviceIcon category={data.device.category} size={44} />
+          <DeviceIcon
+            category={data.device.category}
+            sensorKind={data.device.sensor?.kind}
+            size={44}
+          />
         </div>
 
         {/*

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -74,6 +74,7 @@ import {
   getCableRejectionReason,
   isProtocolCableCompatible
 } from './connectionRules'
+import { DEFAULT_SENSOR_CONFIG } from '../properties/SensorPanel'
 
 /**
  * Protocol options shown in the "Application Protocol" section of the connection menu.
@@ -325,9 +326,7 @@ const DEFAULT_PROTOCOLS: Record<DeviceCategory, Protocol[]> = {
   pmu: ['dnp3'], // PMUs report via DNP3 by default; IEC 61850 in substation deployments
   'iiot-sensor': ['mqtt'], // wireless IIoT sensor publishes MQTT
   'iot-gateway': ['mqtt'], // gateway bridges MQTT ↔ OPC-UA/historian
-  'temperature-sensor': ['modbus-tcp'], // FUXA Simulator → PLC via Modbus TCP
-  'gas-detector': ['modbus-tcp'],
-  'vibration-sensor': ['modbus-tcp'],
+  'smart-sensor': ['modbus-tcp'], // FUXA Simulator → PLC via Modbus TCP
   // ── Control Center (L3) ─────────────────────────────────────────────────────
   hmi: ['none'],
   historian: ['none'],
@@ -379,9 +378,7 @@ const CATEGORY_LABELS: Record<DeviceCategory, string> = {
   pmu: 'PMU',
   'iiot-sensor': 'IIoT Sensor',
   'iot-gateway': 'IoT GW',
-  'temperature-sensor': 'Temp Sensor',
-  'gas-detector': 'Gas Detector',
-  'vibration-sensor': 'Vibration',
+  'smart-sensor': 'Smart Sensor',
   // ── Control Center (L3) ─────────────────────────────────────────────────────
   hmi: 'HMI',
   historian: 'Historian',
@@ -1783,6 +1780,13 @@ export function ScadaCanvas({
           powerSource: 'solar-battery'
         }
         device.rtuConfig = defaultRtu
+      }
+
+      // smart-sensor devices get a sensible default sensor config (Temperature kind,
+      // sine waveform, -20..150°C) so the Sensor Configuration panel and canvas icon
+      // are immediately populated. Authors pick the kind via the Properties Panel dropdown.
+      if (category === 'smart-sensor') {
+        device.sensor = DEFAULT_SENSOR_CONFIG
       }
 
       // Use the pack device type's label if available; fall back to the built-in label.

--- a/packages/app/src/renderer/src/canvas/connectionRules.ts
+++ b/packages/app/src/renderer/src/canvas/connectionRules.ts
@@ -1072,9 +1072,7 @@ const CATEGORY_NAMES: Record<DeviceCategory, string> = {
   pmu: 'Phasor Measurement Unit',
   'iiot-sensor': 'IIoT Sensor',
   'iot-gateway': 'IoT Gateway',
-  'temperature-sensor': 'Temperature Sensor',
-  'gas-detector': 'Gas Detector',
-  'vibration-sensor': 'Vibration Sensor',
+  'smart-sensor': 'Smart Sensor',
   hmi: 'HMI',
   historian: 'Historian',
   'scada-server': 'SCADA Server',
@@ -1157,9 +1155,9 @@ const DEVICE_CABLE_CAPABILITIES: Record<DeviceCategory, Set<CableType>> = {
   pmu: new Set(['cat5e', 'cat6', 'mmf', 'smf', 'ac']), // Ethernet/fiber; GPS antenna not modeled
   'iiot-sensor': new Set(['wifi', 'dc']), // wireless only; battery/loop powered
   'iot-gateway': new Set(['rs485', 'cat5e', 'cat6', 'wifi', 'ac']), // bridges serial→Ethernet
-  'temperature-sensor': new Set(['rs485', 'cat5e', 'dc']), // 4-20 mA loop / Modbus RTU / Ethernet
-  'gas-detector': new Set(['rs485', 'cat5e', 'dc']), // 4-20 mA loop / Modbus RTU / relay
-  'vibration-sensor': new Set(['rs485', 'cat5e', 'wifi', 'dc']), // 4-20 mA / wireless IIoT
+  // Union of all three kinds' wiring options (Temperature/Gas: 4-20 mA loop, RS-485,
+  // Ethernet; Vibration adds Wi-Fi for wireless IIoT accelerometers).
+  'smart-sensor': new Set(['rs485', 'cat5e', 'wifi', 'dc']),
 
   // ── Control center (L3) — Ethernet; EWS also has RS-232 console port ─────────────
   // HMI: Cat5e/Cat6 wired; modern panel PCs may also have Wi-Fi for roaming tablets.

--- a/packages/app/src/renderer/src/icons/DeviceIcons.tsx
+++ b/packages/app/src/renderer/src/icons/DeviceIcons.tsx
@@ -21,7 +21,7 @@
  *   <DeviceIcon category="sensor" size={20} className="my-icon" />
  */
 
-import type { DeviceCategory } from '@otforge/schema'
+import type { DeviceCategory, SensorConfig } from '@otforge/schema'
 
 /**
  * Shared SVG presentation attributes applied to every icon.
@@ -909,9 +909,9 @@ const ICON_MAP: Record<DeviceCategory, () => JSX.Element> = {
   pmu: PmuSvg, // IEEE C37.118 Phasor Measurement Unit
   'iiot-sensor': IiotSensorSvg, // IIoT wireless sensor node
   'iot-gateway': IotGatewaySvg, // IIoT protocol gateway / Modbus-to-MQTT bridge
-  'temperature-sensor': TemperatureSensorSvg, // RTD/thermocouple temperature transmitter
-  'gas-detector': GasDetectorSvg, // fixed combustible/toxic gas detector
-  'vibration-sensor': VibrationSensorSvg, // rotating machinery vibration / accelerometer
+  // smart-sensor's icon actually varies by SensorConfig.kind (see SENSOR_KIND_ICONS below);
+  // this entry is the exhaustiveness fallback used only if no kind has been chosen yet.
+  'smart-sensor': TemperatureSensorSvg,
   // ── Control Center (Level 3) ────────────────────────────────────────────────
   hmi: HmiSvg,
   historian: HistorianSvg,
@@ -941,13 +941,27 @@ const ICON_MAP: Record<DeviceCategory, () => JSX.Element> = {
 }
 
 /**
+ * Per-kind icon lookup for the smart-sensor category. Unlike every other
+ * category, smart-sensor's icon depends on SensorConfig.kind rather than on
+ * DeviceCategory alone — the Properties Panel dropdown picks Temperature/Gas/
+ * Vibration, and the canvas node icon follows that choice.
+ */
+const SENSOR_KIND_ICONS: Record<SensorConfig['kind'], () => JSX.Element> = {
+  temperature: TemperatureSensorSvg,
+  gas: GasDetectorSvg,
+  vibration: VibrationSensorSvg
+}
+
+/**
  * Renders the ISA-5.1-inspired SVG icon for a given device category.
  *
  * Wraps the raw SVG in a `<span>` with `display: inline-flex` so it flows
  * correctly in both flex containers (palette items) and grid layouts (device nodes).
  * The `flexShrink: 0` prevents the icon from being squeezed in tight horizontal layouts.
  *
- * @param category  - The DeviceCategory to render an icon for.
+ * @param category   - The DeviceCategory to render an icon for.
+ * @param sensorKind - For category === 'smart-sensor', the chosen SensorConfig.kind;
+ *   selects Temperature/Gas/Vibration icon. Ignored for every other category.
  * @param size      - Width and height in pixels (defaults to 24).
  * @param color     - CSS color value passed as `color` to the span, inherited by
  *   `stroke: currentColor` inside the SVG. Defaults to 'currentColor'.
@@ -955,16 +969,19 @@ const ICON_MAP: Record<DeviceCategory, () => JSX.Element> = {
  */
 export function DeviceIcon({
   category,
+  sensorKind,
   size = 24,
   color = 'currentColor',
   className
 }: {
   category: DeviceCategory
+  sensorKind?: SensorConfig['kind']
   size?: number
   color?: string
   className?: string
 }) {
-  const IconComponent = ICON_MAP[category]
+  const IconComponent =
+    category === 'smart-sensor' && sensorKind ? SENSOR_KIND_ICONS[sensorKind] : ICON_MAP[category]
   return (
     <span
       className={className}

--- a/packages/app/src/renderer/src/palette/DevicePalette.tsx
+++ b/packages/app/src/renderer/src/palette/DevicePalette.tsx
@@ -46,7 +46,9 @@ interface PaletteSection {
  *
  * OT tab sections (Levels 0–2):
  *   Primary Control   — PLCs, Safety PLC, DCS Controller, RTU, IED
- *   Field Instruments — sensors, flow/pressure/level transmitters, analyzer
+ *   Field Instruments — sensors, flow/pressure/level transmitters, analyzer,
+ *                       smart sensor (Temperature/Gas/Vibration kind chosen in
+ *                       Properties Panel; FUXA-simulated, no container)
  *   Actuators & Drives — actuator, pump, valve, VFD
  *   IIoT / Wireless   — IIoT sensor node, IoT gateway
  *   Power / Grid      — PMU (power generation / transmission scenarios)
@@ -74,7 +76,8 @@ const PALETTE: PaletteSection[] = [
       { category: 'flow-meter', label: 'Flow Meter' },
       { category: 'pressure-transmitter', label: 'Pressure TX' },
       { category: 'level-transmitter', label: 'Level TX' },
-      { category: 'analyzer', label: 'Analyzer' }
+      { category: 'analyzer', label: 'Analyzer' },
+      { category: 'smart-sensor', label: 'Smart Sensor' }
     ]
   },
   {

--- a/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
+++ b/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
@@ -28,10 +28,11 @@
  */
 
 import { useEffect, useState } from 'react'
-import type { DeviceConfig, SecurityLayer, RtuConfig } from '@otforge/schema'
+import type { DeviceConfig, SecurityLayer, RtuConfig, SensorConfig } from '@otforge/schema'
 import { DeviceIcon } from '../icons/DeviceIcons'
 import { ZONE_COLORS } from '../canvas/DeviceNode'
 import { FirewallPanel, IDSPanel } from './SecurityPanel'
+import { SensorPanel } from './SensorPanel'
 
 /** Full human-readable names for the properties panel header. */
 const CATEGORY_LABELS: Record<string, string> = {
@@ -46,6 +47,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   valve: 'Control Valve',
   'flow-meter': 'Flow Meter',
   'pressure-transmitter': 'Pressure Transmitter',
+  'smart-sensor': 'Smart Sensor',
   firewall: 'Firewall',
   'ids-ips': 'IDS / IPS',
   switch: 'Network Switch',
@@ -85,7 +87,7 @@ interface PropertiesPanelProps {
    */
   onDeviceChange?: (
     nodeId: string,
-    changes: { ipAddress?: string; label?: string; rtuConfig?: RtuConfig }
+    changes: { ipAddress?: string; label?: string; rtuConfig?: RtuConfig; sensor?: SensorConfig }
   ) => void
   /**
    * Called when the user edits security config in FirewallPanel or IDSPanel.
@@ -116,6 +118,8 @@ interface PropertiesPanelProps {
  *   - Modbus config (if device.modbus is defined)
  *   - DNP3 config (if device.dnp3 is defined)
  *   - OPC UA config (if device.opcua is defined)
+ *   - Sensor config (SensorPanel) if category === 'smart-sensor' — kind dropdown
+ *     (Temperature/Gas/Vibration) plus waveform/range/Modbus register fields
  *   - Attack machine panel — "Open Attack Terminal" button when sim running,
  *     or a "start the simulation" note when idle.
  *
@@ -170,7 +174,12 @@ export function PropertiesPanel({
     <aside className="properties-panel">
       {/* Header: icon + category type label (colored by zone) + node ID */}
       <div className="properties-header">
-        <DeviceIcon category={device.category} size={22} color={zoneColor} />
+        <DeviceIcon
+          category={device.category}
+          sensorKind={device.sensor?.kind}
+          size={22}
+          color={zoneColor}
+        />
         <div className="properties-title">
           <div className="properties-name">{device.nodeId}</div>
           <div className="properties-type" style={{ color: zoneColor }}>
@@ -433,6 +442,16 @@ export function PropertiesPanel({
                 <code className="prop-value">{device.opcua.namespace}</code>
               </div>
             </section>
+          )}
+
+          {/* ── Smart sensor config (Temperature / Gas / Vibration) ────────────── */}
+          {device.category === 'smart-sensor' && (
+            <SensorPanel
+              sensorConfig={device.sensor}
+              nodeId={device.nodeId}
+              readOnly={readOnly}
+              onChange={(nodeId, sensor) => onDeviceChange?.(nodeId, { sensor })}
+            />
           )}
 
           {/* ── Firewall panel (Phase 5) ──────────────────────────────────────── */}

--- a/packages/app/src/renderer/src/properties/SensorPanel.tsx
+++ b/packages/app/src/renderer/src/properties/SensorPanel.tsx
@@ -1,0 +1,277 @@
+/**
+ * SensorPanel.tsx — smart-sensor configuration panel for the Properties Panel.
+ *
+ * Renders the configuration form for the consolidated smart-sensor device type.
+ * Rather than a separate DeviceCategory per physical instrument, smart-sensor
+ * carries a single `kind` field (Temperature / Gas / Vibration) selected here via
+ * dropdown — the canvas icon, default engineering units, and default range follow
+ * that choice automatically. This keeps adding a future sensor kind a config-only
+ * change: no new DeviceCategory, no touching every Record<DeviceCategory, ...>
+ * exhaustiveness table across the renderer and orchestrator packages.
+ *
+ * smart-sensor does NOT spawn a Docker container — fuxa-provisioning.ts reads this
+ * config at simulation start and writes it into FUXA's Simulator device/tag JSON.
+ * The PLC then polls the value over real Modbus TCP at `modbusRegister`.
+ *
+ * Author Mode: all fields are editable dropdowns / inputs; changes committed
+ *              immediately (select) or on blur (text/number inputs).
+ * Student Mode (readOnly): all values rendered as read-only badges.
+ */
+
+import { useEffect, useState } from 'react'
+import type { SensorConfig } from '@otforge/schema'
+
+type SensorKind = SensorConfig['kind']
+type Waveform = SensorConfig['waveform']
+
+// ── Option tables ────────────────────────────────────────────────────────────
+
+const KIND_OPTIONS: { value: SensorKind; label: string }[] = [
+  { value: 'temperature', label: 'Temperature' },
+  { value: 'gas', label: 'Gas Detector' },
+  { value: 'vibration', label: 'Vibration' }
+]
+
+const WAVEFORM_OPTIONS: { value: Waveform; label: string }[] = [
+  { value: 'sine', label: 'Sine (smooth oscillation)' },
+  { value: 'random', label: 'Random (white noise)' },
+  { value: 'sawtooth', label: 'Sawtooth (ramp + reset)' },
+  { value: 'square', label: 'Square (two-state)' },
+  { value: 'constant', label: 'Constant' }
+]
+
+/**
+ * Sensible engineering-unit / range / waveform defaults per sensor kind.
+ * Applied whenever the author switches the Kind dropdown, since a temperature
+ * range in °C makes no sense once the node becomes a gas detector reading ppm.
+ */
+const KIND_DEFAULTS: Record<
+  SensorKind,
+  Pick<SensorConfig, 'units' | 'minValue' | 'maxValue' | 'waveform' | 'noisePercent'>
+> = {
+  temperature: { units: '°C', minValue: -20, maxValue: 150, waveform: 'sine', noisePercent: 5 },
+  gas: { units: 'ppm', minValue: 0, maxValue: 100, waveform: 'random', noisePercent: 10 },
+  vibration: { units: 'mm/s²', minValue: 0, maxValue: 50, waveform: 'sine', noisePercent: 15 }
+}
+
+// ── Default config ────────────────────────────────────────────────────────────
+
+/**
+ * Sensible default values used when a smart-sensor is first dropped onto the
+ * canvas and no SensorConfig has been set yet.
+ */
+export const DEFAULT_SENSOR_CONFIG: SensorConfig = {
+  kind: 'temperature',
+  ...KIND_DEFAULTS.temperature,
+  modbusRegister: 0
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface SensorPanelProps {
+  /** Current sensor configuration (may be undefined if device predates this feature). */
+  sensorConfig?: SensorConfig
+  /** Node ID of the smart-sensor device — passed through to the onChange callback. */
+  nodeId: string
+  /** When true, all fields are rendered as read-only text (Student Mode). */
+  readOnly: boolean
+  /**
+   * Called whenever any sensor configuration field changes.
+   * Receives the complete updated SensorConfig so App.tsx can replace the stored config atomically.
+   */
+  onChange?: (nodeId: string, config: SensorConfig) => void
+}
+
+/**
+ * Menu-driven smart-sensor configuration panel.
+ *
+ * Manages a local copy of the SensorConfig and calls onChange whenever the
+ * author commits a change (immediately for selects; on blur for text/number inputs).
+ */
+export function SensorPanel({ sensorConfig, nodeId, readOnly, onChange }: SensorPanelProps) {
+  // Merge incoming config with defaults so every field always has a valid value.
+  // This handles smart-sensor devices created before SensorConfig had a required `kind`.
+  const [cfg, setCfg] = useState<SensorConfig>({ ...DEFAULT_SENSOR_CONFIG, ...sensorConfig })
+
+  // Re-sync local state when the selected device changes or its config is updated externally.
+  useEffect(() => {
+    setCfg({ ...DEFAULT_SENSOR_CONFIG, ...sensorConfig })
+  }, [nodeId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  /**
+   * Switches the sensor kind and resets units/range/waveform/noise to that
+   * kind's sensible defaults. Modbus register, sample rate, alarm band, and
+   * tag name are left untouched since those are placement-specific, not kind-specific.
+   */
+  function handleKindChange(kind: SensorKind): void {
+    const next = { ...cfg, kind, ...KIND_DEFAULTS[kind] }
+    setCfg(next)
+    onChange?.(nodeId, next)
+  }
+
+  /** Updates the waveform — selecting an option is an explicit commit, no blur needed. */
+  function handleWaveformChange(waveform: Waveform): void {
+    const next = { ...cfg, waveform }
+    setCfg(next)
+    onChange?.(nodeId, next)
+  }
+
+  /** Commits the current local config on blur — used by all numeric/text inputs. */
+  function commit(): void {
+    onChange?.(nodeId, cfg)
+  }
+
+  const kindLabel = KIND_OPTIONS.find(o => o.value === cfg.kind)?.label ?? cfg.kind
+  const waveformLabel = WAVEFORM_OPTIONS.find(o => o.value === cfg.waveform)?.label ?? cfg.waveform
+
+  return (
+    <section className="prop-section">
+      <div className="prop-section-title">Sensor Configuration</div>
+
+      {/* Kind — Temperature / Gas / Vibration */}
+      <div className="prop-row">
+        <span className="prop-label">Kind</span>
+        {readOnly ? (
+          <span className="prop-value">{kindLabel}</span>
+        ) : (
+          <select
+            className="rtu-select"
+            value={cfg.kind}
+            onChange={e => handleKindChange(e.target.value as SensorKind)}
+          >
+            {KIND_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {/* Waveform */}
+      <div className="prop-row">
+        <span className="prop-label">Waveform</span>
+        {readOnly ? (
+          <span className="prop-value">{waveformLabel}</span>
+        ) : (
+          <select
+            className="rtu-select"
+            value={cfg.waveform}
+            onChange={e => handleWaveformChange(e.target.value as Waveform)}
+          >
+            {WAVEFORM_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {/* Range — min/max engineering value */}
+      <div className="prop-row">
+        <span className="prop-label">Range</span>
+        {readOnly ? (
+          <span className="prop-value">
+            {cfg.minValue} – {cfg.maxValue} {cfg.units}
+          </span>
+        ) : (
+          <div className="rtu-interval-row">
+            <input
+              className="prop-input prop-input-mono rtu-interval-input"
+              type="number"
+              value={cfg.minValue}
+              onChange={e => setCfg(prev => ({ ...prev, minValue: Number(e.target.value) || 0 }))}
+              onBlur={commit}
+            />
+            <span className="rtu-interval-unit">–</span>
+            <input
+              className="prop-input prop-input-mono rtu-interval-input"
+              type="number"
+              value={cfg.maxValue}
+              onChange={e => setCfg(prev => ({ ...prev, maxValue: Number(e.target.value) || 0 }))}
+              onBlur={commit}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Units — free text, e.g. °C, ppm, mm/s² */}
+      <div className="prop-row">
+        <span className="prop-label">Units</span>
+        {readOnly ? (
+          <code className="prop-value">{cfg.units}</code>
+        ) : (
+          <input
+            className="prop-input prop-input-mono"
+            type="text"
+            value={cfg.units}
+            onChange={e => setCfg(prev => ({ ...prev, units: e.target.value }))}
+            onBlur={commit}
+          />
+        )}
+      </div>
+
+      {/* Noise % */}
+      <div className="prop-row">
+        <span className="prop-label">Noise</span>
+        {readOnly ? (
+          <span className="prop-value">{cfg.noisePercent}%</span>
+        ) : (
+          <div className="rtu-interval-row">
+            <input
+              className="prop-input prop-input-mono rtu-interval-input"
+              type="number"
+              min={0}
+              max={100}
+              value={cfg.noisePercent}
+              onChange={e =>
+                setCfg(prev => ({ ...prev, noisePercent: Number(e.target.value) || 0 }))
+              }
+              onBlur={commit}
+            />
+            <span className="rtu-interval-unit">%</span>
+          </div>
+        )}
+      </div>
+
+      {/* Modbus register — FC03 holding register address FUXA exposes this tag on */}
+      <div className="prop-row">
+        <span className="prop-label">Modbus Reg</span>
+        {readOnly ? (
+          <code className="prop-value">{cfg.modbusRegister}</code>
+        ) : (
+          <input
+            className="prop-input prop-input-mono"
+            type="number"
+            min={0}
+            value={cfg.modbusRegister}
+            onChange={e =>
+              setCfg(prev => ({ ...prev, modbusRegister: Number(e.target.value) || 0 }))
+            }
+            onBlur={commit}
+          />
+        )}
+      </div>
+
+      {/* Tag name override — optional, free text */}
+      <div className="prop-row">
+        <span className="prop-label">Tag Name</span>
+        {readOnly ? (
+          <span className="prop-value">
+            {cfg.tagName || <em className="prop-value-muted">auto</em>}
+          </span>
+        ) : (
+          <input
+            className="prop-input"
+            type="text"
+            placeholder="auto from label"
+            value={cfg.tagName ?? ''}
+            onChange={e => setCfg(prev => ({ ...prev, tagName: e.target.value }))}
+            onBlur={commit}
+          />
+        )}
+      </div>
+    </section>
+  )
+}

--- a/packages/orchestrator/src/__tests__/schema-fuzz.test.ts
+++ b/packages/orchestrator/src/__tests__/schema-fuzz.test.ts
@@ -107,9 +107,7 @@ const deviceCategory = fc.constantFrom(
   'process-unit',
   'flow-meter',
   'pressure-transmitter',
-  'temperature-sensor',
-  'gas-detector',
-  'vibration-sensor'
+  'smart-sensor'
 )
 
 /** Well-formed CIDR strings from common RFC 1918 ranges */

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -80,9 +80,7 @@ const DEVICE_IMAGES: Record<DeviceCategory, string> = {
   // STUB: IoT gateway — MQTT broker/bridge stub until otforge-iot-gateway is built.
   'iot-gateway': 'ghcr.io/iburres/alpine:latest',
   // No container — values live in FUXA Simulator; image field satisfies Record type only.
-  'temperature-sensor': '',
-  'gas-detector': '',
-  'vibration-sensor': '',
+  'smart-sensor': '',
   // ── Control Center (Level 3) ────────────────────────────────────────────────
   hmi: 'ghcr.io/iburres/fuxa:latest',
   // OPC UA 1.04 server — asyncua Python server on Alpine (containers/opcua)
@@ -163,9 +161,7 @@ const DEVICE_LIMITS: Record<DeviceCategory, { memory: number; cpus: string }> = 
   'iiot-sensor': { memory: 64, cpus: '0.1' }, // IIoT sensor — lightweight MQTT publish loop
   'iot-gateway': { memory: 96, cpus: '0.2' }, // IoT gateway — MQTT broker + protocol bridge
   // No container — zero resource budget; FUXA Simulator provides the synthetic values.
-  'temperature-sensor': { memory: 0, cpus: '0' },
-  'gas-detector': { memory: 0, cpus: '0' },
-  'vibration-sensor': { memory: 0, cpus: '0' },
+  'smart-sensor': { memory: 0, cpus: '0' },
   // ── Control Center (Level 3) ────────────────────────────────────────────────
   hmi: { memory: 256, cpus: '0.5' }, // FUXA Node.js HMI
   'scada-server': { memory: 256, cpus: '0.5' }, // OPC UA server (asyncua Python)
@@ -510,17 +506,11 @@ export function generateCompose(
     return `${prefix}${host}`
   }
 
-  // Sensor categories that live entirely inside FUXA's Simulator device — no Docker
-  // container is spawned. fuxa-provisioning.ts reads their SensorConfig and generates
-  // the corresponding FUXA device/tag JSON before compose up.
-  const FUXA_SENSOR_CATEGORIES = new Set<DeviceCategory>([
-    'temperature-sensor',
-    'gas-detector',
-    'vibration-sensor'
-  ])
-
   for (const [nodeId, device] of Object.entries(scenario.devices.devices)) {
-    if (FUXA_SENSOR_CATEGORIES.has(device.category)) continue
+    // smart-sensor lives entirely inside FUXA's Simulator device — no Docker container
+    // is spawned. fuxa-provisioning.ts reads its SensorConfig and generates the
+    // corresponding FUXA device/tag JSON before compose up.
+    if (device.category === 'smart-sensor') continue
 
     // Use a custom image if specified (for advanced scenarios), otherwise use the category default
     const image = device.dockerImage ?? DEVICE_IMAGES[device.category]

--- a/packages/schema/src/icslab.ts
+++ b/packages/schema/src/icslab.ts
@@ -87,9 +87,7 @@ export type DeviceCategory =
   | 'pmu' // Phasor Measurement Unit — IEEE C37.118 synchrophasor, GPS-timestamped grid telemetry
   | 'iiot-sensor' // IIoT wireless sensor node — WirelessHART, ISA100.11a, MQTT publisher
   | 'iot-gateway' // IIoT protocol gateway — Modbus-to-MQTT/REST bridge, edge aggregator
-  | 'temperature-sensor' // Temperature transmitter — RTD/thermocouple, 4-20 mA / HART output
-  | 'gas-detector' // Fixed gas detector — combustible / toxic gas, 4-20 mA / relay output
-  | 'vibration-sensor' // Vibration / proximity sensor — rotating machinery health monitoring
+  | 'smart-sensor' // Configurable field sensor (Temperature / Gas / Vibration — pick `kind` in Properties Panel); FUXA-Simulator-driven, no container
   // ── Control Center (Level 3) ─────────────────────────────────────────────────
   | 'hmi'
   | 'historian'
@@ -579,13 +577,17 @@ export interface RtuConfig {
 }
 
 /**
- * Physics simulation parameters for sensor nodes on the OT canvas.
+ * Physics simulation parameters for the smart-sensor canvas node.
  *
- * Sensor nodes (temperature-sensor, pressure-transmitter, flow-meter,
- * level-transmitter, gas-detector, vibration-sensor) do NOT spawn Docker
- * containers. Instead, this config is read at simulation start by
- * fuxa-provisioning.ts and written into FUXA's device/tag JSON so the
- * FUXA Simulator device generates realistic synthetic process values.
+ * smart-sensor does NOT spawn a Docker container. Instead, this config is read
+ * at simulation start by fuxa-provisioning.ts and written into FUXA's device/tag
+ * JSON so the FUXA Simulator device generates realistic synthetic process values.
+ *
+ * `kind` selects which physical instrument this node represents — Temperature,
+ * Gas, or Vibration — chosen from a dropdown in the Properties Panel rather than
+ * a separate DeviceCategory per sensor type. This keeps adding a new sensor type
+ * a config-only change (no new DeviceCategory, no touching every
+ * Record<DeviceCategory, ...> exhaustiveness table across the renderer/orchestrator).
  *
  * The PLC polls sensor values over real Modbus TCP — FUXA exposes each
  * sensor tag as a holding register at the address in `modbusRegister`.
@@ -599,6 +601,8 @@ export interface RtuConfig {
  *   constant — fixed value at (min + max) / 2 (baseline / fault scenario)
  */
 export interface SensorConfig {
+  /** Which physical instrument this node represents. Drives the icon, default units/range, and FUXA tag. */
+  kind: 'temperature' | 'gas' | 'vibration'
   /**
    * FUXA Simulator waveform type for this sensor tag.
    * Determines the shape of the synthetic process value over time.
@@ -664,7 +668,7 @@ export interface DeviceConfig {
   plcProgram?: PLCProgramConfig
   safetyPlc?: SafetyPlcConfig // SIS config for safety-plc devices
   rtuConfig?: RtuConfig // RTU deployment configuration (rtu, iec104-rtu devices)
-  sensor?: SensorConfig // Physics simulation parameters for sensor canvas nodes (no container)
+  sensor?: SensorConfig // Physics simulation parameters for smart-sensor canvas nodes (no container)
   dockerImage?: string // override default image for this device type
   /**
    * Additional Purdue Model zone networks to attach this device to, beyond the


### PR DESCRIPTION
## Summary
- Replaces `temperature-sensor`/`gas-detector`/`vibration-sensor` with one `smart-sensor` DeviceCategory plus a `SensorConfig.kind` dropdown (Temperature/Gas/Vibration) — these three were structurally identical (no container, same FUXA Simulator config) and each new kind required touching six separate `Record<DeviceCategory, ...>` tables across the renderer and orchestrator.
- Adds `SensorPanel.tsx` (Properties Panel) so the kind/waveform/range/units/noise/Modbus register fields are configurable in Author Mode instead of JSON-only.
- Icon now resolves per `SensorConfig.kind` rather than per category.
- Adds `docs/research/fuxa-demo-export.json` — decoded reference for FUXA's stock demo project (HMI widget-type naming), recovered from a stray file left over from manual icon-rendering research.

## Test plan
- [x] `tsc --noEmit` clean on schema/orchestrator/app packages
- [x] `npm run lint` — no new warnings/errors
- [x] orchestrator test suite (157 tests, incl. schema-fuzz) passes
- [ ] CI: build/CodeQL/Gitleaks workflows green