### PR TITLE
feat(schema): split power-electric sector, add chemical-batch

### DIFF
--- a/packages/app/src/renderer/src/metadata/MetadataModal.tsx
+++ b/packages/app/src/renderer/src/metadata/MetadataModal.tsx
@@ -23,8 +23,10 @@ import type { OTForgeMeta, Sector } from '@otforge/schema'
 const SECTOR_OPTIONS: { value: Sector; label: string }[] = [
   { value: 'generic', label: 'Generic (no specific sector)' },
   { value: 'oil-gas', label: 'Oil & Gas' },
-  { value: 'power-electric', label: 'Power & Electric' },
+  { value: 'power-generation', label: 'Power Generation' },
+  { value: 'power-distribution', label: 'Power Distribution' },
   { value: 'water-treatment', label: 'Water Treatment' },
+  { value: 'chemical-batch', label: 'Chemical / Batch Processing' },
   { value: 'automotive', label: 'Automotive Manufacturing' }
 ]
 

--- a/packages/schema/src/icslab.ts
+++ b/packages/schema/src/icslab.ts
@@ -2,7 +2,14 @@
 // All four layers are present in unlocked scenarios. Locked scenarios omit visual/security
 // layer details to prevent topology extraction by students.
 
-export type Sector = 'oil-gas' | 'power-electric' | 'water-treatment' | 'automotive' | 'generic'
+export type Sector =
+  | 'oil-gas'
+  | 'power-generation'
+  | 'power-distribution'
+  | 'water-treatment'
+  | 'chemical-batch'
+  | 'automotive'
+  | 'generic'
 
 export type Protocol =
   | 'modbus-tcp'


### PR DESCRIPTION
Sector enum couldn't distinguish power generation from distribution and had no slot for chemical/batch (brewery-style) scenarios. First step of the device/protocol audit roadmap. No scenario files used power-electric, so this is a clean rename with no migration needed.