### PR TITLE
feat(app): add "Update Images" toolbar button to refresh stale images

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -31,6 +31,7 @@ import type {
   ScenarioDeleteFileResult,
   SimulationStartResult,
   SimulationStopResult,
+  SimulationUpdateResult,
   ContainerStatus,
   OTForgeScenario,
   DeviceConfig,
@@ -542,15 +543,12 @@ function registerIPCHandlers(): void {
   // ── App metadata ─────────────────────────────────────────────────────────────
 
   /** Returns version strings displayed in the launch screen and about panel. */
-  ipcMain.handle(
-    'app:info',
-    (): AppInfo => ({
-      version: app.getVersion(),
-      nodeVersion: process.versions.node,
-      electronVersion: process.versions.electron,
-      platform: process.platform as AppInfo['platform']
-    })
-  )
+  ipcMain.handle('app:info', (): AppInfo => ({
+    version: app.getVersion(),
+    nodeVersion: process.versions.node,
+    electronVersion: process.versions.electron,
+    platform: process.platform as AppInfo['platform']
+  }))
 
   /** Opens a URL in the system browser (used for documentation links). */
   ipcMain.handle('app:openExternal', async (_e, { url }: { url: string }) => {
@@ -906,6 +904,45 @@ function registerIPCHandlers(): void {
         activeAttackPorts.clear()
         activeWorkstationPorts.clear()
         return { ok: false, error: `Simulation start failed: ${(err as Error).message}` }
+      }
+    }
+  )
+
+  /**
+   * Force-pulls the newest image for every service in the loaded scenario.
+   *
+   * Backs the toolbar "Update Images" button. Because the default
+   * `pull_policy: if_not_present` never re-pulls a `:latest` tag that already
+   * exists locally, a student who pulled an image weeks ago would otherwise
+   * keep running a stale image even after a new one is published to GHCR. This
+   * runs `docker compose pull`, which always re-fetches each tag.
+   *
+   * Reuses the same compose generation as simulation:start so the pull targets
+   * exactly the images this scenario would launch. It does NOT set
+   * activeProjectName or start any container — pulling only refreshes the local
+   * image cache; the updated image takes effect on the next Run Simulation.
+   *
+   * Progress lines are streamed to the renderer over 'simulation:updateProgress'.
+   */
+  ipcMain.handle(
+    'simulation:updateImages',
+    async (_e, scenario: OTForgeScenario): Promise<SimulationUpdateResult> => {
+      try {
+        const dockerAvailable = await dockerClient.isAvailable()
+        if (!dockerAvailable) {
+          return { ok: false, error: 'Docker Desktop is not running.' }
+        }
+
+        const projectName = toProjectName(scenario.meta.name)
+        const zones = await resolveZones()
+        const scenarioDir = pathJoin(app.getPath('userData'), 'scenarios', projectName)
+        const composeYaml = generateCompose(scenario, projectName, scenarioDir, zones)
+
+        return await dockerClient.updateImages(projectName, composeYaml, (line: string) => {
+          mainWindow?.webContents.send('simulation:updateProgress', { line })
+        })
+      } catch (err) {
+        return { ok: false, error: `Image update failed: ${(err as Error).message}` }
       }
     }
   )
@@ -2530,10 +2567,8 @@ function registerIPCHandlers(): void {
    * @returns { ok: true } on success, { ok: false, error } if simulation is not
    *   running or FUXA's port is not yet accepting connections.
    */
-  ipcMain.handle(
-    'hmi:openEditor',
-    async (): Promise<{ ok: boolean; error?: string }> =>
-      openFuxaWindow('FUXA — Editor', '/editor', '#1e1e2e')
+  ipcMain.handle('hmi:openEditor', async (): Promise<{ ok: boolean; error?: string }> =>
+    openFuxaWindow('FUXA — Editor', '/editor', '#1e1e2e')
   )
 
   /**
@@ -2544,14 +2579,12 @@ function registerIPCHandlers(): void {
    * @returns { ok: true } on success, { ok: false, error } if simulation is not
    *   running or FUXA's port is not yet accepting connections.
    */
-  ipcMain.handle(
-    'scada:open',
-    async (): Promise<{ ok: boolean; error?: string }> =>
-      openFuxaWindow(
-        'SCADA Overview — OT Process',
-        `/home?viewName=${encodeURIComponent('SCADA Overview')}`,
-        '#0d1117'
-      )
+  ipcMain.handle('scada:open', async (): Promise<{ ok: boolean; error?: string }> =>
+    openFuxaWindow(
+      'SCADA Overview — OT Process',
+      `/home?viewName=${encodeURIComponent('SCADA Overview')}`,
+      '#0d1117'
+    )
   )
 
   // ── PLC firmware import ────────────────────────────────────────────────────────

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -32,6 +32,7 @@ import type {
   ScenarioDeleteFileResult,
   SimulationStartResult,
   SimulationStopResult,
+  SimulationUpdateResult,
   ContainerStatus,
   LicenseValidationResult,
   OTForgeScenario,
@@ -128,7 +129,18 @@ const api = {
      * Returns the current state and health of all containers in the active simulation.
      * Returns an empty array when no simulation is running.
      */
-    status: (): Promise<ContainerStatus[]> => ipcRenderer.invoke('simulation:status')
+    status: (): Promise<ContainerStatus[]> => ipcRenderer.invoke('simulation:status'),
+
+    /**
+     * Force-pulls the newest image for every service in the scenario via
+     * `docker compose pull`. Unlike start (which uses --pull missing), this
+     * always re-fetches each :latest tag, so students receive updated GHCR
+     * images that a cached tag would otherwise mask. Does not start containers.
+     * Progress is streamed via on.simulationUpdateProgress().
+     * @param scenario - The full scenario whose images to refresh.
+     */
+    updateImages: (scenario: OTForgeScenario): Promise<SimulationUpdateResult> =>
+      ipcRenderer.invoke('simulation:updateImages', scenario)
   },
 
   // ── System info ───────────────────────────────────────────────────────────────
@@ -686,6 +698,19 @@ const api = {
     simulationPullProgress: (cb: (status: { line: string }) => void) => {
       ipcRenderer.on('simulation:pullProgress', (_event, status) => cb(status))
       return () => ipcRenderer.removeAllListeners('simulation:pullProgress')
+    },
+
+    /**
+     * Fires for each output line emitted by `docker compose pull` during a
+     * toolbar-triggered "Update Images" action. Lets the renderer show the most
+     * recent Docker line in the update overlay.
+     *
+     * @param cb - Callback receiving { line: string } — one Docker output line.
+     * @returns Unsubscribe function — call in useEffect cleanup.
+     */
+    simulationUpdateProgress: (cb: (status: { line: string }) => void) => {
+      ipcRenderer.on('simulation:updateProgress', (_event, status) => cb(status))
+      return () => ipcRenderer.removeAllListeners('simulation:updateProgress')
     }
   }
 }

--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -502,6 +502,19 @@ export default function App() {
   /** Most recent output line from docker compose during a pull — shown in the overlay. */
   const [pullProgress, setPullProgress] = useState<string>('')
 
+  /**
+   * True while a toolbar-triggered "Update Images" pull is in progress. Drives the
+   * "Updating Container Images" overlay. Independent of simStatus — the update runs
+   * with the simulation stopped and does not start any container.
+   */
+  const [updating, setUpdating] = useState<boolean>(false)
+  /** Most recent `docker compose pull` output line — shown in the update overlay. */
+  const [updateProgress, setUpdateProgress] = useState<string>('')
+  /** Transient success message shown as a toast after an image update completes. */
+  const [updateNotice, setUpdateNotice] = useState<string | null>(null)
+  /** Auto-dismiss timer for the update-success toast. */
+  const updateNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   // attackLaunched state removed — toolbar button now opens AttackTerminalModal directly
   // so button color uses (attackTerminalDevice !== null) instead of a separate flag.
 
@@ -606,11 +619,23 @@ export default function App() {
       }
     })
 
+    // Stream `docker compose pull` output during a toolbar "Update Images" action
+    // into the update overlay, using the same line-filtering as the start pull.
+    const unsubUpdate = window.electronAPI.on.simulationUpdateProgress(({ line }) => {
+      if (
+        line.length < 120 &&
+        /pulling|pull|download|extract|layer|image|pushed|digest|up to date/i.test(line)
+      ) {
+        setUpdateProgress(line)
+      }
+    })
+
     // Clean up IPC listeners when the component unmounts
     return () => {
       unsubStatus()
       unsubPull()
       unsubProgress()
+      unsubUpdate()
     }
   }, [])
 
@@ -1317,6 +1342,37 @@ export default function App() {
   }, [scenario])
 
   /**
+   * Toolbar "Update Images" handler.
+   *
+   * Runs `docker compose pull` for the loaded scenario so the local cache picks
+   * up newly published GHCR images that the default `pull_policy: if_not_present`
+   * would otherwise never re-fetch (e.g. an updated Kali attack-base image). Does
+   * not start any container — the refreshed image is used on the next Run.
+   * Only enabled while the simulation is idle.
+   */
+  const handleUpdateImages = useCallback(async () => {
+    if (!scenario) return
+    setSimError(null)
+    setUpdateProgress('')
+    setUpdating(true)
+    try {
+      const result = await window.electronAPI.simulation.updateImages(scenario)
+      if (result.ok) {
+        setUpdateNotice('Container images are up to date.')
+        if (updateNoticeTimerRef.current) clearTimeout(updateNoticeTimerRef.current)
+        updateNoticeTimerRef.current = setTimeout(() => setUpdateNotice(null), 6000)
+      } else {
+        setSimError(result.error ?? 'Image update failed.')
+      }
+    } catch (err) {
+      setSimError(`Image update failed: ${(err as Error).message}`)
+    } finally {
+      setUpdating(false)
+      setUpdateProgress('')
+    }
+  }, [scenario])
+
+  /**
    * Stops the simulation:
    *   1. Transition to 'stopping'
    *   2. Call simulation:stop IPC which runs docker compose down --volumes
@@ -1486,6 +1542,29 @@ export default function App() {
             >
               Open
             </button>
+            {/*
+             * Update Images — force-pulls the newest GHCR images for the loaded
+             * scenario. Needed because pull_policy: if_not_present never re-pulls a
+             * :latest tag that already exists locally, so a published image update
+             * (e.g. a new Kali attack-base) would otherwise never reach the student.
+             * Shown only with a scenario loaded; disabled unless idle + Docker up.
+             */}
+            {scenario && (
+              <button
+                className="btn btn-sm btn-ghost"
+                onClick={handleUpdateImages}
+                disabled={!simIsIdle || !docker?.available || updating}
+                title={
+                  !docker?.available
+                    ? 'Docker is not running'
+                    : !simIsIdle
+                      ? 'Stop the simulation to update images'
+                      : 'Download the latest container images for this scenario from the registry'
+                }
+              >
+                {updating ? 'Updating…' : 'Update Images'}
+              </button>
+            )}
             {/*
              * Edit Scenario — shown whenever a scenario is open.
              * Grayed in Student Mode (builderModeActive = false) because editing
@@ -2029,6 +2108,46 @@ export default function App() {
               {pullProgress && <p className="pull-progress-line">{pullProgress}</p>}
             </div>
           </div>
+        </div>
+      )}
+      {/*
+       * "Updating Container Images" overlay — shown while a toolbar-triggered
+       * `docker compose pull` runs. Reuses the pull-overlay styles. Independent of
+       * simStatus since the update runs with the simulation stopped.
+       */}
+      {updating && (
+        <div className="pull-overlay" role="alertdialog" aria-label="Updating images">
+          <div className="pull-overlay-card">
+            <div className="pull-spinner" aria-hidden="true" />
+            <div className="pull-overlay-text">
+              <strong>Updating Container Images</strong>
+              <p>
+                Pulling the latest images for this scenario from the registry.
+                <br />
+                This may take a few minutes depending on your connection speed.
+              </p>
+              {updateProgress && <p className="pull-progress-line">{updateProgress}</p>}
+            </div>
+          </div>
+        </div>
+      )}
+      {/* Update-complete toast — reuses the desktop-hint toast styling. */}
+      {updateNotice && (
+        <div className="desktop-hint-toast" role="status" aria-live="polite">
+          <div className="desktop-hint-toast-header">
+            <span className="desktop-hint-toast-title">✓ Images Updated</span>
+            <button
+              className="desktop-hint-toast-close"
+              onClick={() => {
+                if (updateNoticeTimerRef.current) clearTimeout(updateNoticeTimerRef.current)
+                setUpdateNotice(null)
+              }}
+              aria-label="Dismiss"
+            >
+              ×
+            </button>
+          </div>
+          <div className="desktop-hint-toast-body">{updateNotice}</div>
         </div>
       )}
     </div>

