### PR TITLE
fix(docker): bump zeek SECURITY_REFRESH for libcurl CVEs

### DIFF
--- a/containers/zeek/Dockerfile
+++ b/containers/zeek/Dockerfile
@@ -14,7 +14,12 @@ FROM zeek/zeek:latest
 # to be pulled. 2026-07-06: libssh2 1.11.1-1+deb13u1 fixes CVE-2026-55200
 # (CRITICAL out-of-bounds write), CVE-2026-55199 (HIGH DoS), and CVE-2026-7598
 # — none of which were in the repos when this image was last built (2026-06-29).
-ARG SECURITY_REFRESH=2026-07-06
+# 2026-07-13: libcurl3t64-gnutls 8.14.1-2+deb13u4 fixes CVE-2026-5773 (HIGH,
+# wrong file transfer via incorrect SMB connection reuse) and CVE-2026-6276
+# (HIGH, cookie-leak information disclosure on connection reuse) — flagged by
+# the Trivy scan on the fix/zeek-capture-and-scripts rebuild; not in the repos
+# when this image was last built (2026-07-06).
+ARG SECURITY_REFRESH=2026-07-13
 RUN echo "security-refresh: ${SECURITY_REFRESH}" \
     && apt-get update && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- Follow-up to #33 (merged). That merge's Trivy scan on `otforge-zeek` came back red with 2 new HIGH CVEs (CVE-2026-5773, CVE-2026-6276) in `libcurl3t64-gnutls`, already fixed upstream (`8.14.1-2+deb13u4`) but not in the Debian repos when the image was last refreshed (`SECURITY_REFRESH=2026-07-06`).
- The image build/push itself succeeded — only the informational Trivy scan job failed, same recurring stale-red pattern as this Dockerfile's own comment history describes.
- Bumped `SECURITY_REFRESH` to `2026-07-13` to bust the apt-get upgrade layer's cache.

## Test plan

- [x] `docker build --no-cache` locally, confirmed base moved to Debian 13.6 with the patched libcurl
- [x] `trivy image --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore` (matching the CI job's exact flags) — 0 vulnerabilities
- [x] `npx vitest run` (orchestrator) — 166/166 pass
- [x] `npx tsc --noEmit` — both packages clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)