### PR TITLE
feat(iec61850): add IEC 61850 substation IED support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,8 @@ jobs:
             context: containers/opcua
           - image: otforge-bacnet
             context: containers/bacnet
+          - image: otforge-iec61850
+            context: containers/iec61850
           - image: otforge-firewall
             context: containers/firewall
           - image: otforge-switch

--- a/containers/iec61850/Dockerfile
+++ b/containers/iec61850/Dockerfile
@@ -1,0 +1,53 @@
+# otforge-iec61850 — IEC 61850 substation IED (MMS server on TCP 102).
+#
+# IEC 61850 is the dominant protocol for electrical substation automation, used
+# across power generation and power distribution. This image runs a real IED
+# server built on libiec61850 (the de-facto open-source IEC 61850 stack), serving
+# the MMS (Manufacturing Message Specification) client/server protocol on TCP 102.
+#
+# Scope: MMS only for now. GOOSE and Sampled Values are layer-2 multicast and are
+# impractical on Docker bridge networks without extra plumbing — deferred.
+
+# ── Build stage: compile libiec61850 + its example servers ───────────────────
+FROM debian:bookworm-slim AS build
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git cmake build-essential ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+RUN git clone --depth 1 https://github.com/mz-automation/libiec61850.git
+WORKDIR /src/libiec61850
+RUN mkdir build && cd build \
+    && cmake -DBUILD_EXAMPLES=ON .. \
+    && make -j"$(nproc)"
+# Surface where the example server binaries landed (aids COPY path below and
+# future customization). Non-fatal listing.
+RUN find /src/libiec61850/build -type f -perm -111 -name 'server_example*' -print
+
+# ── Runtime stage ────────────────────────────────────────────────────────────
+FROM debian:bookworm-slim
+# apt-get upgrade pulls current Debian security patches into the runtime base
+# (same hygiene as the zeek image). netcat-openbsd is only for readiness probes.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+
+# server_example_basic_io ships a static IEC 61850 data model (GGIO + analog
+# nodes) and serves it over MMS on port 102 — a working IED to start from. A
+# later increment swaps in a realistic substation model (MMXU measurements +
+# XCBR breaker).
+COPY --from=build \
+    /src/libiec61850/build/examples/server_example_basic_io/server_example_basic_io \
+    /app/iec61850-server
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENV DEVICE_ID=ied-1 \
+    DEVICE_CATEGORY=iec61850-ied \
+    IEC61850_PORT=102
+
+# MMS / IEC 61850 client-server port.
+EXPOSE 102
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/containers/iec61850/Dockerfile
+++ b/containers/iec61850/Dockerfile
@@ -8,21 +8,23 @@
 # Scope: MMS only for now. GOOSE and Sampled Values are layer-2 multicast and are
 # impractical on Docker bridge networks without extra plumbing — deferred.
 
-# ── Build stage: compile libiec61850 + its example servers ───────────────────
+# ── Build stage: compile libiec61850, then our substation IED server ─────────
 FROM debian:bookworm-slim AS build
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git cmake build-essential ca-certificates \
+    git make gcc g++ build-essential ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 RUN git clone --depth 1 https://github.com/mz-automation/libiec61850.git
+# Our custom substation IED server + its Makefile, dropped into the library's
+# examples tree so it links via libiec61850's own make flags.
+COPY server.c /src/libiec61850/examples/otforge-substation/server.c
+COPY substation.Makefile /src/libiec61850/examples/otforge-substation/Makefile
 WORKDIR /src/libiec61850
-RUN mkdir build && cd build \
-    && cmake -DBUILD_EXAMPLES=ON .. \
-    && make -j"$(nproc)"
-# Surface where the example server binaries landed (aids COPY path below and
-# future customization). Non-fatal listing.
-RUN find /src/libiec61850/build -type f -perm -111 -name 'server_example*' -print
+# Build the static library (POSIX make build), then our server against it.
+RUN make -j"$(nproc)"
+WORKDIR /src/libiec61850/examples/otforge-substation
+RUN make
 
 # ── Runtime stage ────────────────────────────────────────────────────────────
 FROM debian:bookworm-slim
