### PR TITLE
feat(schema): generalize device-authoring pattern via smart-controller

### DIFF
--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -46,6 +46,7 @@ import type {
   ResolvedPackDeviceType,
   RtuConfig,
   SensorConfig,
+  ControllerConfig,
   FluidType
 } from '@otforge/schema'
 import { ScadaCanvas } from './canvas/ScadaCanvas'
@@ -907,7 +908,13 @@ export default function App() {
   const handleDeviceChange = useCallback(
     (
       nodeId: string,
-      changes: { ipAddress?: string; label?: string; rtuConfig?: RtuConfig; sensor?: SensorConfig }
+      changes: {
+        ipAddress?: string
+        label?: string
+        rtuConfig?: RtuConfig
+        sensor?: SensorConfig
+        controller?: ControllerConfig
+      }
     ) => {
       setScenario(prev => {
         if (!prev) return prev

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -75,6 +75,7 @@ import {
   isProtocolCableCompatible
 } from './connectionRules'
 import { DEFAULT_SENSOR_CONFIG } from '../properties/SensorPanel'
+import { DEFAULT_CONTROLLER_CONFIG } from '../properties/ControllerPanel'
 
 /**
  * Protocol options shown in the "Application Protocol" section of the connection menu.
@@ -311,22 +312,14 @@ const DEFAULT_PROTOCOLS: Record<DeviceCategory, Protocol[]> = {
   ied: ['dnp3'],
   'safety-plc': ['modbus-tcp'], // SIS — same Modbus transport as standard PLC
   'dcs-controller': ['opc-ua'], // DCS prefers OPC-UA upward by convention
-  vfd: ['modbus-rtu'], // most VFDs ship with Modbus RTU by default
   'legacy-plc': ['s7comm'], // Siemens S7 — S7comm primary protocol (Phase 10)
   'iec104-rtu': ['iec-104'], // IEC 60870-5-104 RTU (Phase 10)
   'process-unit': ['modbus-tcp'], // physics process sim — Modbus TCP server (Phase 11)
   sensor: ['modbus-tcp'],
-  actuator: ['modbus-tcp'],
-  pump: ['modbus-tcp'],
-  valve: ['modbus-tcp'],
-  'flow-meter': ['modbus-tcp'],
-  'pressure-transmitter': ['modbus-tcp'],
-  'level-transmitter': ['modbus-tcp'],
-  analyzer: ['modbus-tcp'],
-  pmu: ['dnp3'], // PMUs report via DNP3 by default; IEC 61850 in substation deployments
   'iiot-sensor': ['mqtt'], // wireless IIoT sensor publishes MQTT
   'iot-gateway': ['mqtt'], // gateway bridges MQTT ↔ OPC-UA/historian
   'smart-sensor': ['modbus-tcp'], // FUXA Simulator → PLC via Modbus TCP
+  'smart-controller': ['modbus-tcp'], // real pymodbus container → PLC via Modbus TCP
   // ── Control Center (L3) ─────────────────────────────────────────────────────
   hmi: ['none'],
   historian: ['none'],
@@ -363,22 +356,14 @@ const CATEGORY_LABELS: Record<DeviceCategory, string> = {
   ied: 'IED',
   'safety-plc': 'Safety PLC',
   'dcs-controller': 'DCS Ctrl',
-  vfd: 'VFD',
   'legacy-plc': 'S7 PLC', // Phase 10
   'iec104-rtu': 'IEC 104', // Phase 10
   'process-unit': 'Process Unit', // Phase 11
   sensor: 'Sensor',
-  actuator: 'Actuator',
-  pump: 'Pump',
-  valve: 'Valve',
-  'flow-meter': 'Flow Meter',
-  'pressure-transmitter': 'Pressure TX',
-  'level-transmitter': 'Level TX',
-  analyzer: 'Analyzer',
-  pmu: 'PMU',
   'iiot-sensor': 'IIoT Sensor',
   'iot-gateway': 'IoT GW',
   'smart-sensor': 'Smart Sensor',
+  'smart-controller': 'Smart Ctrl',
   // ── Control Center (L3) ─────────────────────────────────────────────────────
   hmi: 'HMI',
   historian: 'Historian',
@@ -1787,6 +1772,13 @@ export function ScadaCanvas({
       // are immediately populated. Authors pick the kind via the Properties Panel dropdown.
       if (category === 'smart-sensor') {
         device.sensor = DEFAULT_SENSOR_CONFIG
+      }
+
+      // smart-controller devices get a sensible default controller config (Pump kind)
+      // so the Controller Configuration panel and canvas icon are immediately populated.
+      // Authors pick the kind via the Properties Panel dropdown.
+      if (category === 'smart-controller') {
+        device.controller = DEFAULT_CONTROLLER_CONFIG
       }
 
       // Use the pack device type's label if available; fall back to the built-in label.

--- a/packages/app/src/renderer/src/canvas/connectionRules.ts
+++ b/packages/app/src/renderer/src/canvas/connectionRules.ts
@@ -69,14 +69,8 @@ export const VALID_CONNECTIONS: Partial<
   // ── PLC (Modbus master, EtherNet/IP peer, OPC-UA server upward) ────────────
   plc: {
     sensor: ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
-    actuator: ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
-    pump: ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
-    valve: ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
-    'flow-meter': ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
-    'pressure-transmitter': ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
-    'level-transmitter': ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
-    analyzer: ['modbus-tcp', 'modbus-rtu', 'opc-ua'],
-    vfd: ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'], // PLC drives VFDs via fieldbus
+    'smart-controller': ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
+    'smart-sensor': ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'opc-ua'],
     rtu: ['modbus-tcp', 'modbus-rtu', 'dnp3'],
     ied: ['modbus-tcp', 'iec61850'],
     plc: ['modbus-tcp', 'ethernet-ip'], // peer-to-peer PLC network
@@ -95,15 +89,8 @@ export const VALID_CONNECTIONS: Partial<
   // ── RTU (remote terminal unit — serial concentrator for field and SCADA) ────
   rtu: {
     sensor: ['modbus-rtu', 'modbus-tcp', 'dnp3'],
-    actuator: ['modbus-rtu', 'modbus-tcp', 'dnp3'],
-    pump: ['modbus-rtu', 'modbus-tcp', 'dnp3'],
-    valve: ['modbus-rtu', 'modbus-tcp', 'dnp3'],
-    'flow-meter': ['modbus-rtu', 'modbus-tcp', 'dnp3'],
-    'pressure-transmitter': ['modbus-rtu', 'modbus-tcp', 'dnp3'],
-    'level-transmitter': ['modbus-rtu', 'modbus-tcp', 'dnp3'],
-    analyzer: ['modbus-rtu', 'modbus-tcp'],
-    vfd: ['modbus-rtu', 'modbus-tcp'],
-    pmu: ['dnp3', 'modbus-tcp'], // RTU collects PMU data via DNP3 or Modbus
+    'smart-controller': ['modbus-rtu', 'modbus-tcp', 'dnp3'],
+    'smart-sensor': ['modbus-rtu', 'modbus-tcp', 'dnp3'], // includes former pmu (RTU collects via DNP3/Modbus)
     plc: ['modbus-tcp', 'modbus-rtu', 'dnp3'],
     'legacy-plc': ['s7comm', 'modbus-tcp'], // RTU → Siemens S7 peer (Phase 10)
     'iec104-rtu': ['iec-104', 'modbus-tcp'], // RTU → IEC 104 RTU peer (Phase 10)
@@ -123,7 +110,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['iec61850', 'dnp3'], // GOOSE between peer IEDs
     rtu: ['iec61850', 'dnp3'],
     plc: ['iec61850', 'modbus-tcp'],
-    pmu: ['iec61850', 'dnp3'], // IED receives PMU synchrophasor data
+    'smart-sensor': ['iec61850', 'dnp3'], // includes former pmu — IED receives synchrophasor data
     'legacy-plc': ['s7comm'], // IED → Siemens S7 (S7comm read, Phase 10)
     'iec104-rtu': ['iec-104', 'dnp3'], // IED → IEC 104 RTU (Phase 10)
     hmi: ['dnp3', 'iec61850'],
@@ -143,12 +130,8 @@ export const VALID_CONNECTIONS: Partial<
   // serial cross-connections violate ISA-84 separation requirements.
   'safety-plc': {
     sensor: ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'],
-    actuator: ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'], // final element ESD valve/relay
-    pump: ['modbus-tcp', 'modbus-rtu'],
-    valve: ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'],
-    'flow-meter': ['modbus-tcp', 'modbus-rtu'],
-    'pressure-transmitter': ['modbus-tcp', 'modbus-rtu'],
-    'level-transmitter': ['modbus-tcp', 'modbus-rtu'],
+    'smart-controller': ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'], // final element ESD valve/relay
+    'smart-sensor': ['modbus-tcp', 'modbus-rtu'],
     plc: ['ethernet-ip', 'modbus-tcp'], // read-only status sharing with BPCS
     hmi: ['modbus-tcp', 'opc-ua'], // operator visibility (read-only view of SIS status)
     historian: ['opc-ua'], // safety event logging
@@ -167,14 +150,9 @@ export const VALID_CONNECTIONS: Partial<
   // Modbus/serial (downward to legacy field instruments).
   'dcs-controller': {
     sensor: ['modbus-tcp', 'modbus-rtu', 'opc-ua'],
-    actuator: ['modbus-tcp', 'modbus-rtu'],
-    pump: ['modbus-tcp', 'modbus-rtu'],
-    valve: ['modbus-tcp', 'modbus-rtu'],
-    'flow-meter': ['modbus-tcp', 'modbus-rtu', 'opc-ua'],
-    'pressure-transmitter': ['modbus-tcp', 'modbus-rtu'],
-    'level-transmitter': ['modbus-tcp', 'modbus-rtu'],
-    analyzer: ['modbus-tcp', 'modbus-rtu', 'opc-ua'],
-    vfd: ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'],
+    // Includes former vfd/actuator/pump/valve (Stuxnet manipulated Siemens VFDs this way)
+    'smart-controller': ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'],
+    'smart-sensor': ['modbus-tcp', 'modbus-rtu', 'opc-ua'],
     rtu: ['modbus-tcp'],
     plc: ['opc-ua', 'modbus-tcp'], // data exchange with adjacent PLC system
     hmi: ['opc-ua', 'modbus-tcp'],
@@ -184,20 +162,6 @@ export const VALID_CONNECTIONS: Partial<
     switch: ['none'],
     router: ['none'],
     firewall: ['none'],
-    'ids-ips': ['none']
-  },
-
-  // ── VFD / Motor Drive (polled by PLC, RTU, or DCS; passive Modbus slave) ─────
-  // Variable Frequency Drives are AC motor controllers. They accept speed/torque
-  // setpoints from a master PLC or DCS via Modbus or EtherNet/IP and report
-  // speed, current, fault status. The Stuxnet worm manipulated Siemens VFDs by
-  // intercepting and replaying Modbus write commands to the drive frequency register.
-  vfd: {
-    plc: ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'],
-    rtu: ['modbus-rtu', 'modbus-tcp'],
-    'dcs-controller': ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'],
-    switch: ['none'],
-    router: ['none'],
     'ids-ips': ['none']
   },
 
@@ -226,8 +190,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['dnp3', 'iec61850'],
     'safety-plc': ['opc-ua'], // logs safety system events
     'dcs-controller': ['opc-ua', 'modbus-tcp'],
-    analyzer: ['opc-ua', 'modbus-tcp'], // analyzers often connect directly to historian
-    pmu: ['dnp3', 'opc-ua'],
+    'smart-sensor': ['opc-ua', 'modbus-tcp', 'dnp3'], // includes former analyzer/pmu
     'iot-gateway': ['mqtt', 'opc-ua'], // IIoT time-series data
     'legacy-plc': ['s7comm', 'opc-ua'], // Historian archives Siemens S7 data (Phase 10)
     'iec104-rtu': ['iec-104'], // Historian archives IEC 104 RTU data (Phase 10)
@@ -251,7 +214,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['iec61850', 'dnp3'],
     'dcs-controller': ['opc-ua', 'modbus-tcp'],
     'safety-plc': ['opc-ua', 'modbus-tcp'],
-    pmu: ['dnp3', 'opc-ua'],
+    'smart-sensor': ['dnp3', 'opc-ua'], // includes former pmu
     'iot-gateway': ['opc-ua', 'mqtt'],
     'legacy-plc': ['s7comm', 'opc-ua'], // Phase 10
     'iec104-rtu': ['iec-104'], // Phase 10
@@ -275,14 +238,11 @@ export const VALID_CONNECTIONS: Partial<
   // connections so the pipe renders at full opacity with animated icons; 'none' is
   // also permitted for untagged physical connections.
   'process-unit': {
-    pump: ['modbus-tcp', 'none'], // inlet / discharge pipe
-    valve: ['modbus-tcp', 'none'], // outlet / control valve pipe
     sensor: ['modbus-tcp', 'none'], // sensor measures vessel (e.g., level sensor on tank)
-    actuator: ['modbus-tcp', 'none'], // actuator driven by vessel state (e.g., ESD damper)
-    'flow-meter': ['modbus-tcp', 'none'], // flow measurement on inlet or outlet pipe
-    'level-transmitter': ['modbus-tcp', 'none'], // level transmitter mounted on vessel
-    'pressure-transmitter': ['modbus-tcp', 'none'], // pressure tap on vessel
-    analyzer: ['modbus-tcp', 'none'], // inline analyzer (pH, TOC, conductivity)
+    // Includes former pump/valve/actuator — pipe / control valve / ESD damper attached to vessel
+    'smart-controller': ['modbus-tcp', 'none'],
+    // Includes former flow-meter/level-transmitter/pressure-transmitter/analyzer
+    'smart-sensor': ['modbus-tcp', 'none'],
     'process-unit': ['modbus-tcp', 'none'], // vessel-to-vessel pipe (e.g., tank feeds reactor)
     switch: ['none'],
     router: ['none'],
@@ -296,11 +256,8 @@ export const VALID_CONNECTIONS: Partial<
   // Modbus master to poll classic Modbus field devices.
   'legacy-plc': {
     sensor: ['s7comm', 'modbus-tcp', 'modbus-rtu'],
-    actuator: ['s7comm', 'modbus-tcp', 'modbus-rtu'],
-    pump: ['s7comm', 'modbus-tcp', 'modbus-rtu'],
-    valve: ['s7comm', 'modbus-tcp', 'modbus-rtu'],
-    'flow-meter': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
-    'pressure-transmitter': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
+    'smart-controller': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
+    'smart-sensor': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
     plc: ['s7comm', 'modbus-tcp'], // peer PLC
     rtu: ['s7comm', 'modbus-tcp'], // upward to SCADA RTU
     ied: ['s7comm'], // IED in substation
@@ -320,11 +277,8 @@ export const VALID_CONNECTIONS: Partial<
   // SCADA master (HMI/Historian) using the IEC 104 telecontrol protocol.
   'iec104-rtu': {
     sensor: ['modbus-rtu', 'modbus-tcp'],
-    actuator: ['modbus-rtu', 'modbus-tcp'],
-    pump: ['modbus-rtu', 'modbus-tcp'],
-    valve: ['modbus-rtu', 'modbus-tcp'],
-    'flow-meter': ['modbus-rtu', 'modbus-tcp'],
-    'pressure-transmitter': ['modbus-rtu', 'modbus-tcp'],
+    'smart-controller': ['modbus-rtu', 'modbus-tcp'],
+    'smart-sensor': ['modbus-rtu', 'modbus-tcp'],
     plc: ['iec-104', 'modbus-tcp'], // peer PLC / SCADA master
     rtu: ['iec-104'], // peer RTU (RTU concentrator chain)
     ied: ['iec-104', 'dnp3'], // IED in same zone
@@ -368,107 +322,46 @@ export const VALID_CONNECTIONS: Partial<
     'iec104-rtu': ['modbus-rtu', 'modbus-tcp'],
     'iot-gateway': ['mqtt', 'modbus-tcp'],
     'process-unit': ['modbus-tcp', 'none'], // P&ID: sensor mounted on / measuring the vessel
-    actuator: ['modbus-tcp', 'none'] // P&ID: positioner feedback — sensor reads actuator position
-  },
-  actuator: {
-    plc: ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
-    rtu: ['modbus-rtu', 'modbus-tcp'],
-    ied: ['dnp3'],
-    'safety-plc': ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'],
-    'dcs-controller': ['modbus-tcp', 'modbus-rtu'],
-    'legacy-plc': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
-    'iec104-rtu': ['modbus-rtu', 'modbus-tcp'],
-    'process-unit': ['modbus-tcp', 'none'], // P&ID: actuator driven by / attached to vessel
-    valve: ['modbus-tcp', 'none'], // P&ID: actuator drives the valve stem (electric/pneumatic)
-    sensor: ['modbus-tcp', 'none'] // P&ID: positioner feedback sensor on actuator
-  },
-  pump: {
-    plc: ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
-    rtu: ['modbus-rtu', 'modbus-tcp'],
-    ied: ['dnp3'],
-    'safety-plc': ['modbus-tcp', 'modbus-rtu'],
-    'dcs-controller': ['modbus-tcp', 'modbus-rtu'],
-    'legacy-plc': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
-    'iec104-rtu': ['modbus-rtu', 'modbus-tcp'],
-    'process-unit': ['modbus-tcp', 'none'], // P&ID: pump feeds or drains the vessel
-    valve: ['modbus-tcp', 'none'], // P&ID: discharge / suction valve on pump line
-    'flow-meter': ['modbus-tcp', 'none'], // P&ID: flow meter inline on pump discharge
-    'pressure-transmitter': ['modbus-tcp', 'none'] // P&ID: pressure tap on pump discharge
-  },
-  valve: {
-    plc: ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
-    rtu: ['modbus-rtu', 'modbus-tcp'],
-    ied: ['dnp3'],
-    'safety-plc': ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'],
-    'dcs-controller': ['modbus-tcp', 'modbus-rtu'],
-    'legacy-plc': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
-    'iec104-rtu': ['modbus-rtu', 'modbus-tcp'],
-    'process-unit': ['modbus-tcp', 'none'], // P&ID: valve on vessel outlet / bypass
-    actuator: ['modbus-tcp', 'none'], // P&ID: actuator mounted on valve body
-    pump: ['modbus-tcp', 'none'], // P&ID: valve on pump suction or discharge line
-    'flow-meter': ['modbus-tcp', 'none'], // P&ID: flow meter downstream of valve
-    'pressure-transmitter': ['modbus-tcp', 'none'] // P&ID: pressure tap downstream of valve
-  },
-  'flow-meter': {
-    plc: ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
-    rtu: ['modbus-rtu', 'modbus-tcp'],
-    ied: ['dnp3'],
-    'safety-plc': ['modbus-tcp', 'modbus-rtu'],
-    'dcs-controller': ['modbus-tcp', 'modbus-rtu', 'opc-ua'],
-    'legacy-plc': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
-    'iec104-rtu': ['modbus-rtu', 'modbus-tcp'],
-    'process-unit': ['modbus-tcp', 'none'], // P&ID: flow meter on vessel inlet/outlet pipe
-    pump: ['modbus-tcp', 'none'], // P&ID: inline on pump line
-    valve: ['modbus-tcp', 'none'] // P&ID: inline adjacent to valve
-  },
-  'pressure-transmitter': {
-    plc: ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
-    rtu: ['modbus-rtu', 'modbus-tcp'],
-    ied: ['dnp3'],
-    'safety-plc': ['modbus-tcp', 'modbus-rtu'],
-    'dcs-controller': ['modbus-tcp', 'modbus-rtu'],
-    'legacy-plc': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
-    'iec104-rtu': ['modbus-rtu', 'modbus-tcp'],
-    'process-unit': ['modbus-tcp', 'none'], // P&ID: pressure tap on vessel
-    pump: ['modbus-tcp', 'none'], // P&ID: pressure on pump discharge
-    valve: ['modbus-tcp', 'none'] // P&ID: pressure downstream of valve
+    'smart-controller': ['modbus-tcp', 'none'] // P&ID: positioner feedback — sensor reads actuator position
   },
 
-  // ── Level Transmitter (ISA instrument — polled like a sensor, specifically level) ──
-  'level-transmitter': {
+  // ── Smart Controller (consolidated pump/valve/vfd/actuator — real Modbus container) ──
+  // Configurable field controller (kind chosen in Properties Panel). Accepts speed/
+  // position/setpoint writes from a master PLC/RTU/DCS/SIS via Modbus or EtherNet/IP
+  // and reports status — same role the former pump/valve/vfd/actuator categories played.
+  // The Stuxnet worm manipulated Siemens VFDs by replaying Modbus write commands this way.
+  'smart-controller': {
     plc: ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'ethernet-ip'],
+    rtu: ['modbus-rtu', 'modbus-tcp'],
+    ied: ['dnp3'],
+    'safety-plc': ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'],
+    'dcs-controller': ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'],
+    'legacy-plc': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
+    'iec104-rtu': ['modbus-rtu', 'modbus-tcp'],
+    'process-unit': ['modbus-tcp', 'none'], // P&ID: pump/valve/actuator attached to vessel
+    sensor: ['modbus-tcp', 'none'], // P&ID: positioner feedback sensor
+    'smart-sensor': ['modbus-tcp', 'none'], // P&ID: adjacent inline instrument
+    'smart-controller': ['modbus-tcp', 'none'] // P&ID: adjacent actuator/valve/pump on same line
+  },
+
+  // ── Smart Sensor (consolidated flow-meter/pressure/level/analyzer/pmu — FUXA-driven) ──
+  // Configurable field instrument (kind chosen in Properties Panel). No container — FUXA
+  // Simulator generates the value, exposed to the PLC/RTU/historian as a Modbus register
+  // (or DNP3/OPC-UA for the former pmu/analyzer paths). Slower-cycling kinds (analyzer)
+  // and synchrophasor kinds (pmu) reuse the same transport, simplified for lab purposes.
+  'smart-sensor': {
+    plc: ['modbus-tcp', 'modbus-rtu', 'modbus-ascii', 'opc-ua'],
     rtu: ['modbus-rtu', 'modbus-tcp', 'dnp3'],
-    ied: ['dnp3'],
+    ied: ['dnp3', 'iec61850'],
     'safety-plc': ['modbus-tcp', 'modbus-rtu'],
-    'dcs-controller': ['modbus-tcp', 'modbus-rtu'],
+    'dcs-controller': ['modbus-tcp', 'modbus-rtu', 'opc-ua'],
     'legacy-plc': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
     'iec104-rtu': ['modbus-rtu', 'modbus-tcp'],
-    'process-unit': ['modbus-tcp', 'none'] // P&ID: level transmitter mounted on vessel
-  },
-
-  // ── Process Analyzer (online chromatograph, pH, TOC, conductivity) ───────────
-  // Analyzers are slower-cycling instruments (0.5–2 min sample cycle) but use the
-  // same Modbus/OPC-UA transport. High-value sabotage targets in oil/gas and water.
-  analyzer: {
-    plc: ['modbus-tcp', 'modbus-rtu', 'opc-ua'],
-    rtu: ['modbus-rtu', 'modbus-tcp'],
-    'dcs-controller': ['modbus-tcp', 'modbus-rtu', 'opc-ua'],
-    historian: ['opc-ua', 'modbus-tcp'],
-    'iot-gateway': ['mqtt', 'modbus-tcp'],
-    'process-unit': ['modbus-tcp', 'none'] // P&ID: inline analyzer on vessel stream
-  },
-
-  // ── PMU — Phasor Measurement Unit (IEEE C37.118, synchrophasor, GPS-timed) ───
-  // PMUs measure voltage/current phasors at 30–60 samples/sec with GPS-synchronized
-  // timestamps. Essential for grid stability monitoring. DNP3 and IEC 61850 are the
-  // two primary transport protocols used by SCADA/WAMS (Wide Area Monitoring Systems).
-  pmu: {
-    rtu: ['dnp3', 'modbus-tcp'],
-    ied: ['iec61850', 'dnp3'],
-    historian: ['dnp3', 'opc-ua'],
+    historian: ['opc-ua', 'modbus-tcp', 'dnp3'],
     'scada-server': ['dnp3', 'opc-ua'],
-    switch: ['none'],
-    router: ['none']
+    'iot-gateway': ['mqtt', 'modbus-tcp'],
+    'process-unit': ['modbus-tcp', 'none'], // P&ID: instrument mounted on vessel
+    'smart-controller': ['modbus-tcp', 'none'] // P&ID: instrument inline with pump/valve
   },
 
   // ── IIoT Wireless Sensor Node ────────────────────────────────────────────────
@@ -488,7 +381,7 @@ export const VALID_CONNECTIONS: Partial<
   'iot-gateway': {
     'iiot-sensor': ['mqtt'], // collects from wireless sensor nodes
     sensor: ['modbus-tcp', 'modbus-rtu'], // also polls wired Modbus sensors
-    analyzer: ['mqtt', 'modbus-tcp'],
+    'smart-sensor': ['mqtt', 'modbus-tcp'], // includes former analyzer
     historian: ['mqtt', 'opc-ua'], // pushes time-series upward
     'scada-server': ['mqtt', 'opc-ua'],
     switch: ['none'],
@@ -650,7 +543,6 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'],
     'safety-plc': ['none'],
     'dcs-controller': ['none'],
-    vfd: ['none'],
     'legacy-plc': ['none'], // Phase 10
     'iec104-rtu': ['none'], // Phase 10
     'process-unit': ['none'], // Phase 11
@@ -661,14 +553,8 @@ export const VALID_CONNECTIONS: Partial<
     'database-server': ['none'],
     'engineering-workstation': ['none'],
     sensor: ['none'],
-    actuator: ['none'],
-    pump: ['none'],
-    valve: ['none'],
-    'flow-meter': ['none'],
-    'pressure-transmitter': ['none'],
-    'level-transmitter': ['none'],
-    analyzer: ['none'],
-    pmu: ['none'],
+    'smart-controller': ['none'],
+    'smart-sensor': ['none'],
     'iiot-sensor': ['none'],
     'iot-gateway': ['none'],
     'jump-server': ['none'],
@@ -693,7 +579,6 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'],
     'safety-plc': ['none'],
     'dcs-controller': ['none'],
-    vfd: ['none'],
     'legacy-plc': ['none'], // Phase 10
     'iec104-rtu': ['none'], // Phase 10
     'process-unit': ['none'], // Phase 11
@@ -704,14 +589,8 @@ export const VALID_CONNECTIONS: Partial<
     'database-server': ['none'],
     'engineering-workstation': ['none'],
     sensor: ['none'],
-    actuator: ['none'],
-    pump: ['none'],
-    valve: ['none'],
-    'flow-meter': ['none'],
-    'pressure-transmitter': ['none'],
-    'level-transmitter': ['none'],
-    analyzer: ['none'],
-    pmu: ['none'],
+    'smart-controller': ['none'],
+    'smart-sensor': ['none'],
     'iiot-sensor': ['none'],
     'iot-gateway': ['none'],
     'jump-server': ['none'],
@@ -736,7 +615,6 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'],
     'safety-plc': ['none'],
     'dcs-controller': ['none'],
-    vfd: ['none'],
     'legacy-plc': ['none'], // Phase 10
     'iec104-rtu': ['none'], // Phase 10
     'process-unit': ['none'], // Phase 11
@@ -747,14 +625,8 @@ export const VALID_CONNECTIONS: Partial<
     'database-server': ['none'],
     'engineering-workstation': ['none'],
     sensor: ['none'],
-    actuator: ['none'],
-    pump: ['none'],
-    valve: ['none'],
-    'flow-meter': ['none'],
-    'pressure-transmitter': ['none'],
-    'level-transmitter': ['none'],
-    analyzer: ['none'],
-    pmu: ['none'],
+    'smart-controller': ['none'],
+    'smart-sensor': ['none'],
     'iiot-sensor': ['none'],
     'iot-gateway': ['none'],
     'jump-server': ['none'],
@@ -779,7 +651,6 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'],
     'safety-plc': ['none'],
     'dcs-controller': ['none'],
-    vfd: ['none'],
     'legacy-plc': ['none'], // Phase 10
     'iec104-rtu': ['none'], // Phase 10
     'process-unit': ['none'], // Phase 11
@@ -790,14 +661,8 @@ export const VALID_CONNECTIONS: Partial<
     'database-server': ['none'],
     'engineering-workstation': ['none'],
     sensor: ['none'],
-    actuator: ['none'],
-    pump: ['none'],
-    valve: ['none'],
-    'flow-meter': ['none'],
-    'pressure-transmitter': ['none'],
-    'level-transmitter': ['none'],
-    analyzer: ['none'],
-    pmu: ['none'],
+    'smart-controller': ['none'],
+    'smart-sensor': ['none'],
     'iiot-sensor': ['none'],
     'iot-gateway': ['none'],
     'jump-server': ['none'],
@@ -856,8 +721,6 @@ export const VALID_CONNECTIONS: Partial<
     'safety-plc': ['modbus-tcp', 'modbus-rtu', 'ethernet-ip', 'opc-ua', 'none'],
     // DCS attacks: OPC-UA credential attacks, Modbus setpoint manipulation
     'dcs-controller': ['modbus-tcp', 'modbus-rtu', 'opc-ua', 'none'],
-    // Stuxnet attack vector: Modbus/EtherNet/IP frequency manipulation on Siemens VFDs
-    vfd: ['modbus-tcp', 'modbus-rtu', 'ethernet-ip', 'none'],
     // Siemens S7 attack surface: s7-enumerate (Nmap), siemens_simatic_manager (Metasploit)
     'legacy-plc': [
       's7comm',
@@ -925,7 +788,8 @@ export const VALID_CONNECTIONS: Partial<
       'iec61850',
       'none'
     ],
-    actuator: [
+    // Includes former actuator/pump/valve/vfd — Stuxnet-style Modbus/EtherNet-IP setpoint manipulation
+    'smart-controller': [
       'modbus-tcp',
       'modbus-rtu',
       'dnp3',
@@ -935,7 +799,9 @@ export const VALID_CONNECTIONS: Partial<
       'iec61850',
       'none'
     ],
-    pump: [
+    // Includes former flow-meter/pressure-transmitter/level-transmitter/analyzer/pmu —
+    // GPS spoofing + DNP3 injection attacks apply to the former pmu kind
+    'smart-sensor': [
       'modbus-tcp',
       'modbus-rtu',
       'dnp3',
@@ -945,39 +811,6 @@ export const VALID_CONNECTIONS: Partial<
       'iec61850',
       'none'
     ],
-    valve: [
-      'modbus-tcp',
-      'modbus-rtu',
-      'dnp3',
-      'opc-ua',
-      'bacnet',
-      'ethernet-ip',
-      'iec61850',
-      'none'
-    ],
-    'flow-meter': [
-      'modbus-tcp',
-      'modbus-rtu',
-      'dnp3',
-      'opc-ua',
-      'bacnet',
-      'ethernet-ip',
-      'iec61850',
-      'none'
-    ],
-    'pressure-transmitter': [
-      'modbus-tcp',
-      'modbus-rtu',
-      'dnp3',
-      'opc-ua',
-      'bacnet',
-      'ethernet-ip',
-      'iec61850',
-      'none'
-    ],
-    'level-transmitter': ['modbus-tcp', 'modbus-rtu', 'dnp3', 'opc-ua', 'none'],
-    analyzer: ['modbus-tcp', 'modbus-rtu', 'opc-ua', 'none'],
-    pmu: ['dnp3', 'iec61850', 'none'], // GPS spoofing + DNP3 injection attacks
     // IIoT attack surface: MQTT broker compromise, spoofed sensor readings
     'iiot-sensor': ['mqtt', 'none'],
     'iot-gateway': ['mqtt', 'opc-ua', 'modbus-tcp', 'none'],
@@ -1057,22 +890,14 @@ const CATEGORY_NAMES: Record<DeviceCategory, string> = {
   ied: 'IED',
   'safety-plc': 'Safety PLC / SIS',
   'dcs-controller': 'DCS Controller',
-  vfd: 'VFD / Motor Drive',
   'legacy-plc': 'Siemens S7 PLC', // Phase 10
   'iec104-rtu': 'IEC 104 RTU', // Phase 10
   'process-unit': 'Process Unit', // Phase 11
   sensor: 'Sensor',
-  actuator: 'Actuator',
-  pump: 'Pump',
-  valve: 'Valve',
-  'flow-meter': 'Flow Meter',
-  'pressure-transmitter': 'Pressure Transmitter',
-  'level-transmitter': 'Level Transmitter',
-  analyzer: 'Process Analyzer',
-  pmu: 'Phasor Measurement Unit',
   'iiot-sensor': 'IIoT Sensor',
   'iot-gateway': 'IoT Gateway',
   'smart-sensor': 'Smart Sensor',
+  'smart-controller': 'Smart Controller',
   hmi: 'HMI',
   historian: 'Historian',
   'scada-server': 'SCADA Server',
@@ -1135,8 +960,6 @@ const DEVICE_CABLE_CAPABILITIES: Record<DeviceCategory, Set<CableType>> = {
   'safety-plc': new Set(['rs485', 'rs232', 'cat5e', 'cat6', 'ac']),
   // DCS Controller: larger system, fiber uplinks to DCS node bus are common
   'dcs-controller': new Set(['rs485', 'rs232', 'cat5e', 'cat6', 'mmf', 'smf', 'ac']),
-  // VFD: RS-485 serial (Modbus RTU) + Cat5e Ethernet (EtherNet/IP) + AC power input
-  vfd: new Set(['rs485', 'cat5e', 'ac']),
   'legacy-plc': new Set(['rs485', 'rs232', 'cat5e', 'cat6', 'ac']), // Siemens S7 — same ports
   'iec104-rtu': new Set(['rs485', 'rs232', 'cat5e', 'cat6', 'ac']), // IEC 104 RTU — same ports
   'process-unit': new Set(['cat5e', 'cat6', 'ac']), // process sim panel — Ethernet + mains
@@ -1145,19 +968,13 @@ const DEVICE_CABLE_CAPABILITIES: Record<DeviceCategory, Set<CableType>> = {
   // Smart sensors with WirelessHART/ISA100 also support Wi-Fi for wireless polling.
   // DC loop power (4-20 mA / HART) is the standard 24 VDC two-wire instrument supply.
   sensor: new Set(['rs485', 'cat5e', 'wifi', 'dc']),
-  actuator: new Set(['rs485', 'cat5e', 'wifi', 'dc']),
-  pump: new Set(['rs485', 'cat5e', 'ac']), // pumps draw AC from MCC
-  valve: new Set(['rs485', 'cat5e', 'wifi', 'dc']),
-  'flow-meter': new Set(['rs485', 'cat5e', 'wifi', 'dc']),
-  'pressure-transmitter': new Set(['rs485', 'cat5e', 'wifi', 'dc']),
-  'level-transmitter': new Set(['rs485', 'cat5e', 'wifi', 'dc']), // same as pressure-transmitter family
-  analyzer: new Set(['rs485', 'cat5e', 'wifi', 'ac']), // AC powered; RS-485 or Ethernet fieldbus
-  pmu: new Set(['cat5e', 'cat6', 'mmf', 'smf', 'ac']), // Ethernet/fiber; GPS antenna not modeled
   'iiot-sensor': new Set(['wifi', 'dc']), // wireless only; battery/loop powered
   'iot-gateway': new Set(['rs485', 'cat5e', 'cat6', 'wifi', 'ac']), // bridges serial→Ethernet
-  // Union of all three kinds' wiring options (Temperature/Gas: 4-20 mA loop, RS-485,
-  // Ethernet; Vibration adds Wi-Fi for wireless IIoT accelerometers).
+  // Union of all 8 kinds' wiring options (temperature/gas/flow/pressure/level/analyzer:
+  // 4-20 mA loop, RS-485, Ethernet; vibration/pmu add Wi-Fi/fiber for wireless/GPS-timed links).
   'smart-sensor': new Set(['rs485', 'cat5e', 'wifi', 'dc']),
+  // VFD/pump/valve/actuator wiring: RS-485 (Modbus RTU) + Cat5e (EtherNet/IP) + AC from MCC.
+  'smart-controller': new Set(['rs485', 'cat5e', 'wifi', 'dc', 'ac']),
 
   // ── Control center (L3) — Ethernet; EWS also has RS-232 console port ─────────────
   // HMI: Cat5e/Cat6 wired; modern panel PCs may also have Wi-Fi for roaming tablets.

--- a/packages/app/src/renderer/src/icons/DeviceIcons.tsx
+++ b/packages/app/src/renderer/src/icons/DeviceIcons.tsx
@@ -21,7 +21,7 @@
  *   <DeviceIcon category="sensor" size={20} className="my-icon" />
  */
 
-import type { DeviceCategory, SensorConfig } from '@otforge/schema'
+import type { ControllerConfig, DeviceCategory, SensorConfig } from '@otforge/schema'
 
 /**
  * Shared SVG presentation attributes applied to every icon.
@@ -146,6 +146,21 @@ function ValveSvg() {
       <polygon points="2,5 12,12 2,19" />
       <polygon points="22,5 12,12 22,19" />
       <line x1="12" y1="2" x2="12" y2="22" />
+    </svg>
+  )
+}
+
+/**
+ * Wellhead Controller — simplified Christmas-tree symbol: wellbore stem with a
+ * master valve (horizontal bar) and choke valve (triangle) stacked above the casing.
+ */
+function WellheadControllerSvg() {
+  return (
+    <svg viewBox="0 0 24 24" {...S}>
+      <line x1="12" y1="3" x2="12" y2="21" />
+      <line x1="6" y1="9" x2="18" y2="9" />
+      <polygon points="9,14 15,14 12,19" />
+      <line x1="3" y1="21" x2="21" y2="21" />
     </svg>
   )
 }
@@ -894,24 +909,18 @@ const ICON_MAP: Record<DeviceCategory, () => JSX.Element> = {
   ied: IedSvg,
   'safety-plc': SafetyPlcSvg, // IEC 61511 Safety PLC / SIS — Triconex, Siemens Safety
   'dcs-controller': DcsControllerSvg, // Distributed Control System — DeltaV, Experion, 800xA
-  vfd: VfdSvg, // Variable Frequency Drive / motor drive
   'legacy-plc': LegacyPlcSvg, // Siemens S7-300/400/1200/1500 via S7comm (Phase 10)
   'iec104-rtu': Iec104RtuSvg, // IEC 60870-5-104 RTU via conpot emulation (Phase 10)
   'process-unit': ProcessUnitSvg, // physics-simulated process unit (Phase 11)
   sensor: SensorSvg,
-  actuator: ActuatorSvg,
-  pump: PumpSvg,
-  valve: ValveSvg,
-  'flow-meter': FlowMeterSvg,
-  'pressure-transmitter': PressureTransmitterSvg,
-  'level-transmitter': LevelTransmitterSvg, // tank/vessel level measurement
-  analyzer: AnalyzerSvg, // online process analyzer
-  pmu: PmuSvg, // IEEE C37.118 Phasor Measurement Unit
   'iiot-sensor': IiotSensorSvg, // IIoT wireless sensor node
   'iot-gateway': IotGatewaySvg, // IIoT protocol gateway / Modbus-to-MQTT bridge
   // smart-sensor's icon actually varies by SensorConfig.kind (see SENSOR_KIND_ICONS below);
   // this entry is the exhaustiveness fallback used only if no kind has been chosen yet.
   'smart-sensor': TemperatureSensorSvg,
+  // smart-controller's icon actually varies by ControllerConfig.kind (see
+  // CONTROLLER_KIND_ICONS below); this entry is the exhaustiveness fallback.
+  'smart-controller': WellheadControllerSvg,
   // ── Control Center (Level 3) ────────────────────────────────────────────────
   hmi: HmiSvg,
   historian: HistorianSvg,
@@ -943,13 +952,32 @@ const ICON_MAP: Record<DeviceCategory, () => JSX.Element> = {
 /**
  * Per-kind icon lookup for the smart-sensor category. Unlike every other
  * category, smart-sensor's icon depends on SensorConfig.kind rather than on
- * DeviceCategory alone — the Properties Panel dropdown picks Temperature/Gas/
- * Vibration, and the canvas node icon follows that choice.
+ * DeviceCategory alone — the Properties Panel dropdown picks the instrument
+ * kind, and the canvas node icon follows that choice. flow/pressure/level/
+ * analyzer/pmu were consolidated from their own former DeviceCategory values.
  */
 const SENSOR_KIND_ICONS: Record<SensorConfig['kind'], () => JSX.Element> = {
   temperature: TemperatureSensorSvg,
   gas: GasDetectorSvg,
-  vibration: VibrationSensorSvg
+  vibration: VibrationSensorSvg,
+  flow: FlowMeterSvg,
+  pressure: PressureTransmitterSvg,
+  level: LevelTransmitterSvg,
+  analyzer: AnalyzerSvg,
+  pmu: PmuSvg
+}
+
+/**
+ * Per-kind icon lookup for the smart-controller category. Mirrors
+ * SENSOR_KIND_ICONS — pump/valve/vfd/actuator were consolidated from their own
+ * former DeviceCategory values; wellhead-controller is the first net-new kind.
+ */
+const CONTROLLER_KIND_ICONS: Record<ControllerConfig['kind'], () => JSX.Element> = {
+  pump: PumpSvg,
+  valve: ValveSvg,
+  vfd: VfdSvg,
+  actuator: ActuatorSvg,
+  'wellhead-controller': WellheadControllerSvg
 }
 
 /**
@@ -959,9 +987,11 @@ const SENSOR_KIND_ICONS: Record<SensorConfig['kind'], () => JSX.Element> = {
  * correctly in both flex containers (palette items) and grid layouts (device nodes).
  * The `flexShrink: 0` prevents the icon from being squeezed in tight horizontal layouts.
  *
- * @param category   - The DeviceCategory to render an icon for.
- * @param sensorKind - For category === 'smart-sensor', the chosen SensorConfig.kind;
- *   selects Temperature/Gas/Vibration icon. Ignored for every other category.
+ * @param category       - The DeviceCategory to render an icon for.
+ * @param sensorKind     - For category === 'smart-sensor', the chosen SensorConfig.kind.
+ *   Ignored for every other category.
+ * @param controllerKind - For category === 'smart-controller', the chosen
+ *   ControllerConfig.kind. Ignored for every other category.
  * @param size      - Width and height in pixels (defaults to 24).
  * @param color     - CSS color value passed as `color` to the span, inherited by
  *   `stroke: currentColor` inside the SVG. Defaults to 'currentColor'.
@@ -970,18 +1000,23 @@ const SENSOR_KIND_ICONS: Record<SensorConfig['kind'], () => JSX.Element> = {
 export function DeviceIcon({
   category,
   sensorKind,
+  controllerKind,
   size = 24,
   color = 'currentColor',
   className
 }: {
   category: DeviceCategory
   sensorKind?: SensorConfig['kind']
+  controllerKind?: ControllerConfig['kind']
   size?: number
   color?: string
   className?: string
 }) {
-  const IconComponent =
-    category === 'smart-sensor' && sensorKind ? SENSOR_KIND_ICONS[sensorKind] : ICON_MAP[category]
+  let IconComponent = ICON_MAP[category]
+  if (category === 'smart-sensor' && sensorKind) IconComponent = SENSOR_KIND_ICONS[sensorKind]
+  if (category === 'smart-controller' && controllerKind) {
+    IconComponent = CONTROLLER_KIND_ICONS[controllerKind]
+  }
   return (
     <span
       className={className}

--- a/packages/app/src/renderer/src/palette/DevicePalette.tsx
+++ b/packages/app/src/renderer/src/palette/DevicePalette.tsx
@@ -46,12 +46,13 @@ interface PaletteSection {
  *
  * OT tab sections (Levels 0–2):
  *   Primary Control   — PLCs, Safety PLC, DCS Controller, RTU, IED
- *   Field Instruments — sensors, flow/pressure/level transmitters, analyzer,
- *                       smart sensor (Temperature/Gas/Vibration kind chosen in
- *                       Properties Panel; FUXA-simulated, no container)
- *   Actuators & Drives — actuator, pump, valve, VFD
+ *   Field Instruments — sensor, smart sensor (kind chosen in Properties Panel;
+ *                       covers temperature/gas/vibration/flow/pressure/level/
+ *                       analyzer/pmu; FUXA-simulated, no container)
+ *   Actuators & Drives — smart controller (kind chosen in Properties Panel;
+ *                       covers pump/valve/vfd/actuator/wellhead-controller;
+ *                       real Modbus-backed container, same image as RTU)
  *   IIoT / Wireless   — IIoT sensor node, IoT gateway
- *   Power / Grid      — PMU (power generation / transmission scenarios)
  *   Legacy / Protocol — Siemens S7 PLC, IEC 104 RTU
  *   Process Simulation — physics-simulated process unit
  */
@@ -73,10 +74,9 @@ const PALETTE: PaletteSection[] = [
     layers: ['ot'],
     items: [
       { category: 'sensor', label: 'Sensor' },
-      { category: 'flow-meter', label: 'Flow Meter' },
-      { category: 'pressure-transmitter', label: 'Pressure TX' },
-      { category: 'level-transmitter', label: 'Level TX' },
-      { category: 'analyzer', label: 'Analyzer' },
+      // Kind chosen after drop in the Properties Panel — covers temperature/gas/
+      // vibration plus the consolidated former flow-meter/pressure-transmitter/
+      // level-transmitter/analyzer/pmu categories.
       { category: 'smart-sensor', label: 'Smart Sensor' }
     ]
   },
@@ -84,10 +84,9 @@ const PALETTE: PaletteSection[] = [
     label: 'Actuators & Drives',
     layers: ['ot'],
     items: [
-      { category: 'actuator', label: 'Actuator' },
-      { category: 'pump', label: 'Pump' },
-      { category: 'valve', label: 'Valve' },
-      { category: 'vfd', label: 'VFD / Motor Drive' }
+      // Kind chosen after drop in the Properties Panel — covers the consolidated
+      // former actuator/pump/valve/vfd categories plus wellhead-controller.
+      { category: 'smart-controller', label: 'Smart Controller' }
     ]
   },
   {
@@ -97,11 +96,6 @@ const PALETTE: PaletteSection[] = [
       { category: 'iiot-sensor', label: 'IIoT Sensor' },
       { category: 'iot-gateway', label: 'IoT Gateway' }
     ]
-  },
-  {
-    label: 'Power / Grid',
-    layers: ['ot'],
-    items: [{ category: 'pmu', label: 'Phasor Meas. Unit' }]
   },
   {
     // Phase 10: Siemens S7 and IEC 104 legacy devices for fingerprinting labs.
@@ -216,10 +210,8 @@ const PALETTE_COLORS: Partial<Record<DeviceCategory, string>> = {
   'safety-plc': '#f85149',
   // DCS Controller — cornflower blue (primary process control)
   'dcs-controller': '#58a6ff',
-  // VFD — teal/cyan (motor/drive systems)
-  vfd: '#3dc9b0',
-  // Power/grid device — blue (electrical)
-  pmu: '#388bfd',
+  // Smart Controller — teal/cyan (motor/drive/actuator systems, consolidated from vfd)
+  'smart-controller': '#3dc9b0',
   // IIoT devices — mint green (edge/cloud)
   'iiot-sensor': '#39d0b0',
   'iot-gateway': '#56d364',

--- a/packages/app/src/renderer/src/properties/ControllerPanel.tsx
+++ b/packages/app/src/renderer/src/properties/ControllerPanel.tsx
@@ -1,0 +1,409 @@
+/**
+ * ControllerPanel.tsx — smart-controller configuration panel for the Properties Panel.
+ *
+ * Renders the configuration form for the consolidated smart-controller device type.
+ * Rather than a separate DeviceCategory per physical device, smart-controller carries
+ * a single `kind` field (pump/valve/vfd/actuator/wellhead-controller) selected here via
+ * dropdown — the canvas icon and the set of kind-specific fields shown below follow that
+ * choice. Unlike SensorPanel's kinds (which share one field shape with different
+ * defaults), controller kinds have genuinely different fields — ControllerConfig models
+ * this as one flat interface with all kind-specific fields optional, same pattern as
+ * ProcessUnitConfig. This keeps adding a future controller kind a config-only change: no
+ * new DeviceCategory, no touching every Record<DeviceCategory, ...> exhaustiveness table
+ * across the renderer and orchestrator packages.
+ *
+ * Unlike smart-sensor, smart-controller DOES spawn a real Docker container (the same
+ * otforge-modbus image rtu uses) — these fields are informational/educational, injected
+ * as CONTROLLER_* env vars by compose-generator. Real protocol behavior comes from the
+ * device's generic modbus/dnp3 config blocks.
+ *
+ * Author Mode: all fields are editable dropdowns / inputs; changes committed
+ *              immediately (select) or on blur (text/number inputs).
+ * Student Mode (readOnly): all values rendered as read-only badges.
+ */
+
+import { useEffect, useState } from 'react'
+import type { ControllerConfig } from '@otforge/schema'
+
+type ControllerKind = ControllerConfig['kind']
+
+// ── Option tables ────────────────────────────────────────────────────────────
+
+const KIND_OPTIONS: { value: ControllerKind; label: string }[] = [
+  { value: 'pump', label: 'Pump' },
+  { value: 'valve', label: 'Valve' },
+  { value: 'vfd', label: 'VFD / Motor Drive' },
+  { value: 'actuator', label: 'Actuator' },
+  { value: 'wellhead-controller', label: 'Wellhead Controller' }
+]
+
+const ACTUATOR_TYPE_OPTIONS: NonNullable<ControllerConfig['actuatorType']>[] = [
+  'pneumatic',
+  'electric',
+  'hydraulic'
+]
+const FAIL_POSITION_OPTIONS: NonNullable<ControllerConfig['failPosition']>[] = [
+  'open',
+  'closed',
+  'last'
+]
+const TRAVEL_TYPE_OPTIONS: NonNullable<ControllerConfig['travelType']>[] = ['linear', 'rotary']
+const SIGNAL_TYPE_OPTIONS: NonNullable<ControllerConfig['signalType']>[] = [
+  '4-20mA',
+  'discrete',
+  'modbus'
+]
+const LIFT_METHOD_OPTIONS: NonNullable<ControllerConfig['liftMethod']>[] = [
+  'natural',
+  'rod-pump',
+  'esp',
+  'gas-lift'
+]
+
+/**
+ * Sensible kind-specific field defaults. Applied whenever the author switches the
+ * Kind dropdown — clears the previous kind's fields since they're not relevant.
+ */
+const KIND_DEFAULTS: Record<ControllerKind, Partial<ControllerConfig>> = {
+  pump: { ratedFlowLpm: 150, motorPowerKw: 7.5 },
+  valve: { actuatorType: 'electric', failPosition: 'closed' },
+  vfd: { maxFrequencyHz: 60 },
+  actuator: { travelType: 'linear', signalType: '4-20mA' },
+  'wellhead-controller': {
+    chokePositionPercent: 50,
+    downholePressureSetpointBar: 200,
+    liftMethod: 'natural'
+  }
+}
+
+// ── Default config ────────────────────────────────────────────────────────────
+
+/**
+ * Sensible default values used when a smart-controller is first dropped onto the
+ * canvas and no ControllerConfig has been set yet.
+ */
+export const DEFAULT_CONTROLLER_CONFIG: ControllerConfig = {
+  kind: 'pump',
+  ...KIND_DEFAULTS.pump
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface ControllerPanelProps {
+  /** Current controller configuration (may be undefined if device predates this feature). */
+  controllerConfig?: ControllerConfig
+  /** Node ID of the smart-controller device — passed through to the onChange callback. */
+  nodeId: string
+  /** When true, all fields are rendered as read-only text (Student Mode). */
+  readOnly: boolean
+  /**
+   * Called whenever any controller configuration field changes.
+   * Receives the complete updated ControllerConfig so App.tsx can replace the stored config atomically.
+   */
+  onChange?: (nodeId: string, config: ControllerConfig) => void
+}
+
+/**
+ * Menu-driven smart-controller configuration panel.
+ *
+ * Manages a local copy of the ControllerConfig and calls onChange whenever the
+ * author commits a change (immediately for selects; on blur for text/number inputs).
+ */
+export function ControllerPanel({
+  controllerConfig,
+  nodeId,
+  readOnly,
+  onChange
+}: ControllerPanelProps) {
+  // Merge incoming config with defaults so every field always has a valid value.
+  const [cfg, setCfg] = useState<ControllerConfig>({
+    ...DEFAULT_CONTROLLER_CONFIG,
+    ...controllerConfig
+  })
+
+  // Re-sync local state when the selected device changes or its config is updated externally.
+  useEffect(() => {
+    setCfg({ ...DEFAULT_CONTROLLER_CONFIG, ...controllerConfig })
+  }, [nodeId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  /** Switches the controller kind and resets to that kind's field defaults. */
+  function handleKindChange(kind: ControllerKind): void {
+    const next: ControllerConfig = { kind, ...KIND_DEFAULTS[kind] }
+    setCfg(next)
+    onChange?.(nodeId, next)
+  }
+
+  /** Commits the current local config immediately (used by selects). */
+  function commitNow(next: ControllerConfig): void {
+    setCfg(next)
+    onChange?.(nodeId, next)
+  }
+
+  /** Commits the current local config on blur — used by all numeric inputs. */
+  function commit(): void {
+    onChange?.(nodeId, cfg)
+  }
+
+  const kindLabel = KIND_OPTIONS.find(o => o.value === cfg.kind)?.label ?? cfg.kind
+
+  return (
+    <section className="prop-section">
+      <div className="prop-section-title">Controller Configuration</div>
+
+      {/* Kind — Pump / Valve / VFD / Actuator / Wellhead Controller */}
+      <div className="prop-row">
+        <span className="prop-label">Kind</span>
+        {readOnly ? (
+          <span className="prop-value">{kindLabel}</span>
+        ) : (
+          <select
+            className="rtu-select"
+            value={cfg.kind}
+            onChange={e => handleKindChange(e.target.value as ControllerKind)}
+          >
+            {KIND_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {/* ── pump fields ──────────────────────────────────────────────────── */}
+      {cfg.kind === 'pump' && (
+        <>
+          <div className="prop-row">
+            <span className="prop-label">Rated Flow</span>
+            {readOnly ? (
+              <span className="prop-value">{cfg.ratedFlowLpm} L/min</span>
+            ) : (
+              <input
+                className="prop-input prop-input-mono"
+                type="number"
+                min={0}
+                value={cfg.ratedFlowLpm ?? 0}
+                onChange={e =>
+                  setCfg(prev => ({ ...prev, ratedFlowLpm: Number(e.target.value) || 0 }))
+                }
+                onBlur={commit}
+              />
+            )}
+          </div>
+          <div className="prop-row">
+            <span className="prop-label">Motor Power</span>
+            {readOnly ? (
+              <span className="prop-value">{cfg.motorPowerKw} kW</span>
+            ) : (
+              <input
+                className="prop-input prop-input-mono"
+                type="number"
+                min={0}
+                value={cfg.motorPowerKw ?? 0}
+                onChange={e =>
+                  setCfg(prev => ({ ...prev, motorPowerKw: Number(e.target.value) || 0 }))
+                }
+                onBlur={commit}
+              />
+            )}
+          </div>
+        </>
+      )}
+
+      {/* ── valve fields ─────────────────────────────────────────────────── */}
+      {cfg.kind === 'valve' && (
+        <>
+          <div className="prop-row">
+            <span className="prop-label">Actuator Type</span>
+            {readOnly ? (
+              <span className="prop-value">{cfg.actuatorType}</span>
+            ) : (
+              <select
+                className="rtu-select"
+                value={cfg.actuatorType ?? 'electric'}
+                onChange={e =>
+                  commitNow({
+                    ...cfg,
+                    actuatorType: e.target.value as ControllerConfig['actuatorType']
+                  })
+                }
+              >
+                {ACTUATOR_TYPE_OPTIONS.map(v => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+          <div className="prop-row">
+            <span className="prop-label">Fail Position</span>
+            {readOnly ? (
+              <span className="prop-value">{cfg.failPosition}</span>
+            ) : (
+              <select
+                className="rtu-select"
+                value={cfg.failPosition ?? 'closed'}
+                onChange={e =>
+                  commitNow({
+                    ...cfg,
+                    failPosition: e.target.value as ControllerConfig['failPosition']
+                  })
+                }
+              >
+                {FAIL_POSITION_OPTIONS.map(v => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* ── vfd fields ───────────────────────────────────────────────────── */}
+      {cfg.kind === 'vfd' && (
+        <div className="prop-row">
+          <span className="prop-label">Max Frequency</span>
+          {readOnly ? (
+            <span className="prop-value">{cfg.maxFrequencyHz} Hz</span>
+          ) : (
+            <input
+              className="prop-input prop-input-mono"
+              type="number"
+              min={0}
+              value={cfg.maxFrequencyHz ?? 0}
+              onChange={e =>
+                setCfg(prev => ({ ...prev, maxFrequencyHz: Number(e.target.value) || 0 }))
+              }
+              onBlur={commit}
+            />
+          )}
+        </div>
+      )}
+
+      {/* ── actuator fields ──────────────────────────────────────────────── */}
+      {cfg.kind === 'actuator' && (
+        <>
+          <div className="prop-row">
+            <span className="prop-label">Travel Type</span>
+            {readOnly ? (
+              <span className="prop-value">{cfg.travelType}</span>
+            ) : (
+              <select
+                className="rtu-select"
+                value={cfg.travelType ?? 'linear'}
+                onChange={e =>
+                  commitNow({
+                    ...cfg,
+                    travelType: e.target.value as ControllerConfig['travelType']
+                  })
+                }
+              >
+                {TRAVEL_TYPE_OPTIONS.map(v => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+          <div className="prop-row">
+            <span className="prop-label">Signal Type</span>
+            {readOnly ? (
+              <span className="prop-value">{cfg.signalType}</span>
+            ) : (
+              <select
+                className="rtu-select"
+                value={cfg.signalType ?? '4-20mA'}
+                onChange={e =>
+                  commitNow({
+                    ...cfg,
+                    signalType: e.target.value as ControllerConfig['signalType']
+                  })
+                }
+              >
+                {SIGNAL_TYPE_OPTIONS.map(v => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* ── wellhead-controller fields ───────────────────────────────────── */}
+      {cfg.kind === 'wellhead-controller' && (
+        <>
+          <div className="prop-row">
+            <span className="prop-label">Choke Position</span>
+            {readOnly ? (
+              <span className="prop-value">{cfg.chokePositionPercent}%</span>
+            ) : (
+              <input
+                className="prop-input prop-input-mono"
+                type="number"
+                min={0}
+                max={100}
+                value={cfg.chokePositionPercent ?? 0}
+                onChange={e =>
+                  setCfg(prev => ({
+                    ...prev,
+                    chokePositionPercent: Number(e.target.value) || 0
+                  }))
+                }
+                onBlur={commit}
+              />
+            )}
+          </div>
+          <div className="prop-row">
+            <span className="prop-label">Downhole Pressure SP</span>
+            {readOnly ? (
+              <span className="prop-value">{cfg.downholePressureSetpointBar} bar</span>
+            ) : (
+              <input
+                className="prop-input prop-input-mono"
+                type="number"
+                min={0}
+                value={cfg.downholePressureSetpointBar ?? 0}
+                onChange={e =>
+                  setCfg(prev => ({
+                    ...prev,
+                    downholePressureSetpointBar: Number(e.target.value) || 0
+                  }))
+                }
+                onBlur={commit}
+              />
+            )}
+          </div>
+          <div className="prop-row">
+            <span className="prop-label">Lift Method</span>
+            {readOnly ? (
+              <span className="prop-value">{cfg.liftMethod}</span>
+            ) : (
+              <select
+                className="rtu-select"
+                value={cfg.liftMethod ?? 'natural'}
+                onChange={e =>
+                  commitNow({
+                    ...cfg,
+                    liftMethod: e.target.value as ControllerConfig['liftMethod']
+                  })
+                }
+              >
+                {LIFT_METHOD_OPTIONS.map(v => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+        </>
+      )}
+    </section>
+  )
+}

--- a/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
+++ b/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
@@ -28,11 +28,18 @@
  */
 
 import { useEffect, useState } from 'react'
-import type { DeviceConfig, SecurityLayer, RtuConfig, SensorConfig } from '@otforge/schema'
+import type {
+  DeviceConfig,
+  SecurityLayer,
+  RtuConfig,
+  SensorConfig,
+  ControllerConfig
+} from '@otforge/schema'
 import { DeviceIcon } from '../icons/DeviceIcons'
 import { ZONE_COLORS } from '../canvas/DeviceNode'
 import { FirewallPanel, IDSPanel } from './SecurityPanel'
 import { SensorPanel } from './SensorPanel'
+import { ControllerPanel } from './ControllerPanel'
 
 /** Full human-readable names for the properties panel header. */
 const CATEGORY_LABELS: Record<string, string> = {
@@ -42,12 +49,8 @@ const CATEGORY_LABELS: Record<string, string> = {
   hmi: 'Human Machine Interface',
   historian: 'Data Historian',
   sensor: 'Field Sensor',
-  actuator: 'Actuator',
-  pump: 'Pump',
-  valve: 'Control Valve',
-  'flow-meter': 'Flow Meter',
-  'pressure-transmitter': 'Pressure Transmitter',
   'smart-sensor': 'Smart Sensor',
+  'smart-controller': 'Smart Controller',
   firewall: 'Firewall',
   'ids-ips': 'IDS / IPS',
   switch: 'Network Switch',
@@ -87,7 +90,13 @@ interface PropertiesPanelProps {
    */
   onDeviceChange?: (
     nodeId: string,
-    changes: { ipAddress?: string; label?: string; rtuConfig?: RtuConfig; sensor?: SensorConfig }
+    changes: {
+      ipAddress?: string
+      label?: string
+      rtuConfig?: RtuConfig
+      sensor?: SensorConfig
+      controller?: ControllerConfig
+    }
   ) => void
   /**
    * Called when the user edits security config in FirewallPanel or IDSPanel.
@@ -119,7 +128,9 @@ interface PropertiesPanelProps {
  *   - DNP3 config (if device.dnp3 is defined)
  *   - OPC UA config (if device.opcua is defined)
  *   - Sensor config (SensorPanel) if category === 'smart-sensor' — kind dropdown
- *     (Temperature/Gas/Vibration) plus waveform/range/Modbus register fields
+ *     plus waveform/range/Modbus register fields
+ *   - Controller config (ControllerPanel) if category === 'smart-controller' —
+ *     kind dropdown plus kind-specific fields (pump/valve/vfd/actuator/wellhead)
  *   - Attack machine panel — "Open Attack Terminal" button when sim running,
  *     or a "start the simulation" note when idle.
  *
@@ -177,6 +188,7 @@ export function PropertiesPanel({
         <DeviceIcon
           category={device.category}
           sensorKind={device.sensor?.kind}
+          controllerKind={device.controller?.kind}
           size={22}
           color={zoneColor}
         />
@@ -444,13 +456,23 @@ export function PropertiesPanel({
             </section>
           )}
 
-          {/* ── Smart sensor config (Temperature / Gas / Vibration) ────────────── */}
+          {/* ── Smart sensor config (kind chosen in dropdown) ───────────────────── */}
           {device.category === 'smart-sensor' && (
             <SensorPanel
               sensorConfig={device.sensor}
               nodeId={device.nodeId}
               readOnly={readOnly}
               onChange={(nodeId, sensor) => onDeviceChange?.(nodeId, { sensor })}
+            />
+          )}
+
+          {/* ── Smart controller config (kind chosen in dropdown) ───────────────── */}
+          {device.category === 'smart-controller' && (
+            <ControllerPanel
+              controllerConfig={device.controller}
+              nodeId={device.nodeId}
+              readOnly={readOnly}
+              onChange={(nodeId, controller) => onDeviceChange?.(nodeId, { controller })}
             />
           )}
 

--- a/packages/app/src/renderer/src/properties/SensorPanel.tsx
+++ b/packages/app/src/renderer/src/properties/SensorPanel.tsx
@@ -3,11 +3,12 @@
  *
  * Renders the configuration form for the consolidated smart-sensor device type.
  * Rather than a separate DeviceCategory per physical instrument, smart-sensor
- * carries a single `kind` field (Temperature / Gas / Vibration) selected here via
- * dropdown — the canvas icon, default engineering units, and default range follow
- * that choice automatically. This keeps adding a future sensor kind a config-only
- * change: no new DeviceCategory, no touching every Record<DeviceCategory, ...>
- * exhaustiveness table across the renderer and orchestrator packages.
+ * carries a single `kind` field (temperature/gas/vibration/flow/pressure/level/
+ * analyzer/pmu) selected here via dropdown — the canvas icon, default engineering
+ * units, and default range follow that choice automatically. This keeps adding a
+ * future sensor kind a config-only change: no new DeviceCategory, no touching
+ * every Record<DeviceCategory, ...> exhaustiveness table across the renderer and
+ * orchestrator packages.
  *
  * smart-sensor does NOT spawn a Docker container — fuxa-provisioning.ts reads this
  * config at simulation start and writes it into FUXA's Simulator device/tag JSON.
@@ -29,7 +30,12 @@ type Waveform = SensorConfig['waveform']
 const KIND_OPTIONS: { value: SensorKind; label: string }[] = [
   { value: 'temperature', label: 'Temperature' },
   { value: 'gas', label: 'Gas Detector' },
-  { value: 'vibration', label: 'Vibration' }
+  { value: 'vibration', label: 'Vibration' },
+  { value: 'flow', label: 'Flow Meter' },
+  { value: 'pressure', label: 'Pressure Transmitter' },
+  { value: 'level', label: 'Level Transmitter' },
+  { value: 'analyzer', label: 'Process Analyzer' },
+  { value: 'pmu', label: 'Phasor Measurement Unit' }
 ]
 
 const WAVEFORM_OPTIONS: { value: Waveform; label: string }[] = [
@@ -51,7 +57,12 @@ const KIND_DEFAULTS: Record<
 > = {
   temperature: { units: '°C', minValue: -20, maxValue: 150, waveform: 'sine', noisePercent: 5 },
   gas: { units: 'ppm', minValue: 0, maxValue: 100, waveform: 'random', noisePercent: 10 },
-  vibration: { units: 'mm/s²', minValue: 0, maxValue: 50, waveform: 'sine', noisePercent: 15 }
+  vibration: { units: 'mm/s²', minValue: 0, maxValue: 50, waveform: 'sine', noisePercent: 15 },
+  flow: { units: 'L/min', minValue: 0, maxValue: 300, waveform: 'sawtooth', noisePercent: 5 },
+  pressure: { units: 'bar', minValue: 0, maxValue: 16, waveform: 'sine', noisePercent: 5 },
+  level: { units: 'm', minValue: 0, maxValue: 10, waveform: 'sawtooth', noisePercent: 3 },
+  analyzer: { units: 'pH', minValue: 0, maxValue: 14, waveform: 'sine', noisePercent: 8 },
+  pmu: { units: 'Hz', minValue: 49.5, maxValue: 50.5, waveform: 'sine', noisePercent: 2 }
 }
 
 // ── Default config ────────────────────────────────────────────────────────────

--- a/packages/orchestrator/src/__tests__/schema-fuzz.test.ts
+++ b/packages/orchestrator/src/__tests__/schema-fuzz.test.ts
@@ -93,9 +93,6 @@ const deviceCategory = fc.constantFrom(
   'rtu',
   'ied',
   'sensor',
-  'actuator',
-  'pump',
-  'valve',
   'hmi',
   'historian',
   'scada-server',
@@ -105,9 +102,8 @@ const deviceCategory = fc.constantFrom(
   'attack-machine',
   'dns-server',
   'process-unit',
-  'flow-meter',
-  'pressure-transmitter',
-  'smart-sensor'
+  'smart-sensor',
+  'smart-controller'
 )
 
 /** Well-formed CIDR strings from common RFC 1918 ranges */

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -60,27 +60,17 @@ const DEVICE_IMAGES: Record<DeviceCategory, string> = {
   'safety-plc': 'ghcr.io/iburres/otforge-openplc:latest',
   // STUB: DCS Controller — pymodbus on Alpine until otforge-dcs image is built.
   'dcs-controller': 'ghcr.io/iburres/alpine:latest',
-  // STUB: VFD / Motor Drive — Modbus RTU server stub.
-  vfd: 'ghcr.io/iburres/alpine:latest',
   // BACnet/IP device — bacpypes3 Python server on Alpine (containers/bacnet)
   sensor: 'ghcr.io/iburres/otforge-bacnet:latest',
-  actuator: 'ghcr.io/iburres/alpine:latest',
-  pump: 'ghcr.io/iburres/alpine:latest',
-  valve: 'ghcr.io/iburres/alpine:latest',
-  'flow-meter': 'ghcr.io/iburres/alpine:latest',
-  'pressure-transmitter': 'ghcr.io/iburres/alpine:latest',
-  // STUB: Level transmitter — Modbus TCP register server stub.
-  'level-transmitter': 'ghcr.io/iburres/alpine:latest',
-  // STUB: Analyzer — Modbus TCP register server stub.
-  analyzer: 'ghcr.io/iburres/alpine:latest',
-  // STUB: PMU — DNP3 / IEC C37.118 stub until otforge-pmu is built.
-  pmu: 'ghcr.io/iburres/alpine:latest',
   // STUB: IIoT sensor — MQTT publisher stub until otforge-iiot-sensor is built.
   'iiot-sensor': 'ghcr.io/iburres/alpine:latest',
   // STUB: IoT gateway — MQTT broker/bridge stub until otforge-iot-gateway is built.
   'iot-gateway': 'ghcr.io/iburres/alpine:latest',
   // No container — values live in FUXA Simulator; image field satisfies Record type only.
   'smart-sensor': '',
+  // Real Modbus TCP/RTU outstation — same pymodbus server image as rtu (containers/modbus).
+  // Consolidated from the former vfd/actuator/pump/valve STUB categories (Phase 14).
+  'smart-controller': 'ghcr.io/iburres/otforge-modbus:latest',
   // ── Control Center (Level 3) ────────────────────────────────────────────────
   hmi: 'ghcr.io/iburres/fuxa:latest',
   // OPC UA 1.04 server — asyncua Python server on Alpine (containers/opcua)
@@ -148,20 +138,12 @@ const DEVICE_LIMITS: Record<DeviceCategory, { memory: number; cpus: string }> = 
   'process-unit': { memory: 96, cpus: '0.25' }, // pymodbus + physics loop on Alpine (Phase 11)
   'safety-plc': { memory: 128, cpus: '0.5' }, // Safety PLC / SIS — same budget as process PLC
   'dcs-controller': { memory: 128, cpus: '0.5' }, // DCS Controller — OPC-UA server + loop logic
-  vfd: { memory: 64, cpus: '0.15' }, // VFD / Motor Drive — Modbus RTU register server
   sensor: { memory: 96, cpus: '0.25' }, // BACnet/IP bacpypes3 Python server
-  actuator: { memory: 64, cpus: '0.15' },
-  pump: { memory: 64, cpus: '0.15' },
-  valve: { memory: 64, cpus: '0.15' },
-  'flow-meter': { memory: 64, cpus: '0.15' },
-  'pressure-transmitter': { memory: 64, cpus: '0.15' },
-  'level-transmitter': { memory: 64, cpus: '0.15' }, // Level TX — Modbus register stub
-  analyzer: { memory: 80, cpus: '0.15' }, // Process analyzer — slightly heavier than simple TX
-  pmu: { memory: 80, cpus: '0.2' }, // PMU — DNP3/IEC C37.118 publisher
   'iiot-sensor': { memory: 64, cpus: '0.1' }, // IIoT sensor — lightweight MQTT publish loop
   'iot-gateway': { memory: 96, cpus: '0.2' }, // IoT gateway — MQTT broker + protocol bridge
   // No container — zero resource budget; FUXA Simulator provides the synthetic values.
   'smart-sensor': { memory: 0, cpus: '0' },
+  'smart-controller': { memory: 80, cpus: '0.25' }, // pymodbus on Alpine, same budget as rtu
   // ── Control Center (Level 3) ────────────────────────────────────────────────
   hmi: { memory: 256, cpus: '0.5' }, // FUXA Node.js HMI
   'scada-server': { memory: 256, cpus: '0.5' }, // OPC UA server (asyncua Python)
@@ -610,6 +592,39 @@ export function generateCompose(
         if (device.safetyPlc.safeState) sisEnv.push(`SIS_SAFE_STATE=${device.safetyPlc.safeState}`)
         services[serviceName].environment = sisEnv
       }
+    }
+
+    // Controller-specific env vars — injected for smart-controller devices only.
+    // These are informational (visible in container logs / Properties Panel) — real
+    // protocol behavior comes from the device's generic modbus/dnp3 config blocks.
+    if (device.category === 'smart-controller' && device.controller) {
+      const ctrlEnv: string[] = services[serviceName].environment ?? []
+      ctrlEnv.push(`CONTROLLER_KIND=${device.controller.kind}`)
+      if (device.controller.ratedFlowLpm !== undefined)
+        ctrlEnv.push(`CONTROLLER_RATED_FLOW_LPM=${device.controller.ratedFlowLpm}`)
+      if (device.controller.motorPowerKw !== undefined)
+        ctrlEnv.push(`CONTROLLER_MOTOR_POWER_KW=${device.controller.motorPowerKw}`)
+      if (device.controller.actuatorType)
+        ctrlEnv.push(`CONTROLLER_ACTUATOR_TYPE=${device.controller.actuatorType}`)
+      if (device.controller.failPosition)
+        ctrlEnv.push(`CONTROLLER_FAIL_POSITION=${device.controller.failPosition}`)
+      if (device.controller.maxFrequencyHz !== undefined)
+        ctrlEnv.push(`CONTROLLER_MAX_FREQUENCY_HZ=${device.controller.maxFrequencyHz}`)
+      if (device.controller.travelType)
+        ctrlEnv.push(`CONTROLLER_TRAVEL_TYPE=${device.controller.travelType}`)
+      if (device.controller.signalType)
+        ctrlEnv.push(`CONTROLLER_SIGNAL_TYPE=${device.controller.signalType}`)
+      if (device.controller.chokePositionPercent !== undefined) {
+        ctrlEnv.push(`CONTROLLER_CHOKE_POSITION_PCT=${device.controller.chokePositionPercent}`)
+      }
+      if (device.controller.downholePressureSetpointBar !== undefined) {
+        ctrlEnv.push(
+          `CONTROLLER_DOWNHOLE_PRESSURE_SETPOINT_BAR=${device.controller.downholePressureSetpointBar}`
+        )
+      }
+      if (device.controller.liftMethod)
+        ctrlEnv.push(`CONTROLLER_LIFT_METHOD=${device.controller.liftMethod}`)
+      services[serviceName].environment = ctrlEnv
     }
 
     // Process-unit containers publish their Modbus TCP port (502) on a deterministic

--- a/packages/schema/src/icslab.ts
+++ b/packages/schema/src/icslab.ts
@@ -79,22 +79,14 @@ export type DeviceCategory =
   | 'ied'
   | 'safety-plc' // Safety Instrumented System / Safety PLC (IEC 61511) — Triconex, Siemens Safety
   | 'dcs-controller' // Distributed Control System controller — Honeywell, Emerson DeltaV, ABB 800xA
-  | 'vfd' // Variable Frequency Drive / motor drive — AC drives with Modbus/EtherNet/IP
   | 'legacy-plc' // Siemens S7-300/400/1200/1500 via S7comm (Phase 10)
   | 'iec104-rtu' // IEC 60870-5-104 RTU via conpot emulation (Phase 10)
   | 'process-unit' // Physics-simulated process unit: water tank, pipeline, generator (Phase 11)
   | 'sensor'
-  | 'actuator'
-  | 'pump'
-  | 'valve'
-  | 'flow-meter'
-  | 'pressure-transmitter'
-  | 'level-transmitter' // Tank/vessel level measurement — ultrasonic, radar, float (4-20 mA / HART)
-  | 'analyzer' // Online process analyzer — chromatograph, pH, TOC, conductivity
-  | 'pmu' // Phasor Measurement Unit — IEEE C37.118 synchrophasor, GPS-timestamped grid telemetry
   | 'iiot-sensor' // IIoT wireless sensor node — WirelessHART, ISA100.11a, MQTT publisher
   | 'iot-gateway' // IIoT protocol gateway — Modbus-to-MQTT/REST bridge, edge aggregator
-  | 'smart-sensor' // Configurable field sensor (Temperature / Gas / Vibration — pick `kind` in Properties Panel); FUXA-Simulator-driven, no container
+  | 'smart-sensor' // Configurable field sensor (pick `kind` in Properties Panel); FUXA-Simulator-driven, no container
+  | 'smart-controller' // Configurable field controller/actuator (pick `kind` in Properties Panel); real Modbus-backed container
   // ── Control Center (Level 3) ─────────────────────────────────────────────────
   | 'hmi'
   | 'historian'
@@ -590,11 +582,12 @@ export interface RtuConfig {
  * at simulation start by fuxa-provisioning.ts and written into FUXA's device/tag
  * JSON so the FUXA Simulator device generates realistic synthetic process values.
  *
- * `kind` selects which physical instrument this node represents — Temperature,
- * Gas, or Vibration — chosen from a dropdown in the Properties Panel rather than
- * a separate DeviceCategory per sensor type. This keeps adding a new sensor type
- * a config-only change (no new DeviceCategory, no touching every
- * Record<DeviceCategory, ...> exhaustiveness table across the renderer/orchestrator).
+ * `kind` selects which physical instrument this node represents — chosen from a
+ * dropdown in the Properties Panel rather than a separate DeviceCategory per
+ * sensor type. This keeps adding a new sensor type a config-only change (no new
+ * DeviceCategory, no touching every Record<DeviceCategory, ...> exhaustiveness
+ * table across the renderer/orchestrator). flow/pressure/level/analyzer/pmu were
+ * consolidated from their own former STUB DeviceCategory values into this pattern.
  *
  * The PLC polls sensor values over real Modbus TCP — FUXA exposes each
  * sensor tag as a holding register at the address in `modbusRegister`.
@@ -609,7 +602,7 @@ export interface RtuConfig {
  */
 export interface SensorConfig {
   /** Which physical instrument this node represents. Drives the icon, default units/range, and FUXA tag. */
-  kind: 'temperature' | 'gas' | 'vibration'
+  kind: 'temperature' | 'gas' | 'vibration' | 'flow' | 'pressure' | 'level' | 'analyzer' | 'pmu'
   /**
    * FUXA Simulator waveform type for this sensor tag.
    * Determines the shape of the synthetic process value over time.
@@ -655,6 +648,54 @@ export interface SensorConfig {
   tagName?: string
 }
 
+/**
+ * Configuration for the smart-controller canvas node.
+ *
+ * Unlike smart-sensor, smart-controller DOES spawn a real Docker container
+ * (defaults to the same otforge-modbus image rtu uses) — these devices are meant
+ * to be genuinely attackable, not just synthetic FUXA values. Real protocol
+ * behavior (registers, addresses) comes from the existing generic `modbus`/`dnp3`
+ * blocks on DeviceConfig; the fields below are informational/educational only,
+ * injected as CONTROLLER_* env vars (same spirit as SafetyPlcConfig's SIS_* vars)
+ * so students can see them in container logs and the Properties Panel.
+ *
+ * `kind` selects which physical device this node represents — chosen from a
+ * dropdown in the Properties Panel rather than a separate DeviceCategory.
+ * pump/valve/vfd/actuator were consolidated from their own former STUB
+ * DeviceCategory values into this pattern; wellhead-controller is the first
+ * net-new archetype added directly as a kind (oil&gas wellhead/Christmas-tree
+ * controller — choke valve + downhole pressure + artificial-lift control loop).
+ */
+export interface ControllerConfig {
+  /** Which physical device this node represents. Drives the icon and which fields below apply. */
+  kind: 'pump' | 'valve' | 'vfd' | 'actuator' | 'wellhead-controller'
+  // ── pump ──────────────────────────────────────────────────────────────────
+  /** Rated discharge flow at 100% speed, in L/min. */
+  ratedFlowLpm?: number
+  /** Motor nameplate power, in kW. */
+  motorPowerKw?: number
+  // ── valve ─────────────────────────────────────────────────────────────────
+  /** Actuation method. */
+  actuatorType?: 'pneumatic' | 'electric' | 'hydraulic'
+  /** Position the valve drives to on loss of signal/power. */
+  failPosition?: 'open' | 'closed' | 'last'
+  // ── vfd ───────────────────────────────────────────────────────────────────
+  /** Maximum output frequency, in Hz (typically 50/60 base, up to ~120 for overspeed). */
+  maxFrequencyHz?: number
+  // ── actuator ──────────────────────────────────────────────────────────────
+  /** Mechanical motion type. */
+  travelType?: 'linear' | 'rotary'
+  /** Control signal type from the controlling PLC/RTU. */
+  signalType?: '4-20mA' | 'discrete' | 'modbus'
+  // ── wellhead-controller ───────────────────────────────────────────────────
+  /** Current choke valve opening, 0-100%. */
+  chokePositionPercent?: number
+  /** Downhole pressure setpoint, in bar. */
+  downholePressureSetpointBar?: number
+  /** Artificial-lift method used to bring fluid to surface. */
+  liftMethod?: 'natural' | 'rod-pump' | 'esp' | 'gas-lift'
+}
+
 export interface DeviceConfig {
   nodeId: string // matches CanvasNode.id
   category: DeviceCategory
@@ -676,6 +717,7 @@ export interface DeviceConfig {
   safetyPlc?: SafetyPlcConfig // SIS config for safety-plc devices
   rtuConfig?: RtuConfig // RTU deployment configuration (rtu, iec104-rtu devices)
   sensor?: SensorConfig // Physics simulation parameters for smart-sensor canvas nodes (no container)
+  controller?: ControllerConfig // Educational parameters for smart-controller canvas nodes (real container)
   dockerImage?: string // override default image for this device type
   /**
    * Additional Purdue Model zone networks to attach this device to, beyond the


### PR DESCRIPTION
Step 2 of the device/protocol audit roadmap. Adds a smart-controller DeviceCategory (real Modbus-backed container, same image as rtu) with a kind-discriminated ControllerConfig, consolidating the STUB vfd/actuator/ pump/valve categories and seeding one net-new archetype (wellhead-controller) to prove the pattern end-to-end. Also extends smart-sensor's kind union with the former flow-meter/pressure-transmitter/level-transmitter/analyzer/pmu STUB categories. Future device archetypes become config-only additions to ControllerConfig/SensorConfig instead of touching the DeviceCategory union and its 6+ Record<DeviceCategory,...> exhaustiveness tables.

None of the 9 removed categories were used in any shipped .otflab scenario.