### PR TITLE
fix(zeek): capture OT traffic reliably in Lab 03

### DIFF
--- a/containers/zeek/Dockerfile
+++ b/containers/zeek/Dockerfile
@@ -19,16 +19,38 @@ RUN echo "security-refresh: ${SECURITY_REFRESH}" \
     && apt-get update && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
-# ICS protocol monitoring script
-COPY ics-monitor.zeek /usr/local/zeek/share/zeek/site/ics-monitor.zeek
+# iproute2 provides the `ip` binary entrypoint.sh needs to enumerate the host's
+# br-XXXX Docker bridge interfaces and their addresses. zeek/zeek:latest does not
+# include it by default (unlike jasonish/suricata:latest, which does) — without
+# it, `ip addr show`/`ip link set promisc` fail silently (stderr is discarded)
+# and bridge auto-detection always falls through to a hardcoded "eth0", which is
+# never a real bridge in host network mode. This was the actual root cause of
+# Lab 03's empty/inconsistent DNP3 logs.
+RUN apt-get update && apt-get install -y --no-install-recommends iproute2 \
+    && rm -rf /var/lib/apt/lists/*
 
-# Load our script from the site policy
+# ICS protocol monitoring scripts. ics-monitor.zeek (shared module: Notice types,
+# zone classification, generic connection summary) is always loaded via local.zeek.
+# modbus.zeek and dnp3.zeek are optional per-protocol analyzers — bundled here so
+# they exist under the site dir, but only loaded when the scenario's ZEEK_SCRIPTS
+# selection (entrypoint.sh) names them explicitly.
+COPY ics-monitor.zeek /usr/local/zeek/share/zeek/site/ics-monitor.zeek
+COPY modbus.zeek /usr/local/zeek/share/zeek/site/modbus.zeek
+COPY dnp3.zeek /usr/local/zeek/share/zeek/site/dnp3.zeek
+
+# Load the always-on shared script from the site policy
 RUN echo "@load ics-monitor" >> /usr/local/zeek/share/zeek/site/local.zeek
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-ENV DEVICE_ID=zeek-1 \
-    ZEEK_IFACE=eth0
+# No default ZEEK_IFACE here — the entrypoint treats a non-empty ZEEK_IFACE as an
+# explicit single-interface override that skips br-XXXX bridge auto-detection
+# entirely. A baked-in "eth0" default silently disabled auto-detection on every
+# run (this was the actual root cause of Lab 03's DNP3 log gap: Zeek always
+# monitored a hardcoded "eth0" — whichever network Docker happened to assign
+# that name to — never the host-side bridges, regardless of the entrypoint
+# logic added to look for them).
+ENV DEVICE_ID=zeek-1
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/containers/zeek/dnp3.zeek
+++ b/containers/zeek/dnp3.zeek
@@ -1,0 +1,21 @@
+##! ICS Simulator — DNP3 protocol analysis.
+##! Optional script, selected via the IDSPanel "DNP3 analyzer" checkbox
+##! (scenario.security.ids.zeekScripts). Loads Zeek's built-in DNP3 analyzer
+##! and logs ICS-specific DNP3 events on top of the shared ICSMonitor module.
+
+@load ics-monitor
+@load base/protocols/dnp3
+
+module ICSMonitor;
+
+# Zeek 8.x: signature is (c, is_orig, application, fc); fir/fin/con/uns/seq removed.
+event dnp3_application_request_header(c: connection, is_orig: bool,
+        application: count, fc: count) {
+    # FC 3 = DIRECT_OPERATE
+    if (fc == 3) {
+        NOTICE([$note=DNP3_Direct_Operate,
+                $msg=fmt("DNP3 DirectOperate: %s → %s",
+                         c$id$orig_h, c$id$resp_h),
+                $conn=c]);
+    }
+}

--- a/containers/zeek/entrypoint.sh
+++ b/containers/zeek/entrypoint.sh
@@ -2,45 +2,75 @@
 # entrypoint.sh — Zeek network monitor startup for the otforge-zeek container.
 #
 # Reads script configuration injected by compose-generator.ts and starts Zeek
-# in passive analysis mode on the specified interface.
+# in passive analysis mode on the host's simulation bridge interfaces.
 #
 # Environment variables:
 #   DEVICE_ID     — Device node ID from the scenario (logged on start)
-#   ZEEK_IFACE    — Network interface to monitor (default: eth0)
+#   ZEEK_IFACE    — Explicit single interface to monitor, bypassing bridge
+#                   auto-detection (default: auto-detect, see below)
 #   ZEEK_SCRIPTS  — Comma-separated script filenames to load from the Zeek site dir.
-#                   e.g. "modbus.zeek,dnp3.zeek,ics.zeek"
+#                   e.g. "modbus.zeek,dnp3.zeek"
 #                   When empty, defaults to "modbus.zeek,dnp3.zeek".
 #                   Scripts must exist under /opt/zeek/share/zeek/site/.
 #                   The bundled ics-monitor.zeek is always loaded via local.zeek.
 #
-# Zeek operates passively: it observes a copy of all traffic on eth0 but does not
-# block or modify packets. Log files (conn.log, modbus.log, etc.) are written to
+# Zeek operates passively: it observes a copy of all traffic but does not block or
+# modify packets. Log files (conn.log, modbus.log, dnp3.log, etc.) are written to
 # /var/log/zeek/ (a named volume in the compose file, consumed by Loki in Phase 6).
+#
+# Capture topology: like Suricata, this container runs with network_mode: host
+# (see compose-generator.ts) so it can open packet sockets directly on the
+# host-side br-XXXX Linux bridges that Docker creates for each simulation network.
+# A container's own veth in promiscuous mode does NOT see sibling-container
+# unicast traffic — the bridge only forwards frames to the port that owns the
+# destination MAC. Only the host-side bridge itself sees every frame on the
+# segment. Zeek previously joined ot-net/internet-dmz-net/attacker-net as a
+# regular multi-homed container and enabled promisc on whichever single veth it
+# found first — that missed most cross-container traffic and explains why DNP3/
+# Modbus logs were empty or inconsistent for some students. This mirrors the fix
+# already applied to Suricata.
 
 set -e
 
 SCRIPTS="${ZEEK_SCRIPTS:-modbus.zeek,dnp3.zeek}"
 
-# ── Select and prepare the capture interface ────────────────────────────────────
-# Same promiscuous-mode requirement as Suricata: without promisc, Zeek only sees
-# frames addressed to its own MAC. Enabling promisc lets the bridge deliver copies
-# of ALL frames so Zeek can build complete connection logs.
-IFACE="${ZEEK_IFACE:-}"
-if [ -z "$IFACE" ]; then
-    for candidate in $(ls /sys/class/net/ | grep -v lo | sort); do
-        if ip addr show "$candidate" 2>/dev/null | grep -qE 'inet 10\.'; then
-            IFACE="$candidate"
-            break
+# ── Select and prepare the capture interfaces ───────────────────────────────────
+IFACES=()
+
+if [ -n "${ZEEK_IFACE:-}" ]; then
+    # Explicit single-interface override (useful for unit tests or non-host-mode deployments)
+    ip link set "$ZEEK_IFACE" promisc on 2>/dev/null \
+        && echo "[ics-zeek] Promiscuous mode enabled on ${ZEEK_IFACE}" \
+        || echo "[ics-zeek] Warning: could not set promisc on ${ZEEK_IFACE}"
+    IFACES=("$ZEEK_IFACE")
+else
+    # Running in host network mode: detect Docker bridge interfaces (br-XXXX) that
+    # carry simulation traffic, exactly as containers/suricata/entrypoint.sh does.
+    for candidate in $(ls /sys/class/net/ 2>/dev/null | sort); do
+        if [ -d "/sys/class/net/${candidate}/bridge" ] 2>/dev/null; then
+            if ip addr show "$candidate" 2>/dev/null | grep -qE 'inet 10\.200\.'; then
+                echo "[ics-zeek] Found simulation bridge: ${candidate}"
+                IFACES+=("$candidate")
+            fi
         fi
     done
-    IFACE="${IFACE:-eth0}"
+    if [ ${#IFACES[@]} -eq 0 ]; then
+        # Fallback: no bridge interfaces found — may be running outside host-network mode.
+        echo "[ics-zeek] Warning: no br-XXXX bridge interfaces found, falling back to veth scan"
+        for candidate in $(ls /sys/class/net/ 2>/dev/null | grep -v lo | sort); do
+            if ip addr show "$candidate" 2>/dev/null | grep -qE 'inet 10\.'; then
+                ip link set "$candidate" promisc on 2>/dev/null
+                IFACES+=("$candidate")
+            fi
+        done
+    fi
+    if [ ${#IFACES[@]} -eq 0 ]; then
+        echo "[ics-zeek] Warning: no suitable interface found, falling back to eth0"
+        IFACES=("eth0")
+    fi
 fi
 
-ip link set "$IFACE" promisc on 2>/dev/null \
-    && echo "[ics-zeek] Promiscuous mode enabled on ${IFACE}" \
-    || echo "[ics-zeek] Warning: could not set promisc on ${IFACE}"
-
-echo "[ics-zeek] Device=${DEVICE_ID}  interface=${IFACE}"
+echo "[ics-zeek] Device=${DEVICE_ID}  interfaces=${IFACES[*]}"
 echo "[ics-zeek] Requested scripts: ${SCRIPTS}"
 
 # ── Resolve requested scripts to absolute paths ─────────────────────────────────
@@ -67,11 +97,37 @@ done
 # ── Start Zeek ──────────────────────────────────────────────────────────────────
 # `zeek -i` writes all log files (conn.log, modbus.log, etc.) to its WORKING
 # DIRECTORY — there is no --logdir flag in standalone mode (zeekctl handles that
-# in managed deployments). We cd to the named volume path before exec so the logs
-# land where Promtail expects them. exec inherits the working directory.
+# in managed deployments).
+#
+# Unlike Suricata (whose AF_PACKET engine natively multiplexes many interfaces
+# inside one process), Zeek's standalone CLI rejects more than one -i: "Only a
+# single interface option (-i) is allowed." So multi-bridge coverage means one
+# Zeek worker process per detected interface, each in its own subdirectory so
+# their same-named log files (conn.log, dnp3.log, ...) don't collide. Promtail's
+# __path__ glob (grafana-provisioning.ts) picks up every worker's logs.
 LOG_DIR="/var/log/zeek"
 mkdir -p "${LOG_DIR}"
-cd "${LOG_DIR}"
-echo "[ics-zeek] Log directory: ${LOG_DIR}"
-echo "[ics-zeek] Starting Zeek passive monitor on ${IFACE}..."
-exec zeek -i "${IFACE}" "${SITE_DIR}/local.zeek" "${EXTRA_ARGS[@]}"
+echo "[ics-zeek] Starting ${#IFACES[@]} Zeek worker(s), one per interface..."
+
+PIDS=()
+# Forward SIGTERM/SIGINT (`docker stop`) to every worker so the container shuts
+# down promptly instead of waiting out Docker's kill timeout.
+trap 'echo "[ics-zeek] Stopping workers..."; kill "${PIDS[@]}" 2>/dev/null; wait' TERM INT
+
+for iface in "${IFACES[@]}"; do
+    iface_dir="${LOG_DIR}/${iface}"
+    mkdir -p "${iface_dir}"
+    # -C/--no-checksums: Docker veth/bridge interfaces carry checksum-offloaded
+    # traffic — locally-generated packets often have unfilled or "invalid" L4
+    # checksums that only get computed by the NIC (or, here, never at all since
+    # there's no physical NIC). Without -C, Zeek discards nearly every packet as
+    # checksum-invalid, so connections are seen but never fully parsed (visible
+    # as conn.log entries stuck in state OTH with no application-layer log
+    # lines). Suricata does not need an equivalent flag — af-packet capture
+    # trusts the kernel's own checksum-validity flag instead of recomputing it.
+    (cd "${iface_dir}" && exec zeek -C -i "${iface}" "${SITE_DIR}/local.zeek" "${EXTRA_ARGS[@]}") &
+    PIDS+=("$!")
+    echo "[ics-zeek] Worker for ${iface} started (pid $!), logs in ${iface_dir}"
+done
+
+wait

--- a/containers/zeek/ics-monitor.zeek
+++ b/containers/zeek/ics-monitor.zeek
@@ -1,9 +1,11 @@
-##! ICS Simulator — Zeek monitoring script
-##! Enables Modbus and DNP3 protocol analysis and logs ICS-specific events.
+##! ICS Simulator — shared Zeek monitoring definitions.
+##! Always loaded (via local.zeek) regardless of which optional protocol
+##! analyzers (modbus.zeek, dnp3.zeek) the scenario selects. Provides the
+##! shared ICSMonitor module — the Notice::Type enum, zone classification,
+##! and the generic per-connection ICS summary line — that the protocol-
+##! specific scripts build on.
 
 @load base/frameworks/notice
-@load base/protocols/modbus
-@load base/protocols/dnp3
 
 module ICSMonitor;
 
@@ -31,46 +33,9 @@ function zone_name(a: addr): string {
     return "External";
 }
 
-# ── Modbus logging ────────────────────────────────────────────────────────────
-
-# Zeek 8.x: parameter order is (c, headers, is_orig); ModbusData type was removed.
-event modbus_message(c: connection, headers: ModbusHeaders, is_orig: bool) {
-    local src_zone  = zone_name(c$id$orig_h);
-    local dst_zone  = zone_name(c$id$resp_h);
-
-    if (src_zone != dst_zone) {
-        NOTICE([$note=Cross_Zone_Traffic,
-                $msg=fmt("Modbus %s→%s: %s:%d → %s:%d",
-                         src_zone, dst_zone,
-                         c$id$orig_h, c$id$orig_p,
-                         c$id$resp_h, c$id$resp_p),
-                $conn=c]);
-    }
-}
-
-event modbus_write_multiple_registers_request(c: connection, headers: ModbusHeaders,
-        start_address: count, registers: ModbusRegisters) {
-    NOTICE([$note=Modbus_Write_Registers,
-            $msg=fmt("Modbus WriteMultipleRegs: %s → %s  start=%d  count=%d",
-                     c$id$orig_h, c$id$resp_h, start_address, |registers|),
-            $conn=c]);
-}
-
-# ── DNP3 logging ──────────────────────────────────────────────────────────────
-
-# Zeek 8.x: signature is (c, is_orig, application, fc); fir/fin/con/uns/seq removed.
-event dnp3_application_request_header(c: connection, is_orig: bool,
-        application: count, fc: count) {
-    # FC 3 = DIRECT_OPERATE
-    if (fc == 3) {
-        NOTICE([$note=DNP3_Direct_Operate,
-                $msg=fmt("DNP3 DirectOperate: %s → %s",
-                         c$id$orig_h, c$id$resp_h),
-                $conn=c]);
-    }
-}
-
 # ── Connection summary ────────────────────────────────────────────────────────
+# Port-based classification only — this fires regardless of which optional
+# analyzer scripts are loaded, since it doesn't depend on their event handlers.
 
 event connection_state_remove(c: connection) {
     # Log all ICS protocol connections

--- a/containers/zeek/modbus.zeek
+++ b/containers/zeek/modbus.zeek
@@ -1,0 +1,32 @@
+##! ICS Simulator — Modbus TCP protocol analysis.
+##! Optional script, selected via the IDSPanel "Modbus analyzer" checkbox
+##! (scenario.security.ids.zeekScripts). Loads Zeek's built-in Modbus analyzer
+##! and logs ICS-specific Modbus events on top of the shared ICSMonitor module.
+
+@load ics-monitor
+@load base/protocols/modbus
+
+module ICSMonitor;
+
+# Zeek 8.x: parameter order is (c, headers, is_orig); ModbusData type was removed.
+event modbus_message(c: connection, headers: ModbusHeaders, is_orig: bool) {
+    local src_zone  = zone_name(c$id$orig_h);
+    local dst_zone  = zone_name(c$id$resp_h);
+
+    if (src_zone != dst_zone) {
+        NOTICE([$note=Cross_Zone_Traffic,
+                $msg=fmt("Modbus %s→%s: %s:%d → %s:%d",
+                         src_zone, dst_zone,
+                         c$id$orig_h, c$id$orig_p,
+                         c$id$resp_h, c$id$resp_p),
+                $conn=c]);
+    }
+}
+
+event modbus_write_multiple_registers_request(c: connection, headers: ModbusHeaders,
+        start_address: count, registers: ModbusRegisters) {
+    NOTICE([$note=Modbus_Write_Registers,
+            $msg=fmt("Modbus WriteMultipleRegs: %s → %s  start=%d  count=%d",
+                     c$id$orig_h, c$id$resp_h, start_address, |registers|),
+            $conn=c]);
+}

--- a/packages/app/src/renderer/src/properties/SecurityPanel.tsx
+++ b/packages/app/src/renderer/src/properties/SecurityPanel.tsx
@@ -383,11 +383,6 @@ const ZEEK_SCRIPTS_OPTIONS: { id: string; label: string; hint: string }[] = [
     id: 'dnp3.zeek',
     label: 'DNP3 analyzer',
     hint: 'Logs DNP3 sessions and function codes to dnp3.log'
-  },
-  {
-    id: 'ics.zeek',
-    label: 'ICS fingerprinting',
-    hint: 'Passive device fingerprinting via protocol banners'
   }
 ]
 

--- a/packages/orchestrator/src/__tests__/compose-generator.test.ts
+++ b/packages/orchestrator/src/__tests__/compose-generator.test.ts
@@ -1006,4 +1006,13 @@ describe('fixed infrastructure services', () => {
     // br-XXXX Docker bridge interfaces — per-network IP assignments are not used.
     expect(compose.services['suricata'].network_mode).toBe('host')
   })
+
+  it('runs Zeek in host network mode so it sees all simulation bridge interfaces', () => {
+    const compose = gen(infraScenario)
+    // Zeek uses network_mode: 'host', same as Suricata — a container's own veth in
+    // promiscuous mode does not see sibling-container unicast traffic, only the
+    // host-side br-XXXX bridge does. No per-network IP assignments are used.
+    expect(compose.services['zeek'].network_mode).toBe('host')
+    expect(compose.services['zeek'].networks).toBeUndefined()
+  })
 })

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -444,8 +444,8 @@ export function generateCompose(
   //   .1        — bridge gateway (Docker)
   //   .240–.249 — system services (influxdb, loki, grafana, fuxa, promtail)
   //   .250      — attack machine's internet-dmz-net leg
-  //   .252      — zeek (ot-net, internet-dmz-net, attacker-net)
-  //   .253      — suricata (ot-net, control-net, internet-dmz-net, attacker-net)
+  //   .252      — reserved (formerly zeek's per-network IP, now network_mode: host)
+  //   .253      — reserved (formerly suricata's per-network IP, now network_mode: host)
   //   .254      — firewall
   const reservedHosts = new Set([1, 240, 241, 242, 243, 244, 250, 252, 253, 254])
   const usedIpsPerNet = new Map<string, Set<number>>([
@@ -1000,15 +1000,22 @@ export function generateCompose(
     deploy: { resources: { limits: { memory: '512m', cpus: '1.0' } } }
   }
 
-  // ── Zeek — passive network analysis tap on OT and attacker-facing networks ──
+  // ── Zeek — passive network analysis tap on all simulation bridge interfaces ──
   // Zeek monitors traffic passively; it does not block or modify packets.
   //
-  // Previously Zeek was only on ot-net (.252), which meant it missed all traffic
-  // between the attack machine and internet-facing services. Zeek is now attached
-  // to three networks so it can observe:
-  //   ot-net          — Modbus/DNP3 protocol traffic between PLCs and controllers
+  // Zeek runs with network_mode: host, same as Suricata and for the same reason:
+  // a container's own veth in promiscuous mode does not see sibling-container
+  // unicast traffic (the Docker bridge only forwards to the port that owns the
+  // destination MAC). Zeek previously joined ot-net/internet-dmz-net/attacker-net
+  // as a regular multi-homed container and only auto-detected ONE of those veths
+  // to monitor — it missed most cross-container traffic, which is why DNP3/Modbus
+  // logs were empty or inconsistent for some students. In host mode the entrypoint
+  // scans for the host-side br-XXXX Linux bridges (one per simulation network) and
+  // passes all of them to Zeek via repeated -i flags, so it observes:
+  //   ot-net           — Modbus/DNP3 protocol traffic between PLCs and controllers
   //   internet-dmz-net — attack machine ↔ web/DNS server scans and exploits
   //   attacker-net     — outbound C2 traffic and tool downloads from Kali
+  //   (and any other simulation network present in the scenario)
   //
   // ZEEK_SCRIPTS — comma-separated script filenames from the Zeek site directory,
   //   selected in the IDSPanel UI (scenario.security.ids.zeekScripts).
@@ -1018,29 +1025,25 @@ export function generateCompose(
       ? scenario.security.ids.zeekScripts.join(',')
       : 'modbus.zeek,dnp3.zeek'
 
-  const internetDmzZeekBase = effectiveZones['internet-dmz'].subnet.replace('.0/24', '')
-  const attackerZeekBase = effectiveZones.attacker.subnet.replace('.0/24', '')
-
   volumes[`${projectName}-zeek-logs`] = {}
   services['zeek'] = {
     image: 'ghcr.io/iburres/otforge-zeek:latest',
     pull_policy: 'if_not_present',
     container_name: `${projectName}-zeek`,
     restart: 'unless-stopped',
-    networks: {
-      // OT zone — ICS protocol traffic (Modbus port 502, DNP3 port 20000)
-      'ot-net': { ipv4_address: `${otBase}.252` },
-      // Internet DMZ — attack machine ↔ web server / DNS server traffic
-      'internet-dmz-net': { ipv4_address: `${internetDmzZeekBase}.252` },
-      // Attacker zone — outbound Kali traffic (C2, tool downloads, recon)
-      'attacker-net': { ipv4_address: `${attackerZeekBase}.252` }
-    },
+    // Host network mode: no per-network IP assignments are needed — the entrypoint
+    // discovers the simulation's br-XXXX bridges at startup, same as Suricata.
+    network_mode: 'host',
     environment: [`ZEEK_SCRIPTS=${zeekScripts}`],
     cap_add: ['NET_ADMIN', 'NET_RAW'],
     volumes: [`${projectName}-zeek-logs:/var/log/zeek`],
-    // Bumped from 150m: three AF_PACKET interfaces each need ~50m for ring buffers,
-    // and Zeek's conn-table grows with observed flows. 256m prevents OOM on busy labs.
-    deploy: { resources: { limits: { memory: '256m', cpus: '0.5' } } }
+    // Bumped from 256m: entrypoint.sh now runs one Zeek worker process per detected
+    // bridge (up to 6, one per Purdue zone) since Zeek's standalone CLI — unlike
+    // Suricata's AF_PACKET engine — only accepts a single -i per process. Each
+    // worker's baseline footprint plus its own growing conn-table adds up faster
+    // than the old single-process, three-interface design. 512m prevents OOM on
+    // busy labs with all zones active.
+    deploy: { resources: { limits: { memory: '512m', cpus: '0.5' } } }
   }
 
   // ── InfluxDB 1.8 — time-series process historian ──────────────────────────

--- a/packages/orchestrator/src/grafana-provisioning.ts
+++ b/packages/orchestrator/src/grafana-provisioning.ts
@@ -209,10 +209,13 @@ export async function writeGrafanaProvisioning(
             labels: {
               job: 'zeek',
               scenario: projectName,
-              // Zeek writes logs to its working directory (/var/log/zeek) when
-              // started with `zeek -i` — no `current/` subdirectory is created
-              // (that is a zeekctl-managed deployment convention, not standalone).
-              __path__: '/var/log/zeek/*.log'
+              // Zeek's standalone CLI accepts only one -i per process, so
+              // entrypoint.sh runs one Zeek worker per host bridge interface,
+              // each in its own /var/log/zeek/<iface>/ working directory (no
+              // `current/` subdirectory — that is a zeekctl-managed deployment
+              // convention, not standalone). The double-star glob picks up every
+              // worker's log set.
+              __path__: '/var/log/zeek/**/*.log'
             }
           }
         ]


