### PR TITLE
feat(app): save & resume student sessions (scenario + rules + step + Lab folder)

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -32,6 +32,9 @@ import type {
   SimulationStartResult,
   SimulationStopResult,
   SimulationUpdateResult,
+  SessionSummary,
+  SessionSaveResult,
+  SessionLoadResult,
   ContainerStatus,
   OTForgeScenario,
   DeviceConfig,
@@ -71,6 +74,7 @@ import {
 import type { OtZoneDevice, OtZoneTopology } from '@otforge/orchestrator'
 import type { NetworkZone, ACLRule } from '@otforge/schema'
 import { initDb, saveActiveScenario, loadActiveScenario, clearActiveScenario } from './db'
+import { saveSession, loadSession, listSessions } from './sessions'
 import { parsePlcFile } from './plc-import'
 
 const execAsync = promisify(exec)
@@ -984,6 +988,62 @@ function registerIPCHandlers(): void {
     if (!activeProjectName) return []
     return dockerClient.getStatus(activeProjectName)
   })
+
+  // ── Session save / load ───────────────────────────────────────────────────────
+  /**
+   * Saves the student's current session so a lab can be resumed later. Persists
+   * the scenario (which carries their edited Suricata/firewall rules) and the
+   * tutorial step to <userData>/sessions/<projectName>/. Keyed by scenario name,
+   * so re-saving the same lab overwrites its one session. A later increment also
+   * captures the student's Lab_NN_Student_Saved_Work folder into this directory.
+   */
+  ipcMain.handle(
+    'session:save',
+    async (
+      _e,
+      { scenario, tutorialStep }: { scenario: OTForgeScenario; tutorialStep: number }
+    ): Promise<SessionSaveResult> => {
+      try {
+        const projectName = toProjectName(scenario.meta.name)
+        await saveSession(app.getPath('userData'), {
+          projectName,
+          scenarioName: scenario.meta.name,
+          savedAt: new Date().toISOString(),
+          tutorialStep,
+          scenario
+        })
+        return { ok: true }
+      } catch (err) {
+        return { ok: false, error: `Failed to save session: ${(err as Error).message}` }
+      }
+    }
+  )
+
+  /** Lists all saved sessions (summaries, newest first) for the Load picker. */
+  ipcMain.handle('session:list', async (): Promise<SessionSummary[]> => {
+    try {
+      return await listSessions(app.getPath('userData'))
+    } catch {
+      return []
+    }
+  })
+
+  /**
+   * Loads a saved session by project name, returning the scenario and the tutorial
+   * step to resume at. The renderer applies the scenario and jumps to that step.
+   */
+  ipcMain.handle(
+    'session:load',
+    async (_e, { projectName }: { projectName: string }): Promise<SessionLoadResult> => {
+      try {
+        const session = await loadSession(app.getPath('userData'), projectName)
+        if (!session) return { ok: false, error: 'No saved session found.' }
+        return { ok: true, scenario: session.scenario, tutorialStep: session.tutorialStep }
+      } catch (err) {
+        return { ok: false, error: `Failed to load session: ${(err as Error).message}` }
+      }
+    }
+  )
 
   // ── Firewall runtime reload ───────────────────────────────────────────────────
 

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -74,7 +74,7 @@ import {
 import type { OtZoneDevice, OtZoneTopology } from '@otforge/orchestrator'
 import type { NetworkZone, ACLRule } from '@otforge/schema'
 import { initDb, saveActiveScenario, loadActiveScenario, clearActiveScenario } from './db'
-import { saveSession, loadSession, listSessions } from './sessions'
+import { saveSession, loadSession, listSessions, sessionDir } from './sessions'
 import { parsePlcFile } from './plc-import'
 
 const execAsync = promisify(exec)
@@ -420,6 +420,15 @@ const attackWindows = new Map<string, BrowserWindow>()
  * Used by workstation:launchWindow and workstation:getVncUrl to build the noVNC URL.
  */
 const activeWorkstationPorts = new Map<string, number>()
+
+/**
+ * Project name of a session the user just chose to Load, whose saved
+ * Lab_NN_Student_Saved_Work folder should be copied back into the workstation on
+ * the next simulation start for that project. Set by session:load, consumed and
+ * cleared once by configureWorkstationSaveFolder. Null means "fresh run — do not
+ * restore any prior work".
+ */
+let pendingSessionRestore: string | null = null
 
 /**
  * Tracks open noVNC BrowserWindows keyed by engineering-workstation device nodeId.
@@ -899,6 +908,11 @@ function registerIPCHandlers(): void {
         // Fire-and-forget — runs in the background while the renderer shows "running".
         configureAttackMachine().catch(() => {})
 
+        // Create the per-lab "…_Student_Saved_Work" folder on the workstation so
+        // students have a known place to keep work that Save Session preserves.
+        // Fire-and-forget — runs after the desktop finishes booting.
+        configureWorkstationSaveFolder(scenario).catch(() => {})
+
         return { ok: true, containersStarted: started }
       } catch (err) {
         // Reset active project so a retry doesn't think a simulation is already running
@@ -1012,6 +1026,9 @@ function registerIPCHandlers(): void {
           tutorialStep,
           scenario
         })
+        // Best-effort capture of the student's Lab_NN_Student_Saved_Work folder
+        // (only succeeds while the workstation is running); never fails the save.
+        await captureLabFolder(scenario, projectName)
         return { ok: true }
       } catch (err) {
         return { ok: false, error: `Failed to save session: ${(err as Error).message}` }
@@ -1038,6 +1055,9 @@ function registerIPCHandlers(): void {
       try {
         const session = await loadSession(app.getPath('userData'), projectName)
         if (!session) return { ok: false, error: 'No saved session found.' }
+        // Arm the one-shot restore: the next simulation start for this project
+        // copies the saved lab-work folder back into the workstation.
+        pendingSessionRestore = projectName
         return { ok: true, scenario: session.scenario, tutorialStep: session.tutorialStep }
       } catch (err) {
         return { ok: false, error: `Failed to load session: ${(err as Error).message}` }
@@ -2934,6 +2954,120 @@ function isPortOpen(port: number, timeout = 2000): Promise<boolean> {
  *
  * docker exec runs as root (the container default), so no sudo is required.
  */
+/**
+ * Derives the student save-folder name for a scenario, e.g.
+ * "ICS Lab 03 — …" → "Lab_03_Student_Saved_Work". Non-numbered scenarios
+ * (OpenPLC_Lab, Learning…) fall back to a sanitized scenario name.
+ * Shared by folder provisioning (create) and session save/load (docker cp),
+ * so both always agree on the path.
+ */
+function labSaveFolderName(scenario: OTForgeScenario): string {
+  const name = scenario.meta.name ?? 'Lab'
+  const labMatch = name.match(/\bLab\s+0*(\d+)/i)
+  if (labMatch) {
+    return `Lab_${labMatch[1].padStart(2, '0')}_Student_Saved_Work`
+  }
+  const slug = name
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 40)
+  return `${slug || 'Lab'}_Student_Saved_Work`
+}
+
+/**
+ * Creates the per-lab "…_Student_Saved_Work" folder on each workstation after the
+ * desktop boots, with a README telling students to keep their work there. The
+ * folder lives at /root/Desktop/<name> so it is one click from the Xfce desktop.
+ * Save Session later captures this folder (docker cp) into the session bundle.
+ *
+ * Best-effort and fire-and-forget: any failure just means the student can create
+ * the folder themselves; it must never block or crash a running simulation.
+ */
+async function configureWorkstationSaveFolder(scenario: OTForgeScenario): Promise<void> {
+  if (!activeProjectName || activeWorkstationPorts.size === 0) return
+  // Capture the active project name up-front — it's a mutable module var and this
+  // function awaits, so pin it for the restore-flag comparison and cp paths.
+  const proj = activeProjectName
+
+  const folder = labSaveFolderName(scenario)
+  // ASCII only, no shell-special characters (runs through cmd.exe on Windows).
+  const readme =
+    'Save any work you want to keep in this folder - PLC programs, Wireshark ' +
+    'captures, notes. Everything here is preserved when you click Save Session ' +
+    'in OTForge, so you can resume this lab later.'
+
+  const MAX_WAIT_MS = 90_000
+  const POLL_INTERVAL_MS = 3_000
+
+  for (const [nodeId, vncPort] of activeWorkstationPorts) {
+    // Same container-name derivation as compose-generator.ts / configureAttackMachine.
+    const sanitized = nodeId.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+    const containerName = `${proj}-${sanitized}`
+
+    // Wait for the workstation's noVNC port so the desktop is up before we touch it.
+    const deadline = Date.now() + MAX_WAIT_MS
+    while (Date.now() < deadline) {
+      if (await isPortOpen(vncPort, 1500)) break
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS))
+    }
+
+    try {
+      await execAsync(
+        `docker exec ${containerName} bash -c ` +
+          `"mkdir -p /root/Desktop/${folder} && echo '${readme}' > /root/Desktop/${folder}/README.txt"`,
+        { timeout: 30_000 }
+      )
+    } catch {
+      // Non-fatal — the student can still create the folder manually.
+    }
+
+    // If the student chose Load Session for this project, copy their saved work
+    // back into the freshly-created folder (contents merge over the README).
+    if (pendingSessionRestore === proj) {
+      const src = pathJoin(sessionDir(app.getPath('userData'), proj), 'lab-work')
+      try {
+        await access(src) // throws if the session has no captured work
+        await execAsync(`docker cp "${src}/." ${containerName}:/root/Desktop/${folder}`, {
+          timeout: 60_000
+        })
+      } catch {
+        // No saved lab-work, or cp failed — folder stays as freshly created.
+      }
+    }
+  }
+
+  // Consume the one-shot restore flag so a later fresh run doesn't re-restore.
+  if (pendingSessionRestore === proj) pendingSessionRestore = null
+}
+
+/**
+ * Captures the student's Lab_NN_Student_Saved_Work folder out of the running
+ * workstation into the session bundle (<userData>/sessions/<project>/lab-work),
+ * via `docker cp`. Best-effort: if the workstation isn't running or the folder
+ * doesn't exist, the session is still saved with the scenario + step.
+ */
+async function captureLabFolder(scenario: OTForgeScenario, projectName: string): Promise<void> {
+  const wsNode = Object.entries(scenario.devices.devices).find(
+    ([, d]) => d.category === 'engineering-workstation'
+  )?.[0]
+  if (!wsNode) return // scenario has no workstation to capture from
+
+  const sanitized = wsNode.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+  const containerName = `${projectName}-${sanitized}`
+  const folder = labSaveFolderName(scenario)
+  const dest = pathJoin(sessionDir(app.getPath('userData'), projectName), 'lab-work')
+
+  try {
+    // Remove any prior capture so the copy reflects the current folder exactly.
+    await rm(dest, { recursive: true, force: true })
+    await execAsync(`docker cp ${containerName}:/root/Desktop/${folder} "${dest}"`, {
+      timeout: 60_000
+    })
+  } catch {
+    // Workstation not running or folder absent — scenario + step were still saved.
+  }
+}
+
 async function configureAttackMachine(): Promise<void> {
   if (!activeProjectName || activeAttackPorts.size === 0) return
 

--- a/packages/app/src/main/sessions.ts
+++ b/packages/app/src/main/sessions.ts
@@ -1,0 +1,93 @@
+/**
+ * sessions.ts — On-disk store for saved student "sessions".
+ *
+ * A session lets a student stop a lab and resume it later without redoing their
+ * work. Each session is a directory under `<userData>/sessions/<projectName>/`
+ * containing `session.json` — the scenario (which carries their edited Suricata/
+ * firewall rules) plus the tutorial step they were on. A later increment also
+ * drops the student's `Lab_NN_Student_Saved_Work` folder tarball into this same
+ * directory, which is why a session is a directory rather than a single file.
+ *
+ * Keyed by the sanitized scenario name (the same value used as the Docker Compose
+ * project name), so saving the same lab again overwrites its one session —
+ * "resume my Lab 03" rather than an ever-growing pile of timestamped saves.
+ */
+
+import { mkdir, writeFile, readFile, readdir } from 'fs/promises'
+import { join } from 'path'
+import type { OTForgeScenario, SessionSummary } from '@otforge/schema'
+
+/** Full on-disk session payload. Extends the summary with the scenario itself. */
+export interface StoredSession extends SessionSummary {
+  scenario: OTForgeScenario
+}
+
+/** Absolute path to the sessions root directory. */
+function sessionsRoot(userDataPath: string): string {
+  return join(userDataPath, 'sessions')
+}
+
+/** Absolute path to a single session's directory. */
+export function sessionDir(userDataPath: string, projectName: string): string {
+  return join(sessionsRoot(userDataPath), projectName)
+}
+
+/**
+ * Writes (or overwrites) a session for a scenario.
+ *
+ * @param userDataPath - Electron userData directory.
+ * @param session - The full session payload to persist.
+ */
+export async function saveSession(userDataPath: string, session: StoredSession): Promise<void> {
+  const dir = sessionDir(userDataPath, session.projectName)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'session.json'), JSON.stringify(session), 'utf-8')
+}
+
+/**
+ * Reads a single session by project name.
+ *
+ * @returns The stored session, or null if none is saved for that project.
+ */
+export async function loadSession(
+  userDataPath: string,
+  projectName: string
+): Promise<StoredSession | null> {
+  try {
+    const raw = await readFile(join(sessionDir(userDataPath, projectName), 'session.json'), 'utf-8')
+    return JSON.parse(raw) as StoredSession
+  } catch {
+    // Missing file/dir (never saved) is expected — not an error.
+    return null
+  }
+}
+
+/**
+ * Lists all saved sessions as lightweight summaries (no scenario payload),
+ * newest first. Malformed or partial session directories are skipped.
+ */
+export async function listSessions(userDataPath: string): Promise<SessionSummary[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(sessionsRoot(userDataPath))
+  } catch {
+    // Sessions root doesn't exist yet — no sessions saved.
+    return []
+  }
+
+  const summaries: SessionSummary[] = []
+  for (const name of entries) {
+    const session = await loadSession(userDataPath, name)
+    if (!session) continue
+    summaries.push({
+      projectName: session.projectName,
+      scenarioName: session.scenarioName,
+      savedAt: session.savedAt,
+      tutorialStep: session.tutorialStep
+    })
+  }
+
+  // Newest first so the picker surfaces the most recent work at the top.
+  summaries.sort((a, b) => b.savedAt.localeCompare(a.savedAt))
+  return summaries
+}

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -33,6 +33,9 @@ import type {
   SimulationStartResult,
   SimulationStopResult,
   SimulationUpdateResult,
+  SessionSummary,
+  SessionSaveResult,
+  SessionLoadResult,
   ContainerStatus,
   LicenseValidationResult,
   OTForgeScenario,
@@ -141,6 +144,29 @@ const api = {
      */
     updateImages: (scenario: OTForgeScenario): Promise<SimulationUpdateResult> =>
       ipcRenderer.invoke('simulation:updateImages', scenario)
+  },
+
+  // ── Saved sessions (resume a lab later) ───────────────────────────────────────
+  session: {
+    /**
+     * Saves the current scenario (with the student's edited rules) and tutorial
+     * step so the lab can be resumed later. Keyed by scenario name — re-saving
+     * the same lab overwrites its session.
+     * @param scenario     - The current scenario to snapshot.
+     * @param tutorialStep - 0-based step the student is on.
+     */
+    save: (scenario: OTForgeScenario, tutorialStep: number): Promise<SessionSaveResult> =>
+      ipcRenderer.invoke('session:save', { scenario, tutorialStep }),
+
+    /** Lists all saved sessions (newest first) for the Load Session picker. */
+    list: (): Promise<SessionSummary[]> => ipcRenderer.invoke('session:list'),
+
+    /**
+     * Loads a saved session by its projectName (from a SessionSummary).
+     * Returns the scenario and the tutorial step to resume at.
+     */
+    load: (projectName: string): Promise<SessionLoadResult> =>
+      ipcRenderer.invoke('session:load', { projectName })
   },
 
   // ── System info ───────────────────────────────────────────────────────────────

--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -91,11 +91,13 @@ type SimStatus = 'idle' | 'starting' | 'running' | 'stopping'
 function LaunchScreen({
   docker,
   onImport,
-  onNew
+  onNew,
+  onLoadSession
 }: {
   docker: DockerStatus | null
   onImport: () => void
   onNew: () => void
+  onLoadSession: () => void
 }) {
   return (
     <div className="launch-screen">
@@ -190,6 +192,14 @@ function LaunchScreen({
             disabled={!docker?.available}
           >
             Open .otflab File
+          </button>
+          {/* Resume a previously saved lab session (scenario + rules + step + work). */}
+          <button
+            className="btn btn-ghost btn-lg"
+            onClick={onLoadSession}
+            disabled={!docker?.available}
+          >
+            Resume Saved Lab
           </button>
         </div>
 
@@ -1555,10 +1565,110 @@ export default function App() {
   // instead of a hardcoded padding value that drifts when sidebars change.
   const sidebarWidth = scenario?.meta.locked ? 220 : builderModeActive ? 210 : 0
 
+  // Session save toast + Load-Session picker, shared by both the LaunchScreen
+  // ("Resume Saved Lab") and the main workspace ("Load Session") so the picker
+  // works from either view.
+  const sessionOverlays = (
+    <>
+      {sessionNotice && (
+        <div className="desktop-hint-toast" role="status" aria-live="polite">
+          <div className="desktop-hint-toast-header">
+            <span className="desktop-hint-toast-title">✓ Session Saved</span>
+            <button
+              className="desktop-hint-toast-close"
+              onClick={() => {
+                if (sessionNoticeTimerRef.current) clearTimeout(sessionNoticeTimerRef.current)
+                setSessionNotice(null)
+              }}
+              aria-label="Dismiss"
+            >
+              ×
+            </button>
+          </div>
+          <div className="desktop-hint-toast-body">{sessionNotice}</div>
+        </div>
+      )}
+      {sessionPickerOpen && (
+        <div
+          role="dialog"
+          aria-label="Load saved session"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 500,
+            background: 'rgba(1, 4, 9, 0.7)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+          onClick={() => setSessionPickerOpen(false)}
+        >
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{
+              width: 'min(560px, 90vw)',
+              maxHeight: '80vh',
+              overflowY: 'auto',
+              background: '#0d1117',
+              border: '1px solid #30363d',
+              borderRadius: 8,
+              padding: 20,
+              color: '#e6edf3'
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <strong style={{ fontSize: 16 }}>Resume a Saved Session</strong>
+              <button
+                className="btn btn-sm btn-ghost"
+                onClick={() => setSessionPickerOpen(false)}
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </div>
+            {savedSessions.length === 0 ? (
+              <p style={{ marginTop: 16, color: '#8b949e' }}>
+                No saved sessions yet. Open a lab and click <strong>Save Session</strong> to create
+                one.
+              </p>
+            ) : (
+              <ul style={{ listStyle: 'none', margin: '16px 0 0', padding: 0 }}>
+                {savedSessions.map(s => (
+                  <li key={s.projectName} style={{ marginBottom: 8 }}>
+                    <button
+                      className="btn btn-sm btn-ghost"
+                      style={{ width: '100%', textAlign: 'left' }}
+                      onClick={() => handleLoadSession(s.projectName)}
+                    >
+                      <span style={{ fontWeight: 600 }}>{s.scenarioName}</span>
+                      <span style={{ color: '#8b949e', marginLeft: 8 }}>
+                        step {s.tutorialStep + 1} · saved {new Date(s.savedAt).toLocaleString()}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  )
+
   // ── Render ──────────────────────────────────────────────────────────────────
 
   if (view === 'launch') {
-    return <LaunchScreen docker={docker} onImport={handleImport} onNew={handleNew} />
+    return (
+      <>
+        <LaunchScreen
+          docker={docker}
+          onImport={handleImport}
+          onNew={handleNew}
+          onLoadSession={handleOpenSessionPicker}
+        />
+        {sessionOverlays}
+      </>
+    )
   }
 
   return (
@@ -2248,93 +2358,7 @@ export default function App() {
           <div className="desktop-hint-toast-body">{updateNotice}</div>
         </div>
       )}
-      {/* Session-saved toast — reuses the desktop-hint toast styling. */}
-      {sessionNotice && (
-        <div className="desktop-hint-toast" role="status" aria-live="polite">
-          <div className="desktop-hint-toast-header">
-            <span className="desktop-hint-toast-title">✓ Session Saved</span>
-            <button
-              className="desktop-hint-toast-close"
-              onClick={() => {
-                if (sessionNoticeTimerRef.current) clearTimeout(sessionNoticeTimerRef.current)
-                setSessionNotice(null)
-              }}
-              aria-label="Dismiss"
-            >
-              ×
-            </button>
-          </div>
-          <div className="desktop-hint-toast-body">{sessionNotice}</div>
-        </div>
-      )}
-      {/*
-       * Load-Session picker — a lightweight modal listing saved sessions. Inline
-       * layout styles avoid depending on picker-specific CSS; buttons reuse .btn.
-       */}
-      {sessionPickerOpen && (
-        <div
-          role="dialog"
-          aria-label="Load saved session"
-          style={{
-            position: 'fixed',
-            inset: 0,
-            zIndex: 500,
-            background: 'rgba(1, 4, 9, 0.7)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}
-          onClick={() => setSessionPickerOpen(false)}
-        >
-          <div
-            onClick={e => e.stopPropagation()}
-            style={{
-              width: 'min(560px, 90vw)',
-              maxHeight: '80vh',
-              overflowY: 'auto',
-              background: '#0d1117',
-              border: '1px solid #30363d',
-              borderRadius: 8,
-              padding: 20,
-              color: '#e6edf3'
-            }}
-          >
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <strong style={{ fontSize: 16 }}>Resume a Saved Session</strong>
-              <button
-                className="btn btn-sm btn-ghost"
-                onClick={() => setSessionPickerOpen(false)}
-                aria-label="Close"
-              >
-                ×
-              </button>
-            </div>
-            {savedSessions.length === 0 ? (
-              <p style={{ marginTop: 16, color: '#8b949e' }}>
-                No saved sessions yet. Open a lab and click <strong>Save Session</strong> to create
-                one.
-              </p>
-            ) : (
-              <ul style={{ listStyle: 'none', margin: '16px 0 0', padding: 0 }}>
-                {savedSessions.map(s => (
-                  <li key={s.projectName} style={{ marginBottom: 8 }}>
-                    <button
-                      className="btn btn-sm btn-ghost"
-                      style={{ width: '100%', textAlign: 'left' }}
-                      onClick={() => handleLoadSession(s.projectName)}
-                    >
-                      <span style={{ fontWeight: 600 }}>{s.scenarioName}</span>
-                      <span style={{ color: '#8b949e', marginLeft: 8 }}>
-                        step {s.tutorialStep + 1} · saved {new Date(s.savedAt).toLocaleString()}
-                      </span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        </div>
-      )}
+      {sessionOverlays}
     </div>
   )
 }

--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -47,7 +47,8 @@ import type {
   RtuConfig,
   SensorConfig,
   ControllerConfig,
-  FluidType
+  FluidType,
+  SessionSummary
 } from '@otforge/schema'
 import { ScadaCanvas } from './canvas/ScadaCanvas'
 import { DevicePalette } from './palette/DevicePalette'
@@ -477,6 +478,21 @@ export default function App() {
    */
   const [showTutorial, setShowTutorial] = useState<boolean>(false)
 
+  // ── Saved-session state ────────────────────────────────────────────────────────
+  /** The step the TutorialPanel currently shows — captured when saving a session. */
+  const [currentTutorialStep, setCurrentTutorialStep] = useState<number>(0)
+  /** The step a newly-opened/loaded scenario should start on (0 for a fresh open). */
+  const [resumeTutorialStep, setResumeTutorialStep] = useState<number>(0)
+  /** Bumped on every scenario open/load to force TutorialPanel to remount fresh. */
+  const [tutorialKey, setTutorialKey] = useState<number>(0)
+  /** Whether the Load-Session picker overlay is open. */
+  const [sessionPickerOpen, setSessionPickerOpen] = useState<boolean>(false)
+  /** Saved sessions listed in the picker (loaded when it opens). */
+  const [savedSessions, setSavedSessions] = useState<SessionSummary[]>([])
+  /** Transient toast shown after a successful session save. */
+  const [sessionNotice, setSessionNotice] = useState<string | null>(null)
+  const sessionNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   /**
    * Whether the instructor has activated Builder Mode for the current scenario.
    *
@@ -668,14 +684,63 @@ export default function App() {
       setView('canvas')
       // Track the file path so Delete Scenario can remove it from disk.
       setCurrentFilePath(result.filePath ?? null)
-      // Auto-show the tutorial panel when the imported scenario has guided steps
+      // Auto-show the tutorial panel when the imported scenario has guided steps.
+      // A fresh open always starts on step 0; bump the key so TutorialPanel remounts.
       if (result.scenario.meta.tutorialSteps?.length) {
+        setResumeTutorialStep(0)
+        setTutorialKey(k => k + 1)
         setShowTutorial(true)
       }
     } else if (result.error && result.error !== 'Import cancelled') {
       // Surface validation and parse errors — without this the user sees a blank
       // screen with no feedback when a .otflab file fails schema validation.
       window.alert(`Could not open scenario:\n\n${result.error}`)
+    }
+  }, [])
+
+  /**
+   * Saves the current lab as a resumable session: the scenario (which carries the
+   * student's edited Suricata/firewall rules) plus the tutorial step they're on.
+   * Keyed by scenario name, so re-saving overwrites the same lab's session.
+   */
+  const handleSaveSession = useCallback(async () => {
+    if (!scenario) return
+    const result = await window.electronAPI.session.save(scenario, currentTutorialStep)
+    if (result.ok) {
+      setSessionNotice('Session saved — you can resume this lab later.')
+      if (sessionNoticeTimerRef.current) clearTimeout(sessionNoticeTimerRef.current)
+      sessionNoticeTimerRef.current = setTimeout(() => setSessionNotice(null), 6000)
+    } else {
+      setSimError(result.error ?? 'Failed to save session.')
+    }
+  }, [scenario, currentTutorialStep])
+
+  /** Opens the Load-Session picker, fetching the current list of saved sessions. */
+  const handleOpenSessionPicker = useCallback(async () => {
+    const sessions = await window.electronAPI.session.list()
+    setSavedSessions(sessions)
+    setSessionPickerOpen(true)
+  }, [])
+
+  /**
+   * Loads a saved session: applies its scenario and jumps the tutorial to the
+   * saved step. Mirrors handleImport's scenario-application (View Mode, canvas).
+   */
+  const handleLoadSession = useCallback(async (projectName: string) => {
+    const result = await window.electronAPI.session.load(projectName)
+    setSessionPickerOpen(false)
+    if (!result.ok || !result.scenario) {
+      setSimError(result.error ?? 'Failed to load session.')
+      return
+    }
+    setScenario(result.scenario)
+    setBuilderModeActive(false)
+    setView('canvas')
+    setCurrentFilePath(null) // a session is not backed by a .otflab file on disk
+    if (result.scenario.meta.tutorialSteps?.length) {
+      setResumeTutorialStep(result.tutorialStep ?? 0)
+      setTutorialKey(k => k + 1)
+      setShowTutorial(true)
     }
   }, [])
 
@@ -1566,6 +1631,36 @@ export default function App() {
               </button>
             )}
             {/*
+             * Save Session — snapshots the current lab (scenario + edited rules +
+             * tutorial step) so the student can resume later. Shown with a scenario
+             * loaded. (A later increment also captures their Lab_NN_Student_Saved_Work
+             * folder, which will require the simulation to be running.)
+             */}
+            {scenario && (
+              <button
+                className="btn btn-sm btn-ghost"
+                onClick={handleSaveSession}
+                title="Save your progress in this lab so you can resume it later"
+              >
+                Save Session
+              </button>
+            )}
+            {/*
+             * Load Session — reopens a previously saved lab at the step the student
+             * left off. Disabled while a simulation is running (it replaces the
+             * current scenario), same as Open.
+             */}
+            <button
+              className="btn btn-sm btn-ghost"
+              onClick={handleOpenSessionPicker}
+              disabled={!simIsIdle}
+              title={
+                simIsIdle ? 'Resume a saved lab session' : 'Stop the simulation to load a session'
+              }
+            >
+              Load Session
+            </button>
+            {/*
              * Edit Scenario — shown whenever a scenario is open.
              * Grayed in Student Mode (builderModeActive = false) because editing
              * requires Author Mode — activate it via New Scenario first.
@@ -2074,9 +2169,12 @@ export default function App() {
        */}
       {showTutorial && scenario?.meta.tutorialSteps?.length && (
         <TutorialPanel
+          key={tutorialKey}
           steps={scenario.meta.tutorialSteps}
           devices={scenario.devices.devices}
           onClose={() => setShowTutorial(false)}
+          initialIndex={resumeTutorialStep}
+          onStepChange={setCurrentTutorialStep}
         />
       )}
 
@@ -2148,6 +2246,93 @@ export default function App() {
             </button>
           </div>
           <div className="desktop-hint-toast-body">{updateNotice}</div>
+        </div>
+      )}
+      {/* Session-saved toast — reuses the desktop-hint toast styling. */}
+      {sessionNotice && (
+        <div className="desktop-hint-toast" role="status" aria-live="polite">
+          <div className="desktop-hint-toast-header">
+            <span className="desktop-hint-toast-title">✓ Session Saved</span>
+            <button
+              className="desktop-hint-toast-close"
+              onClick={() => {
+                if (sessionNoticeTimerRef.current) clearTimeout(sessionNoticeTimerRef.current)
+                setSessionNotice(null)
+              }}
+              aria-label="Dismiss"
+            >
+              ×
+            </button>
+          </div>
+          <div className="desktop-hint-toast-body">{sessionNotice}</div>
+        </div>
+      )}
+      {/*
+       * Load-Session picker — a lightweight modal listing saved sessions. Inline
+       * layout styles avoid depending on picker-specific CSS; buttons reuse .btn.
+       */}
+      {sessionPickerOpen && (
+        <div
+          role="dialog"
+          aria-label="Load saved session"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 500,
+            background: 'rgba(1, 4, 9, 0.7)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+          onClick={() => setSessionPickerOpen(false)}
+        >
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{
+              width: 'min(560px, 90vw)',
+              maxHeight: '80vh',
+              overflowY: 'auto',
+              background: '#0d1117',
+              border: '1px solid #30363d',
+              borderRadius: 8,
+              padding: 20,
+              color: '#e6edf3'
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <strong style={{ fontSize: 16 }}>Resume a Saved Session</strong>
+              <button
+                className="btn btn-sm btn-ghost"
+                onClick={() => setSessionPickerOpen(false)}
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </div>
+            {savedSessions.length === 0 ? (
+              <p style={{ marginTop: 16, color: '#8b949e' }}>
+                No saved sessions yet. Open a lab and click <strong>Save Session</strong> to create
+                one.
+              </p>
+            ) : (
+              <ul style={{ listStyle: 'none', margin: '16px 0 0', padding: 0 }}>
+                {savedSessions.map(s => (
+                  <li key={s.projectName} style={{ marginBottom: 8 }}>
+                    <button
+                      className="btn btn-sm btn-ghost"
+                      style={{ width: '100%', textAlign: 'left' }}
+                      onClick={() => handleLoadSession(s.projectName)}
+                    >
+                      <span style={{ fontWeight: 600 }}>{s.scenarioName}</span>
+                      <span style={{ color: '#8b949e', marginLeft: 8 }}>
+                        step {s.tutorialStep + 1} · saved {new Date(s.savedAt).toLocaleString()}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -686,6 +686,30 @@ export default function App() {
    * If the scenario has tutorial steps, the Tutorial panel is auto-shown so students
    * immediately see their guided instructions.
    */
+  /**
+   * Starts a simulation for an explicit scenario, driving the simStatus lifecycle.
+   * Takes the scenario as an argument (rather than reading state) so callers that
+   * have just set it — e.g. resuming a saved session — don't race React's async
+   * state update. Stable (no deps) so other handlers can depend on it freely.
+   */
+  const startSimulation = useCallback(async (sc: OTForgeScenario) => {
+    setSimError(null)
+    setSimStatus('starting')
+    setContainerStatuses([])
+    try {
+      const result = await window.electronAPI.simulation.start(sc)
+      if (result.ok) {
+        setSimStatus('running')
+      } else {
+        setSimStatus('idle')
+        setSimError(result.error ?? 'Simulation failed to start.')
+      }
+    } catch (err) {
+      setSimStatus('idle')
+      setSimError(`Unexpected error: ${(err as Error).message}`)
+    }
+  }, [])
+
   const handleImport = useCallback(async () => {
     const result = await window.electronAPI.scenario.import()
     if (result.scenario) {
@@ -733,26 +757,34 @@ export default function App() {
   }, [])
 
   /**
-   * Loads a saved session: applies its scenario and jumps the tutorial to the
-   * saved step. Mirrors handleImport's scenario-application (View Mode, canvas).
+   * Loads a saved session: applies its scenario, jumps the tutorial to the saved
+   * step, and automatically starts the simulation so the student is dropped right
+   * back into a running lab. (main's session:load armed the folder-restore, which
+   * fires during this start.) Mirrors handleImport's scenario-application.
    */
-  const handleLoadSession = useCallback(async (projectName: string) => {
-    const result = await window.electronAPI.session.load(projectName)
-    setSessionPickerOpen(false)
-    if (!result.ok || !result.scenario) {
-      setSimError(result.error ?? 'Failed to load session.')
-      return
-    }
-    setScenario(result.scenario)
-    setBuilderModeActive(false)
-    setView('canvas')
-    setCurrentFilePath(null) // a session is not backed by a .otflab file on disk
-    if (result.scenario.meta.tutorialSteps?.length) {
-      setResumeTutorialStep(result.tutorialStep ?? 0)
-      setTutorialKey(k => k + 1)
-      setShowTutorial(true)
-    }
-  }, [])
+  const handleLoadSession = useCallback(
+    async (projectName: string) => {
+      const result = await window.electronAPI.session.load(projectName)
+      setSessionPickerOpen(false)
+      if (!result.ok || !result.scenario) {
+        setSimError(result.error ?? 'Failed to load session.')
+        return
+      }
+      setScenario(result.scenario)
+      setBuilderModeActive(false)
+      setView('canvas')
+      setCurrentFilePath(null) // a session is not backed by a .otflab file on disk
+      if (result.scenario.meta.tutorialSteps?.length) {
+        setResumeTutorialStep(result.tutorialStep ?? 0)
+        setTutorialKey(k => k + 1)
+        setShowTutorial(true)
+      }
+      // Auto-start with the loaded scenario passed explicitly (state isn't updated
+      // yet). This also triggers the saved-folder restore inside simulation start.
+      void startSimulation(result.scenario)
+    },
+    [startSimulation]
+  )
 
   /**
    * Creates a blank scenario and navigates to the canvas in View Mode.
@@ -1396,25 +1428,10 @@ export default function App() {
    * writeGrafanaProvisioning or generateCompose errors), ipcRenderer.invoke() rejects
    * and without a catch the simStatus would hang at 'starting' forever.
    */
-  const handleStart = useCallback(async () => {
+  const handleStart = useCallback(() => {
     if (!scenario) return
-    setSimError(null)
-    setSimStatus('starting')
-    setContainerStatuses([])
-    try {
-      const result = await window.electronAPI.simulation.start(scenario)
-      if (result.ok) {
-        setSimStatus('running')
-      } else {
-        setSimStatus('idle')
-        setSimError(result.error ?? 'Simulation failed to start.')
-      }
-    } catch (err) {
-      // IPC handler threw an unhandled exception — surface it to the user
-      setSimStatus('idle')
-      setSimError(`Unexpected error: ${(err as Error).message}`)
-    }
-  }, [scenario])
+    void startSimulation(scenario)
+  }, [scenario, startSimulation])
 
   /**
    * Toolbar "Update Images" handler.

--- a/packages/app/src/renderer/src/tutorial/TutorialPanel.tsx
+++ b/packages/app/src/renderer/src/tutorial/TutorialPanel.tsx
@@ -56,6 +56,17 @@ interface TutorialPanelProps {
   devices?: Record<string, DeviceIpEntry>
   /** Called when the user clicks the × close button. */
   onClose: () => void
+  /**
+   * Step to open on (0-based). Used when resuming a saved session so the student
+   * lands back where they left off. Defaults to 0. Read once on mount — remount
+   * the panel (via a changing React key) to force a jump to a new value.
+   */
+  initialIndex?: number
+  /**
+   * Called whenever the displayed step changes, with the new 0-based index.
+   * The parent uses this to know which step to persist when saving a session.
+   */
+  onStepChange?: (index: number) => void
 }
 
 // ── IP template resolver ───────────────────────────────────────────────────────
@@ -194,9 +205,18 @@ function inlineFormat(text: string): React.ReactNode[] {
  * Rendered as a fixed-position overlay that the student can drag to any corner
  * of the screen without covering the canvas or the attack terminal.
  */
-export function TutorialPanel({ steps, devices, onClose }: TutorialPanelProps): React.JSX.Element {
-  // Which step is currently displayed (0-based index)
-  const [currentIndex, setCurrentIndex] = useState<number>(0)
+export function TutorialPanel({
+  steps,
+  devices,
+  onClose,
+  initialIndex = 0,
+  onStepChange
+}: TutorialPanelProps): React.JSX.Element {
+  // Which step is currently displayed (0-based index). Seeded from initialIndex
+  // (clamped in range) so a resumed session opens on the saved step.
+  const [currentIndex, setCurrentIndex] = useState<number>(() =>
+    Math.min(Math.max(initialIndex, 0), Math.max(steps.length - 1, 0))
+  )
   // Whether the panel body is collapsed to header-only strip
   const [minimized, setMinimized] = useState<boolean>(false)
   // Transient copy feedback — "Copy" → "Copied!" for 1.5 s
@@ -212,6 +232,11 @@ export function TutorialPanel({ steps, devices, onClose }: TutorialPanelProps): 
 
   const step = steps[currentIndex]
   const total = steps.length
+
+  // Report the displayed step to the parent so it can persist it on session save.
+  useEffect(() => {
+    onStepChange?.(currentIndex)
+  }, [currentIndex, onStepChange])
 
   // ── Default position: bottom-right corner, 24 px inset ──────────────────────
   // Calculated on first render using window dimensions to avoid hardcoding.

--- a/packages/schema/src/ipc.ts
+++ b/packages/schema/src/ipc.ts
@@ -58,6 +58,35 @@ export interface SimulationUpdateResult {
   error?: string
 }
 
+/**
+ * Lightweight descriptor of a saved student session, returned by session:list.
+ * Excludes the full scenario payload so the picker stays cheap to render.
+ */
+export interface SessionSummary {
+  /** Sanitized scenario name — the session's directory key and load handle. */
+  projectName: string
+  /** Human-readable scenario name (meta.name) shown in the session picker. */
+  scenarioName: string
+  /** ISO timestamp of when the session was saved. */
+  savedAt: string
+  /** 0-based tutorial step the student was on when they saved. */
+  tutorialStep: number
+}
+
+/** Result of session:save. */
+export interface SessionSaveResult {
+  ok: boolean
+  error?: string
+}
+
+/** Result of session:load — the restored scenario plus where to resume. */
+export interface SessionLoadResult {
+  ok: boolean
+  scenario?: OTForgeScenario
+  tutorialStep?: number
+  error?: string
+}
+
 export interface ContainerStatus {
   nodeId: string
   containerId?: string


### PR DESCRIPTION
## Summary

Lets a student stop a lab and resume it later without redoing their work. Explicit **Save Session** / **Load Session** toolbar buttons.

**A session captures:**
- the scenario — which carries the student's edited Suricata/firewall rules,
- the tutorial step they were on, and
- their `Lab_NN_Student_Saved_Work` folder on the workstation (PLC programs, Wireshark captures, notes).

Stored at `<userData>/sessions/<projectName>/` (`session.json` + `lab-work/`), keyed by scenario name so re-saving a lab overwrites its one session.

## How it works (increments)

1. **Session store + UI** — `session:save/list/load` IPC over a small on-disk store; Save/Load buttons + a picker modal; `TutorialPanel` gained `initialIndex`/`onStepChange` so the step is captured and restored.
2. **Folder provisioning** — after the workstation desktop boots, `docker exec` creates `/root/Desktop/Lab_NN_Student_Saved_Work` (name derived from `meta.name`; non-numbered scenarios use a slug) + a README. Mirrors the existing `configureAttackMachine` post-start pattern — **no image rebuild**.
3. **Capture/restore** — Save `docker cp`s the folder out into the session; Load arms a one-shot flag so the next simulation start copies it back in. Both best-effort: scenario+step still save if the workstation isn't running.

Only labs with an `engineering-workstation` device get the folder (Lab 02/03, OpenPLC_Lab); Lab 01 has none.

## Verification

- `tsc --noEmit` (node + web) clean; `eslint` clean; `electron-vite` bundles.
- **Increment 1 live-confirmed** (Save → Load resumes at the saved step).
- **Still needs a live check:** the folder capture/restore round-trip (start a workstation lab → drop a file in the folder → Save Session → Stop → Load Session → Run → file is back). Not automatable in CI.

## Not included
- Tutorial "keep your work in this folder" pointer (optional increment, easy to add).
- Dashboard placement of the buttons (currently main toolbar only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)