### PR TITLE
feat(tooling): add fix-electron.ps1 self-service repair script

### DIFF
--- a/docs/student-setup.html
+++ b/docs/student-setup.html
@@ -454,8 +454,9 @@ npm run dev</code></pre>
 npm run dev</code></pre>
 
   <h3><code>npm run dev</code> fails &mdash; Electron not installed (Windows)</h3>
-  <p>Run the included repair script from <code>C:\OTForge</code>:</p>
+  <p><code>npm run dev</code> already tries to fix this automatically, but if your antivirus or campus network blocks the direct download from GitHub, it can still fail. Run the included repair script from <code>C:\OTForge</code>:</p>
 <pre><code>.\fix-electron.ps1</code></pre>
+  <p>It checks for an already-cached copy first, then downloads directly with clear error messages if that fails too.</p>
 
   <h3><code>TypeError: crypto.hash is not a function</code></h3>
   <p>You are running Node.js 20. Uninstall it and install Node.js 22 from <a href="https://nodejs.org" target="_blank">https://nodejs.org</a>, then rerun from Step 5.</p>

--- a/docs/student-setup.md
+++ b/docs/student-setup.md
@@ -172,6 +172,13 @@ npm install
 npm run dev
 ```
 
+### `Error: Electron uninstall` (Windows)
+`npm run dev` already tries to fix this automatically, but if your antivirus or campus network blocks the direct download from GitHub, it can still fail. Run the included repair script from `C:\OTForge`:
+```powershell
+.\fix-electron.ps1
+```
+It checks for an already-cached copy first, then downloads directly with clear error messages if that fails too (helpful for telling your instructor exactly what went wrong — antivirus quarantine vs. a blocked network, for example).
+
 ### `TypeError: crypto.hash is not a function`
 You are running Node.js 20. Uninstall it and install Node.js 22 from **https://nodejs.org**, then rerun from Step 5.
 

--- a/fix-electron.ps1
+++ b/fix-electron.ps1
@@ -1,0 +1,172 @@
+<#
+.SYNOPSIS
+  Repairs a missing or broken Electron binary install for OTForge on Windows.
+
+.DESCRIPTION
+  Electron 42+ no longer downloads its own binary automatically via npm's
+  postinstall lifecycle -- it only exposes a manual "install-electron" /
+  install.js command. OTForge's own predev hook already calls that
+  automatically on every "npm run dev", but if the download itself is
+  blocked (antivirus quarantine, a campus network blocking direct GitHub
+  release downloads, a captive portal, etc.) the binary can still end up
+  missing, causing electron-vite to fail with "Error: Electron uninstall".
+
+  This script diagnoses and repairs that directly:
+    1. Checks whether node_modules\electron\dist\electron.exe is already
+       present and looks like a real build (not a 0-byte leftover).
+    2. Looks for an already-cached zip in the same folder Electron's own
+       installer uses (%LOCALAPPDATA%\electron\Cache) before touching the
+       network at all.
+    3. If nothing is cached, downloads the matching release zip straight
+       from GitHub, with clear, non-silent error messages if that fails --
+       unlike a plain "npm install", which can swallow this failure.
+    4. Extracts it into node_modules\electron\dist and writes path.txt,
+       exactly like Electron's own installer does.
+
+.USAGE
+  From the OTForge project root (the folder containing package.json):
+    powershell -ExecutionPolicy Bypass -File scripts\fix-electron.ps1
+
+  Add -Force to reinstall even if a binary already appears present.
+#>
+
+param(
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step($msg) {
+    Write-Host ""
+    Write-Host "==> $msg" -ForegroundColor Cyan
+}
+
+function Write-Ok($msg) {
+    Write-Host "    $msg" -ForegroundColor Green
+}
+
+function Write-Fail($msg) {
+    Write-Host "    $msg" -ForegroundColor Red
+}
+
+# --- Locate the electron package inside node_modules ------------------------
+Write-Step "Locating node_modules\electron"
+
+$electronDir = Join-Path (Get-Location) "node_modules\electron"
+$electronPkgJson = Join-Path $electronDir "package.json"
+
+if (-not (Test-Path $electronPkgJson)) {
+    Write-Fail "node_modules\electron\package.json not found."
+    Write-Fail "Run 'npm install' from the OTForge project root first, then re-run this script."
+    exit 1
+}
+
+$electronPkg = Get-Content $electronPkgJson -Raw | ConvertFrom-Json
+$version = $electronPkg.version
+Write-Ok "Required Electron version: $version"
+
+# --- Check whether it is already properly installed --------------------------
+$exePath = Join-Path $electronDir "dist\electron.exe"
+
+if ((Test-Path $exePath) -and -not $Force) {
+    $exeSize = (Get-Item $exePath).Length
+    if ($exeSize -gt 1000000) {
+        Write-Ok "electron.exe already present ($([math]::Round($exeSize / 1MB, 1)) MB). Nothing to do."
+        Write-Ok "Use -Force to reinstall anyway."
+        exit 0
+    } else {
+        Write-Fail "electron.exe exists but looks too small ($exeSize bytes) -- treating as broken and reinstalling."
+    }
+}
+
+# --- Work out platform/arch and the expected Electron asset filename --------
+$arch = if ([System.Environment]::Is64BitOperatingSystem) {
+    if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "x64" }
+} else {
+    "ia32"
+}
+
+$zipName = "electron-v$version-win32-$arch.zip"
+Write-Ok "Platform target: win32-$arch ($zipName)"
+
+# --- Look for an already-cached zip before downloading anything -------------
+# Same cache location Electron's own installer (@electron/get) uses, so a
+# normal `npm install` that succeeded on another machine, or a previous run
+# of this script, can satisfy this without any network call at all.
+$cacheDir = Join-Path $env:LOCALAPPDATA "electron\Cache"
+$cachedZip = Join-Path $cacheDir $zipName
+
+$zipPath = $null
+
+if (Test-Path $cachedZip) {
+    Write-Step "Found a cached copy at $cachedZip"
+    $zipPath = $cachedZip
+} else {
+    Write-Step "No cached copy found. Downloading from GitHub releases..."
+
+    # Older PowerShell/.NET defaults sometimes negotiate TLS 1.0/1.1, which
+    # GitHub rejects outright with a generic connection-closed error.
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+    $downloadUrl = "https://github.com/electron/electron/releases/download/v$version/$zipName"
+    $tempZip = Join-Path $env:TEMP $zipName
+
+    Write-Ok "URL: $downloadUrl"
+
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $tempZip -UseBasicParsing
+    } catch {
+        Write-Fail "Download failed: $($_.Exception.Message)"
+        Write-Fail ""
+        Write-Fail "This usually means one of:"
+        Write-Fail "  - No internet access right now"
+        Write-Fail "  - A campus/school network or firewall is blocking direct GitHub release downloads"
+        Write-Fail "    (this is different from blocking npm itself, which uses a different host)"
+        Write-Fail "  - A VPN is interfering -- try disconnecting it and re-running this script"
+        exit 1
+    }
+
+    $downloadedSize = (Get-Item $tempZip).Length
+    if ($downloadedSize -lt 1000000) {
+        Write-Fail "Downloaded file is only $downloadedSize bytes -- too small to be a real Electron build."
+        Write-Fail "This usually means a captive portal or proxy intercepted the download and returned an"
+        Write-Fail "error or login page instead of the actual file. Try a different network and re-run."
+        exit 1
+    }
+
+    Write-Ok "Downloaded $([math]::Round($downloadedSize / 1MB, 1)) MB"
+
+    # Save into the standard cache location too, so a normal `npm install`
+    # (or this script again) can reuse it without another download.
+    New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+    Copy-Item $tempZip $cachedZip -Force
+    $zipPath = $tempZip
+}
+
+# --- Extract into node_modules\electron\dist --------------------------------
+Write-Step "Extracting Electron binary into node_modules\electron\dist"
+
+$distDir = Join-Path $electronDir "dist"
+if (Test-Path $distDir) {
+    Remove-Item -Recurse -Force $distDir
+}
+New-Item -ItemType Directory -Force -Path $distDir | Out-Null
+
+Expand-Archive -Path $zipPath -DestinationPath $distDir -Force
+
+# Electron's own installer writes this file with the relative path to the
+# executable; electron-vite's getElectronPath() reads it to find the binary.
+Set-Content -Path (Join-Path $electronDir "path.txt") -Value "electron.exe" -NoNewline -Encoding ascii
+
+# --- Verify -------------------------------------------------------------------
+Write-Step "Verifying"
+
+if (Test-Path $exePath) {
+    $finalSize = (Get-Item $exePath).Length
+    Write-Ok "electron.exe present ($([math]::Round($finalSize / 1MB, 1)) MB)"
+    Write-Host ""
+    Write-Host "Done. You can now run 'npm run dev' from the OTForge project root." -ForegroundColor Green
+} else {
+    Write-Fail "electron.exe still not found after extraction. Something is wrong with the downloaded or cached zip."
+    exit 1
+}


### PR DESCRIPTION
## Summary
- `npm run dev`'s `predev` hook already auto-installs the Electron binary (recent fix), but if the download itself is blocked — antivirus quarantining the freshly downloaded `electron.exe`, or a campus/school network blocking direct GitHub release downloads — students can still hit `Error: Electron uninstall` with no clear signal why.
- Adds `fix-electron.ps1` at the repo root: checks whether `electron.exe` is already present and non-trivially sized, checks the same local cache Electron's own installer (`@electron/get`) uses before touching the network, and if a real download is needed, fetches the release zip directly with explicit error messages distinguishing "no internet" vs "network/firewall blocked it" vs "a captive portal/proxy returned a login page instead of the file".
- Documented in both `docs/student-setup.md` and `docs/student-setup.html` troubleshooting sections. The HTML version already referenced this script by name/path from an earlier session — the file itself just hadn't been committed to the repo until now.

## Test plan
- [x] Ran against a working install — correctly no-ops
- [x] Simulated a broken state (removed `dist` folder) and ran with `-Force` — correctly found the cached zip and re-extracted a working `electron.exe`
- [x] Verified the GitHub release URL construction resolves to a real 144MB asset via a manual HEAD/GET check
- [x] Confirmed the script file is pure ASCII (PowerShell 5.1 misreads non-ASCII via Windows-1252, which breaks string parsing)
- [ ] CI checks — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)