@@ -33,12 +35,10 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
-# server_example_basic_io ships a static IEC 61850 data model (GGIO + analog
-# nodes) and serves it over MMS on port 102 — a working IED to start from. A
-# later increment swaps in a realistic substation model (MMXU measurements +
-# XCBR breaker).
+# Our substation IED: MMXU measurements (live) + a controllable XCBR breaker,
+# served over MMS on port 102 (see server.c).
 COPY --from=build \
-    /src/libiec61850/build/examples/server_example_basic_io/server_example_basic_io \
+    /src/libiec61850/examples/otforge-substation/iec61850-server \
     /app/iec61850-server
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh

--- a/containers/iec61850/entrypoint.sh
+++ b/containers/iec61850/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# entrypoint.sh — IEC 61850 IED (MMS server) startup.
+set -e
+
+echo "[ics-iec61850] Device=${DEVICE_ID}  category=${DEVICE_CATEGORY}  MMS port=${IEC61850_PORT}"
+echo "[ics-iec61850] Serving IEC 61850 over MMS (port 102). GOOSE/SV not enabled."
+
+# server_example_basic_io takes the TCP port as its first argument (defaults to
+# 102 if omitted). Bind on all interfaces via the port only.
+exec /app/iec61850-server "${IEC61850_PORT}"

