### PR TITLE
fix(ci): rebuild Zeek image to pull patched libssh2 (CVE-2026-55200 et al)

### DIFF
--- a/containers/zeek/Dockerfile
+++ b/containers/zeek/Dockerfile
@@ -7,7 +7,16 @@ FROM zeek/zeek:latest
 # --no-install-recommends intentionally omitted: security upgrades should pull
 # in recommended packages so that patch coverage is complete.
 # Fixes CVE-2026-45447 (openssl heap use-after-free, libssl3t64 3.5.6-1~deb13u2).
-RUN apt-get update && apt-get upgrade -y \
+#
+# SECURITY_REFRESH busts this layer's build cache so a rebuild re-runs the
+# upgrade against the *current* Debian repos rather than reusing a months-old
+# cached layer. Bump the date whenever a newly published security update needs
+# to be pulled. 2026-07-06: libssh2 1.11.1-1+deb13u1 fixes CVE-2026-55200
+# (CRITICAL out-of-bounds write), CVE-2026-55199 (HIGH DoS), and CVE-2026-7598
+# — none of which were in the repos when this image was last built (2026-06-29).
+ARG SECURITY_REFRESH=2026-07-06
+RUN echo "security-refresh: ${SECURITY_REFRESH}" \
+    && apt-get update && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
 # ICS protocol monitoring script


### PR DESCRIPTION
## Problem

The **Build and Push Container Images** workflow shows a red status. It's a stale run (the last one was the PR #18 merge on 2026-06-29; nothing since touched `containers/**`, so it never re-ran). Its only failing job is `Trivy — scan otforge-zeek`, which flags three `libssh2-1t64` CVEs:

| CVE | Severity | Status |
|---|---|---|
| CVE-2026-55200 | CRITICAL | fixed in `1.11.1-1+deb13u1` |
| CVE-2026-55199 | HIGH | fixed in `1.11.1-1+deb13u1` |
| CVE-2026-7598 | — | (only this one was suppressed in `.trivyignore`) |

The image already runs `apt-get upgrade -y`, but it was built **2026-06-29**, before Debian published `1.11.1-1+deb13u1`. Because the CRITICAL is *fixed* upstream, `ignore-unfixed: true` does not skip it, and the single `.trivyignore` suppression doesn't cover it. Per this repo's Trivy philosophy ("fail only when a fix exists and we haven't applied it"), the correct fix is to rebuild against current repos, not to suppress.

## Fix

Add a dated `SECURITY_REFRESH` build arg to `containers/zeek/Dockerfile` that busts the `apt-get upgrade` layer cache, so a rebuild re-runs the upgrade against the current Debian package repos and pulls the patched libssh2. Bump the date in future when another security update needs pulling.

## Verification (local)

- Fresh `docker build` of `containers/zeek/` installs **`libssh2-1t64 1.11.1-1+deb13u1`**.
- `trivy image --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore` against the rebuilt image reports **0 vulnerabilities** (exit 0).

Merging this touches `containers/**`, which retriggers the workflow — the zeek scan should now pass and clear the red status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)