### PR TITLE
fix(app): move renderer dev-server port off Windows reserved range

### DIFF
--- a/packages/app/electron.vite.config.ts
+++ b/packages/app/electron.vite.config.ts
@@ -73,6 +73,24 @@ export default defineConfig({
 
   renderer: {
     root: resolve(__dirname, 'src/renderer'),
+    /**
+     * Dev-server port for the renderer (HMR).
+     *
+     * electron-vite's default is 5173, but on Windows hosts running Docker
+     * Desktop / Hyper-V, WinNAT reserves large dynamic TCP port ranges (e.g.
+     * 5146–5245), and 5173 frequently lands inside one. A bind into a reserved
+     * range fails with `EACCES: permission denied` (NOT EADDRINUSE), which
+     * killed `npm run dev` with no other process actually holding the port.
+     *
+     * 3173 sits below the observed reservation clusters (which start ~4710), so
+     * it avoids the collision on the affected machines. The main process loads
+     * the renderer from process.env.ELECTRON_RENDERER_URL (see src/main/index.ts),
+     * which electron-vite sets from this port automatically — no other change
+     * is needed. strictPort is left off so an in-use port still auto-increments.
+     */
+    server: {
+      port: 3173
+    },
     build: {
       rollupOptions: {
         input: {


### PR DESCRIPTION
## Problem

`npm run dev` failed on a Windows host running Docker Desktop with:

```
Error: listen EACCES: permission denied ::1:5173
```

Nothing was actually listening on 5173. The cause is Windows **reserved port ranges**: WinNAT (Hyper-V / Docker Desktop / WSL2) reserves large dynamic TCP ranges, and on the affected machine 5173 fell inside the reserved range **5146–5245** (`netsh int ipv4 show excludedportrange`). A user-mode bind into a reserved range fails with `EACCES` — distinct from `EADDRINUSE` — which is why it looked like a permission error with no process holding the port. This will recur for any Windows/Docker student, since the whole project runs on Docker Desktop.

## Fix

Set the renderer dev-server port to **3173** in `electron.vite.config.ts` (below the observed reservation clusters, which start ~4710). The main process already loads the renderer from `process.env.ELECTRON_RENDERER_URL` (`src/main/index.ts:526`), which electron-vite derives from this port automatically — so no other change is needed. `strictPort` is intentionally left off so an in-use port still auto-increments.

## Verification

- `netsh int ipv4/ipv6 show excludedportrange`: 3173 is outside all reserved ranges; nothing listening on it.
- Ran `npm run dev`: dev server now binds to `http://localhost:3173/` with no `EACCES`, and Electron launches (previously it died before the dev server came up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)