--- a/containers/iec61850/server.c
+++ b/containers/iec61850/server.c
@@ -1,0 +1,161 @@
+/*
+ * server.c — OTForge IEC 61850 substation IED (MMS server).
+ *
+ * Builds a realistic-but-minimal substation feeder-bay data model at runtime
+ * with libiec61850's dynamic model API, and serves it over MMS on TCP 102:
+ *
+ *   LD "BAY"
+ *     LLN0   — Mod / Beh / Health           (mandatory)
+ *     LPHD1  — PhyHealth                     (mandatory)
+ *     MMXU1  — measurements (live-updating):
+ *              TotW  (total active power, W)
+ *              TotVAr(total reactive power, VAr)
+ *              Hz    (frequency)
+ *              PhV   (3-phase voltage, WYE: phsA/B/C)
+ *              A     (3-phase current,  WYE: phsA/B/C)
+ *     XCBR1  — Pos (controllable breaker position; clients can trip/close it)
+ *
+ * Deliberately uses only integer arithmetic for the measurement drift so the
+ * binary needs no libm (-lm) at link time. Measurement child DataAttributes are
+ * NULL-checked before update so an unexpected model path degrades gracefully
+ * rather than crashing the server.
+ */
+
+#include "iec61850_server.h"
+#include "hal_thread.h"
+#include <signal.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+static int running = 0;
+static IedServer iedServer = NULL;
+static DataAttribute* xcbrPosStVal = NULL;
+
+static void sigint_handler(int signalId)
+{
+    (void)signalId;
+    running = 0;
+}
+
+/* Apply a breaker open/close operate to XCBR1.Pos.stVal. DPC ctlVal is a
+ * boolean: true = close (ON), false = open/trip (OFF). */
+static ControlHandlerResult
+posControlHandler(ControlAction action, void* parameter, MmsValue* ctlVal, bool test)
+{
+    (void)action;
+    (void)parameter;
+    if (test)
+        return CONTROL_RESULT_OK;
+
+    bool close = MmsValue_getBoolean(ctlVal);
+    if (xcbrPosStVal != NULL)
+        IedServer_updateDbposValue(iedServer, xcbrPosStVal, close ? DBPOS_ON : DBPOS_OFF);
+
+    printf("[ics-iec61850] XCBR1.Pos operated -> %s\n", close ? "CLOSED" : "OPEN (tripped)");
+    fflush(stdout);
+    return CONTROL_RESULT_OK;
+}
+
+static void
+updateIfPresent(DataAttribute* attr, float value)
+{
+    if (attr != NULL)
+        IedServer_updateFloatAttributeValue(iedServer, attr, value);
+}
+
+int main(int argc, char** argv)
+{
+    int tcpPort = 102;
+    if (argc > 1)
+        tcpPort = atoi(argv[1]);
+
+    /* ── Data model ──────────────────────────────────────────────────────── */
+    IedModel* model = IedModel_create("OTForgeIED");
+    LogicalDevice* bay = LogicalDevice_create("BAY", model);
+
+    LogicalNode* lln0 = LogicalNode_create("LLN0", bay);
+    CDC_ENS_create("Mod", (ModelNode*) lln0, 0);
+    CDC_ENS_create("Beh", (ModelNode*) lln0, 0);
+    CDC_ENS_create("Health", (ModelNode*) lln0, 0);
+
+    LogicalNode* lphd1 = LogicalNode_create("LPHD1", bay);
+    CDC_ENS_create("PhyHealth", (ModelNode*) lphd1, 0);
+
+    LogicalNode* mmxu1 = LogicalNode_create("MMXU1", bay);
+    DataObject* totW   = CDC_MV_create("TotW", (ModelNode*) mmxu1, 0, false);
+    DataObject* totVAr = CDC_MV_create("TotVAr", (ModelNode*) mmxu1, 0, false);
+    DataObject* hz     = CDC_MV_create("Hz", (ModelNode*) mmxu1, 0, false);
+    DataObject* phV    = CDC_WYE_create("PhV", (ModelNode*) mmxu1, 0);
+    DataObject* amp    = CDC_WYE_create("A", (ModelNode*) mmxu1, 0);
+
+    DataAttribute* totW_f   = (DataAttribute*) ModelNode_getChild((ModelNode*) totW, "mag.f");
+    DataAttribute* totVAr_f = (DataAttribute*) ModelNode_getChild((ModelNode*) totVAr, "mag.f");
+    DataAttribute* hz_f     = (DataAttribute*) ModelNode_getChild((ModelNode*) hz, "mag.f");
+    DataAttribute* phVa = (DataAttribute*) ModelNode_getChild((ModelNode*) phV, "phsA.cVal.mag.f");
+    DataAttribute* phVb = (DataAttribute*) ModelNode_getChild((ModelNode*) phV, "phsB.cVal.mag.f");
+    DataAttribute* phVc = (DataAttribute*) ModelNode_getChild((ModelNode*) phV, "phsC.cVal.mag.f");
+    DataAttribute* Aa   = (DataAttribute*) ModelNode_getChild((ModelNode*) amp, "phsA.cVal.mag.f");
+    DataAttribute* Ab   = (DataAttribute*) ModelNode_getChild((ModelNode*) amp, "phsB.cVal.mag.f");
+    DataAttribute* Ac   = (DataAttribute*) ModelNode_getChild((ModelNode*) amp, "phsC.cVal.mag.f");
+
+    LogicalNode* xcbr1 = LogicalNode_create("XCBR1", bay);
+    DataObject* pos = CDC_DPC_create("Pos", (ModelNode*) xcbr1, 0, CDC_CTL_MODEL_DIRECT_NORMAL);
+    xcbrPosStVal = (DataAttribute*) ModelNode_getChild((ModelNode*) pos, "stVal");
+
+    /* ── Server ──────────────────────────────────────────────────────────── */
+    iedServer = IedServer_create(model);
+    IedServer_setControlHandler(iedServer, pos, (ControlHandler) posControlHandler, NULL);
+
+    IedServer_start(iedServer, tcpPort);
+    if (!IedServer_isRunning(iedServer)) {
+        printf("[ics-iec61850] ERROR: MMS server failed to start on port %d\n", tcpPort);
+        IedServer_destroy(iedServer);
+        IedModel_destroy(model);
+        return -1;
+    }
+
+    /* Breaker starts closed (energized feeder). */
+    if (xcbrPosStVal != NULL)
+        IedServer_updateDbposValue(iedServer, xcbrPosStVal, DBPOS_ON);
+
+    printf("[ics-iec61850] IED model 'OTForgeIED/BAY' serving MMS on port %d\n", tcpPort);
+    printf("[ics-iec61850] MMXU1 measurements live; XCBR1.Pos is client-controllable.\n");
+    fflush(stdout);
+
+    running = 1;
+    signal(SIGINT, sigint_handler);
+
+    int t = 0;
+    while (running) {
+        /* Triangle-wave wobble in [-10, +10], integer math (no libm). */
+        int phase = t % 40;
+        float wobble = (float) ((phase < 20 ? phase : 40 - phase) - 10);
+
+        /* Simulated 13.8 kV feeder: ~200 A, ~4 MW, ~0.8 MVAr, 60 Hz. */
+        float v   = 13800.0f + 4.0f * wobble;
+        float a   = 200.0f + 0.8f * wobble;
+        float w   = 4000000.0f + 5000.0f * wobble;
+        float var = 800000.0f + 3000.0f * wobble;
+        float f   = 60.0f + 0.002f * wobble;
+
+        IedServer_lockDataModel(iedServer);
+        updateIfPresent(totW_f, w);
+        updateIfPresent(totVAr_f, var);
+        updateIfPresent(hz_f, f);
+        updateIfPresent(phVa, v);
+        updateIfPresent(phVb, v);
+        updateIfPresent(phVc, v);
+        updateIfPresent(Aa, a);
+        updateIfPresent(Ab, a);
+        updateIfPresent(Ac, a);
+        IedServer_unlockDataModel(iedServer);
+
+        t++;
+        Thread_sleep(1000);
+    }
+
+    IedServer_stop(iedServer);
+    IedServer_destroy(iedServer);
+    IedModel_destroy(model);
+    return 0;
+}