--- a/packages/orchestrator/src/docker-client.ts
+++ b/packages/orchestrator/src/docker-client.ts
@@ -450,6 +450,104 @@ export class DockerClient {
   }
 
   /**
+   * Force-pulls the newest version of every image in a scenario, streaming
+   * progress line-by-line. Backs the toolbar "Update Images" action.
+   *
+   * Unlike `docker compose up --pull missing` (used on start), this runs
+   * `docker compose pull`, which ALWAYS re-fetches each `:latest` tag even when
+   * an older copy is already cached. This is the only path by which a student
+   * who pulled an image weeks ago receives an updated GHCR image — the default
+   * `pull_policy: if_not_present` never re-pulls a tag that already exists
+   * locally.
+   *
+   * The compose file is (re)written from the supplied YAML first, so this works
+   * even for a scenario that has never been started (no compose file on disk yet).
+   * Running containers are not affected — `pull` only refreshes the local image
+   * cache; the new image takes effect on the next simulation start.
+   *
+   * @param projectName - Sanitized Compose project name (lowercase alphanumeric + hyphen).
+   * @param composeYaml - Complete docker-compose.yml content as a YAML string.
+   * @param onProgress  - Optional callback fired with each cleaned output line.
+   * @returns { ok: true } on success, { ok: false, error } on failure.
+   */
+  async updateImages(
+    projectName: string,
+    composeYaml: string,
+    onProgress?: (line: string) => void
+  ): Promise<{ ok: boolean; error?: string }> {
+    const scenarioDir = join(this.workDir, projectName)
+    const composeFile = join(scenarioDir, 'docker-compose.yml')
+
+    try {
+      // recursive: true makes mkdir a no-op if the directory already exists
+      await mkdir(scenarioDir, { recursive: true })
+      await writeFile(composeFile, composeYaml, 'utf-8')
+      await this._composePull(projectName, composeFile, onProgress)
+      return { ok: true }
+    } catch (err) {
+      const pullErr = err as Error & { _composeOutput?: string }
+      const rawOutput = pullErr._composeOutput ?? pullErr.message
+      const errorLines = rawOutput
+        .split('\n')
+        .map(l => l.trim())
+        .filter(l => /error|failed|cannot|denied|unauthorized|no such|not found/i.test(l))
+        .filter((l, i, arr) => arr.indexOf(l) === i)
+        .slice(0, 8)
+      const shortError =
+        errorLines.length > 0 ? errorLines.join('\n') : `docker compose pull failed: ${rawOutput}`
+      return { ok: false, error: shortError }
+    }
+  }
+
+  /**
+   * Runs `docker compose pull` via spawn so output can be streamed line-by-line,
+   * mirroring the cleaning logic in `_composeUp` (CR→LF split, ANSI strip).
+   */
+  private _composePull(
+    projectName: string,
+    composeFile: string,
+    onProgress?: (line: string) => void
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const allLines: string[] = []
+      const child = spawn('docker', ['compose', '-p', projectName, '-f', composeFile, 'pull'], {
+        env: buildEnv()
+      })
+
+      const processChunk = (buf: Buffer): void => {
+        buf
+          .toString()
+          .replace(/\r/g, '\n')
+          .split('\n')
+          .forEach(raw => {
+            // eslint-disable-next-line no-control-regex
+            const line = raw.replace(/\x1B\[[0-9;]*[mGKHF]/g, '').trim()
+            if (!line) return
+            allLines.push(line)
+            onProgress?.(line)
+          })
+      }
+
+      child.stdout?.on('data', processChunk)
+      child.stderr?.on('data', processChunk)
+
+      child.on('close', code => {
+        if (code === 0) {
+          resolve()
+        } else {
+          const e = new Error(`docker compose pull exited with code ${code}`) as Error & {
+            _composeOutput: string
+          }
+          e._composeOutput = allLines.join('\n')
+          reject(e)
+        }
+      })
+
+      child.on('error', reject)
+    })
+  }
+
+  /**
    * Returns the absolute path to a scenario's docker-compose.yml file.
    *
    * @param projectName - The Compose project name.

--- a/packages/schema/src/ipc.ts
+++ b/packages/schema/src/ipc.ts
@@ -53,6 +53,11 @@ export interface SimulationStopResult {
   error?: string
 }
 
+export interface SimulationUpdateResult {
+  ok: boolean
+  error?: string
+}
+
 export interface ContainerStatus {
   nodeId: string
   containerId?: string


### PR DESCRIPTION
## Problem

Scenarios pin GHCR images to `:latest`, start with `docker compose up --pull missing`, and every service sets `pull_policy: if_not_present`. That combination means a machine that pulled an image weeks ago **never re-fetches an updated `:latest` tag**. When an image is republished (e.g. the Kali `otforge-attack-base` after a new attack script was added to its entrypoint), the update silently never reaches students/instructors who already have an older `:latest` cached.

This surfaced with Lab 03: the `dnp3_attack.py` script was in the repo and in the freshly-published GHCR image, but local machines kept running a two-week-old cached image that predated it. Forcing pulls via `pull_policy: always` caused problems previously, so this adds an explicit, **user-triggered** refresh instead.

## Change

A new **Update Images** toolbar button (left action group, shown with a scenario loaded, enabled while the simulation is idle and Docker is up) runs `docker compose pull` for the loaded scenario's compose file, which **always** re-fetches each tag. It does not start any container — the refreshed image takes effect on the next Run Simulation.

- **schema**: add `SimulationUpdateResult`.
- **orchestrator**: `DockerClient.updateImages()` (re)writes the compose file — so it works even for a scenario never started before — then streams `docker compose pull` output line-by-line.
- **main**: `simulation:updateImages` IPC handler reuses the start-path compose generation and streams progress over `simulation:updateProgress`.
- **preload**: expose `simulation.updateImages()` + `on.simulationUpdateProgress()`.
- **renderer**: toolbar button, a progress overlay (reuses the existing pull-overlay styles), and a completion toast.

## Verification

- `tsc --noEmit` clean in schema, orchestrator, and app (node + web).
- Orchestrator vitest: 163/163 pass.
- `eslint` clean (0 errors).
- Full `electron-vite build && electron-builder` packages successfully.
- Underlying mechanism confirmed manually: `docker compose pull` / `docker pull` refreshes the stale `otforge-attack-base:latest` and the new image contains the expected script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)