### PR DESCRIPTION
## Summary

Students reported ICS_Lab_03's Zeek DNP3 log was empty or worked inconsistently across the class ("Zeek container appears to be missing the required dnp3.zeek script"). Traced to three compounding bugs in Zeek's capture pipeline — none related to Suricata rule content — and verified live end-to-end by building the image and running the full Lab 03 compose stack with real DNP3 traffic (legitimate poll + the Kali Direct Operate attack).

**Root causes (each masked the next until fixed in sequence):**

1. `containers/zeek/Dockerfile` baked `ZEEK_IFACE=eth0` into `ENV`, silently disabling the entrypoint's bridge auto-detection on every run for every student — Zeek always watched whichever network Docker happened to name "eth0" on that machine/Compose version. This explains why reports were *inconsistent* rather than uniformly broken: interface-to-name assignment isn't stable across Docker/Compose versions.
2. `zeek/zeek:latest` has no `ip` binary (unlike Suricata's base image), so even after removing the bad `ENV` default, bridge detection failed silently (stderr discarded) and fell back to a hardcoded "eth0" anyway. Fixed by installing `iproute2`.
3. Zeek discards packets it sees as checksum-invalid by default. Docker's checksum-offloaded veth/bridge traffic looks invalid to a raw capture, so even once watching the right bridge, connections showed up in `conn.log` stuck in state `OTH` with no application-layer log line. Fixed with `-C`/`--no-checksums` (Suricata doesn't need this — AF_PACKET trusts the kernel's own checksum-validity flag instead of recomputing it).

**Also fixed alongside:**
- Switched Zeek to `network_mode: host`, mirroring the fix already applied to Suricata for the same underlying reason (a container's own veth in promiscuous mode never sees sibling-container unicast traffic — only the host-side bridge does).
- Zeek's standalone CLI accepts only one `-i` per process (unlike Suricata's AF_PACKET, which multiplexes many interfaces in one process), so `entrypoint.sh` now runs one Zeek worker per detected bridge, each in its own log subdirectory. Promtail's glob and Zeek's memory limit (256m→512m) updated accordingly.
- Split the monolithic `ics-monitor.zeek` into a shared module plus real `modbus.zeek`/`dnp3.zeek` files, matching what the IDSPanel UI already promised (those names were referenced by the UI and by `ICS_Lab_03.otflab` but never existed in any commit, producing a benign but confusing "script not found" warning every run). Removed the never-implemented `ics.zeek` fingerprinting picker option.

**Not in scope for this PR:** the Suricata reject-rule "block" step (Lab 03 Steps 9/10) has a separate, known tap-mode reliability limitation; a second student's "IP conflict at simulation start" report also looks unrelated (likely `findFreeSubnets()` not accounting for leftover Docker networks, compounded by that student running in a VM).

## Test plan

- [x] `npx vitest run` — all 166 orchestrator tests pass
- [x] `npx tsc --noEmit` — both `orchestrator` and `app` packages clean
- [x] Built `otforge-zeek` locally and ran the full generated Lab 03 compose stack (all 15 services) with real containers
- [x] Ran the workstation's legitimate DNP3 poll (`dnp3_poll.py`) — confirmed `dnp3.log` shows `fc_request: READ` on the ot-net bridge worker
- [x] Ran Kali's `dnp3_attack.py` Direct Operate attack — confirmed both Zeek's `dnp3.log` and Suricata's `eve.json` (SID 9000010) fire correctly for the same event
- [x] Confirmed all 6 Zeek worker processes (one per Purdue zone bridge) start and stay up under the new 512m limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)