--- a/containers/iec61850/substation.Makefile
+++ b/containers/iec61850/substation.Makefile
@@ -1,0 +1,20 @@
+# Build recipe for the OTForge substation IED server, dropped into
+# libiec61850/examples/otforge-substation/ so it reuses the library's own
+# make machinery (LIBIEC_HOME=../.. resolves the include/lib flags).
+LIBIEC_HOME=../..
+
+PROJECT_BINARY_NAME = iec61850-server
+PROJECT_SOURCES = server.c
+
+include $(LIBIEC_HOME)/make/target_system.mk
+include $(LIBIEC_HOME)/make/stack_includes.mk
+
+all:	$(PROJECT_BINARY_NAME)
+
+include $(LIBIEC_HOME)/make/common_targets.mk
+
+$(PROJECT_BINARY_NAME):	$(PROJECT_SOURCES) $(LIB_NAME)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $(PROJECT_BINARY_NAME) $(PROJECT_SOURCES) $(INCLUDES) $(LIB_NAME) $(LDLIBS)
+
+clean:
+	rm -f $(PROJECT_BINARY_NAME)

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -333,6 +333,7 @@ const DEFAULT_PROTOCOLS: Record<DeviceCategory, Protocol[]> = {
   plc: ['modbus-tcp'],
   rtu: ['modbus-rtu'],
   ied: ['dnp3'],
+  'iec61850-ied': ['iec61850'],
   'safety-plc': ['modbus-tcp'], // SIS — same Modbus transport as standard PLC
   'dcs-controller': ['opc-ua'], // DCS prefers OPC-UA upward by convention
   'legacy-plc': ['s7comm'], // Siemens S7 — S7comm primary protocol (Phase 10)
@@ -377,6 +378,7 @@ const CATEGORY_LABELS: Record<DeviceCategory, string> = {
   plc: 'PLC',
   rtu: 'RTU',
   ied: 'IED',
+  'iec61850-ied': 'IEC 61850 IED',
   'safety-plc': 'Safety PLC',
   'dcs-controller': 'DCS Ctrl',
   'legacy-plc': 'S7 PLC', // Phase 10

--- a/packages/app/src/renderer/src/canvas/connectionRules.ts
+++ b/packages/app/src/renderer/src/canvas/connectionRules.ts
@@ -889,6 +889,7 @@ const CATEGORY_NAMES: Record<DeviceCategory, string> = {
   plc: 'PLC',
   rtu: 'RTU',
   ied: 'IED',
+  'iec61850-ied': 'IEC 61850 IED',
   'safety-plc': 'Safety PLC / SIS',
   'dcs-controller': 'DCS Controller',
   'legacy-plc': 'Siemens S7 PLC', // Phase 10
@@ -957,6 +958,7 @@ const DEVICE_CABLE_CAPABILITIES: Record<DeviceCategory, Set<CableType>> = {
   rtu: new Set(['rs485', 'rs232', 'cat5e', 'cat6', 'ac']),
   // IEDs: Ethernet only (IEC 61850 GOOSE runs on Cat5e/fiber, no serial field bus)
   ied: new Set(['cat5e', 'cat6', 'mmf', 'smf', 'ac']),
+  'iec61850-ied': new Set(['cat5e', 'cat6', 'mmf', 'smf', 'ac']),
   // Safety PLC: same port set as PLC; isolated physical network segment per ISA-84
   'safety-plc': new Set(['rs485', 'rs232', 'cat5e', 'cat6', 'ac']),
   // DCS Controller: larger system, fiber uplinks to DCS node bus are common

--- a/packages/app/src/renderer/src/icons/DeviceIcons.tsx
+++ b/packages/app/src/renderer/src/icons/DeviceIcons.tsx
@@ -907,6 +907,7 @@ const ICON_MAP: Record<DeviceCategory, () => JSX.Element> = {
   plc: PlcSvg,
   rtu: RtuSvg,
   ied: IedSvg,
+  'iec61850-ied': IedSvg,
   'safety-plc': SafetyPlcSvg, // IEC 61511 Safety PLC / SIS — Triconex, Siemens Safety
   'dcs-controller': DcsControllerSvg, // Distributed Control System — DeltaV, Experion, 800xA
   'legacy-plc': LegacyPlcSvg, // Siemens S7-300/400/1200/1500 via S7comm (Phase 10)

--- a/packages/app/src/renderer/src/palette/DevicePalette.tsx
+++ b/packages/app/src/renderer/src/palette/DevicePalette.tsx
@@ -67,7 +67,8 @@ const PALETTE: PaletteSection[] = [
       { category: 'safety-plc', label: 'Safety PLC / SIS' },
       { category: 'dcs-controller', label: 'DCS Controller' },
       { category: 'rtu', label: 'RTU' },
-      { category: 'ied', label: 'IED' }
+      { category: 'ied', label: 'IED (DNP3)' },
+      { category: 'iec61850-ied', label: 'IEC 61850 IED' }
     ]
   },
   {

--- a/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
+++ b/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
@@ -45,7 +45,8 @@ import { ControllerPanel } from './ControllerPanel'
 const CATEGORY_LABELS: Record<string, string> = {
   plc: 'Programmable Logic Controller',
   rtu: 'Remote Terminal Unit',
-  ied: 'Intelligent Electronic Device',
+  ied: 'Intelligent Electronic Device (DNP3)',
+  'iec61850-ied': 'IEC 61850 IED (MMS) — substation automation',
   hmi: 'Human Machine Interface',
   historian: 'Data Historian',
   sensor: 'Field Sensor',

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -51,6 +51,7 @@ const DEVICE_IMAGES: Record<DeviceCategory, string> = {
   rtu: 'ghcr.io/iburres/otforge-modbus:latest',
   // DNP3 outstation — OpenDNP3 Python bindings on Alpine (containers/dnp3)
   ied: 'ghcr.io/iburres/otforge-dnp3:latest',
+  'iec61850-ied': 'ghcr.io/iburres/otforge-iec61850:latest',
   // Phase 10: Conpot legacy device emulation (S7comm + IEC 104)
   'legacy-plc': 'ghcr.io/iburres/otforge-conpot:latest',
   'iec104-rtu': 'ghcr.io/iburres/otforge-conpot:latest',
@@ -135,6 +136,7 @@ const DEVICE_LIMITS: Record<DeviceCategory, { memory: number; cpus: string }> = 
   plc: { memory: 128, cpus: '0.5' }, // OpenPLC Runtime (Ubuntu base)
   rtu: { memory: 80, cpus: '0.25' }, // pymodbus on Alpine
   ied: { memory: 80, cpus: '0.25' }, // pure-Python DNP3 on Alpine
+  'iec61850-ied': { memory: 128, cpus: '0.25' }, // libiec61850 MMS server on Debian
   'legacy-plc': { memory: 80, cpus: '0.25' }, // pure-Python S7comm on Alpine (Phase 10)
   'iec104-rtu': { memory: 80, cpus: '0.25' }, // pure-Python IEC 104 on Alpine (Phase 10)
   'process-unit': { memory: 96, cpus: '0.25' }, // pymodbus + physics loop on Alpine (Phase 11)

--- a/packages/schema/src/icslab.ts
+++ b/packages/schema/src/icslab.ts
@@ -65,18 +65,14 @@ export type CableType =
  *   attacker     — Red Team:     Isolated attack machine subnet (not shown in Purdue layer tabs)
  */
 export type NetworkZone =
-  | 'ot'
-  | 'control'
-  | 'plant-dmz'
-  | 'enterprise'
-  | 'internet-dmz'
-  | 'attacker'
+  'ot' | 'control' | 'plant-dmz' | 'enterprise' | 'internet-dmz' | 'attacker'
 
 export type DeviceCategory =
   // ── OT Process (Levels 0–2) ──────────────────────────────────────────────────
   | 'plc'
   | 'rtu'
-  | 'ied'
+  | 'ied' // Intelligent Electronic Device — DNP3 outstation (protection relay / bay controller)
+  | 'iec61850-ied' // IEC 61850 IED — MMS server (substation automation: power gen + distribution)
   | 'safety-plc' // Safety Instrumented System / Safety PLC (IEC 61511) — Triconex, Siemens Safety
   | 'dcs-controller' // Distributed Control System controller — Honeywell, Emerson DeltaV, ABB 800xA
   | 'legacy-plc' // Siemens S7-300/400/1200/1500 via S7comm (Phase 10)


### PR DESCRIPTION
## Summary
- Add a real IEC 61850 IED container (libiec61850 MMS server on TCP 102), built via a multi-stage Debian image
- Wire `iec61850-ied` as a new device category across schema, orchestrator (IMAGE_MAP + resource limits), and the app (canvas, connection rules, icons, palette, properties panel)
- Replace the generic GGIO example server with a custom substation model: LD BAY / MMXU1 (live measurements: TotW, TotVAr, Hz, 3-phase PhV/A) and LD BAY / XCBR1 (client-controllable double-point breaker)

GOOSE/Sampled-Values (layer-2 multicast) are deferred as impractical on Docker bridges.

## Test plan
- [x] Image builds and server listens on TCP 102
- [x] libiec61850 MMS client reads realistic MMXU values (3.97 MW, 13.8 kV, 195 A, 59.99 Hz, err=0)
- [x] Operating XCBR1.Pos changes stVal and is logged by the server (control works, not just an open port)
- [x] tsc clean across schema/orchestrator/app
- [x] eslint clean
- [x] orchestrator test suite 163/163
- [ ] CI (docker build-and-push, Trivy scan) — pending PR checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)