### PR TITLE
feat(app): add "Update OTForge" self-updater button

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -31,7 +31,7 @@ import type {
   ScenarioDeleteFileResult,
   SimulationStartResult,
   SimulationStopResult,
-  SimulationUpdateResult,
+  AppUpdateResult,
   SessionSummary,
   SessionSaveResult,
   SessionLoadResult,
@@ -129,6 +129,74 @@ function getScenariosLibraryDir(): string {
     return pathJoin(app.getAppPath(), '..', '..', 'scenarios')
   }
   return pathJoin(app.getPath('documents'), 'OTForge', 'Scenarios')
+}
+
+/**
+ * Returns the absolute path to the git checkout root (the npm workspaces
+ * project root, two levels up from packages/app in electron-vite dev mode).
+ *
+ * Only meaningful when `is.dev` is true — a packaged build has no .git
+ * directory or workspace package.json, so the "Update OTForge" self-updater
+ * (app:update) refuses to run outside dev mode. Callers must check `is.dev`
+ * before calling this.
+ */
+function getProjectRoot(): string {
+  return pathJoin(app.getAppPath(), '..', '..')
+}
+
+/**
+ * Runs a command via spawn(), streaming stdout+stderr to onProgress line-by-line
+ * (CR→LF split, ANSI escape codes stripped) — mirrors DockerClient's internal
+ * `_composePull` streaming so `git pull`/`npm install` output renders the same
+ * way as `docker compose pull` output in the update overlay. `shell: true` lets
+ * Windows resolve `npm` (a .cmd shim) the same way `git` resolves as a normal
+ * binary, without hardcoding a platform-specific executable name.
+ *
+ * Rejects with an Error including the last few output lines if the process
+ * exits non-zero, so the renderer can show a useful message instead of a bare
+ * exit code.
+ */
+function runStreamedCommand(
+  command: string,
+  args: string[],
+  cwd: string,
+  onProgress?: (line: string) => void
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const allLines: string[] = []
+    const child = spawn(command, args, { cwd, shell: true })
+
+    const processChunk = (buf: Buffer): void => {
+      buf
+        .toString()
+        .replace(/\r/g, '\n')
+        .split('\n')
+        .forEach(raw => {
+          // eslint-disable-next-line no-control-regex
+          const line = raw.replace(/\x1B\[[0-9;]*[mGKHF]/g, '').trim()
+          if (!line) return
+          allLines.push(line)
+          onProgress?.(line)
+        })
+    }
+
+    child.stdout?.on('data', processChunk)
+    child.stderr?.on('data', processChunk)
+
+    child.on('close', code => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(
+          new Error(
+            `${command} ${args.join(' ')} exited with code ${code}: ${allLines.slice(-8).join(' | ')}`
+          )
+        )
+      }
+    })
+
+    child.on('error', reject)
+  })
 }
 
 /**
@@ -560,12 +628,105 @@ function registerIPCHandlers(): void {
     version: app.getVersion(),
     nodeVersion: process.versions.node,
     electronVersion: process.versions.electron,
-    platform: process.platform as AppInfo['platform']
+    platform: process.platform as AppInfo['platform'],
+    isDev: is.dev
   }))
 
   /** Opens a URL in the system browser (used for documentation links). */
   ipcMain.handle('app:openExternal', async (_e, { url }: { url: string }) => {
     await shell.openExternal(url)
+  })
+
+  /**
+   * "Update OTForge" self-updater — supersedes the old scenario-scoped "Update
+   * Images" toolbar button (removed). Runs, in order: `git pull` in the project
+   * root, `npm install`, then — if a scenario is loaded and Docker is available
+   * — a `docker compose pull` for that scenario's images via
+   * DockerClient.updateImages(). Only available in dev mode (`npm run dev`
+   * from a git checkout); a packaged build has no .git directory or workspace
+   * package.json to update.
+   *
+   * Guards against a dirty working tree: `git status --porcelain` catches both
+   * uncommitted local edits and an unresolved merge conflict (conflicted files
+   * show as `UU` entries), so an instructor's local changes are never silently
+   * overwritten. `git pull` itself is the fallback safety net for anything the
+   * porcelain check misses (e.g. diverged history) — it fails loudly rather
+   * than force-merging.
+   *
+   * On success, restartRequired is always true — the updated main/renderer
+   * bundles only take effect after a relaunch. Progress lines are streamed to
+   * the renderer over 'app:updateProgress'.
+   */
+  ipcMain.handle('app:update', async (_e, scenario?: OTForgeScenario): Promise<AppUpdateResult> => {
+    if (!is.dev) {
+      return {
+        ok: false,
+        error:
+          'Update OTForge only works when running from a git checkout (npm run dev), not a packaged build.'
+      }
+    }
+
+    const projectRoot = getProjectRoot()
+    const send = (line: string): void => {
+      mainWindow?.webContents.send('app:updateProgress', { line })
+    }
+
+    try {
+      const { stdout } = await execAsync('git status --porcelain', { cwd: projectRoot })
+      if (stdout.trim().length > 0) {
+        return {
+          ok: false,
+          error:
+            'You have uncommitted local changes in the OTForge repo. Commit, stash, or discard them before updating, then try again.'
+        }
+      }
+    } catch (err) {
+      return { ok: false, error: `Could not check git status: ${(err as Error).message}` }
+    }
+
+    try {
+      send('Pulling latest source (git pull)...')
+      await runStreamedCommand('git', ['pull'], projectRoot, send)
+
+      send('Installing dependencies (npm install)...')
+      await runStreamedCommand('npm', ['install'], projectRoot, send)
+
+      if (scenario) {
+        const dockerAvailable = await dockerClient.isAvailable()
+        if (dockerAvailable) {
+          send('Refreshing container images for the loaded scenario...')
+          const projectName = toProjectName(scenario.meta.name)
+          const zones = await resolveZones()
+          const scenarioDir = pathJoin(app.getPath('userData'), 'scenarios', projectName)
+          const composeYaml = generateCompose(scenario, projectName, scenarioDir, zones)
+          const imageResult = await dockerClient.updateImages(projectName, composeYaml, send)
+          if (!imageResult.ok) {
+            send(
+              `Container image refresh failed: ${imageResult.error} (source update still applied)`
+            )
+          }
+        } else {
+          send('Docker is not running — skipping container image refresh.')
+        }
+      } else {
+        send('No scenario loaded — skipping container image refresh.')
+      }
+
+      return { ok: true, restartRequired: true }
+    } catch (err) {
+      return { ok: false, error: `Update failed: ${(err as Error).message}` }
+    }
+  })
+
+  /**
+   * Relaunches the app — used by the "Restart to apply" prompt after
+   * app:update completes. Separate from app:update itself so the renderer can
+   * show a confirmation prompt before the process actually restarts, rather
+   * than the window disappearing out from under the update-complete message.
+   */
+  ipcMain.handle('app:relaunch', (): void => {
+    app.relaunch()
+    app.exit(0)
   })
 
   // ── Docker health check ───────────────────────────────────────────────────────
@@ -922,45 +1083,6 @@ function registerIPCHandlers(): void {
         activeAttackPorts.clear()
         activeWorkstationPorts.clear()
         return { ok: false, error: `Simulation start failed: ${(err as Error).message}` }
-      }
-    }
-  )
-
-  /**
-   * Force-pulls the newest image for every service in the loaded scenario.
-   *
-   * Backs the toolbar "Update Images" button. Because the default
-   * `pull_policy: if_not_present` never re-pulls a `:latest` tag that already
-   * exists locally, a student who pulled an image weeks ago would otherwise
-   * keep running a stale image even after a new one is published to GHCR. This
-   * runs `docker compose pull`, which always re-fetches each tag.
-   *
-   * Reuses the same compose generation as simulation:start so the pull targets
-   * exactly the images this scenario would launch. It does NOT set
-   * activeProjectName or start any container — pulling only refreshes the local
-   * image cache; the updated image takes effect on the next Run Simulation.
-   *
-   * Progress lines are streamed to the renderer over 'simulation:updateProgress'.
-   */
-  ipcMain.handle(
-    'simulation:updateImages',
-    async (_e, scenario: OTForgeScenario): Promise<SimulationUpdateResult> => {
-      try {
-        const dockerAvailable = await dockerClient.isAvailable()
-        if (!dockerAvailable) {
-          return { ok: false, error: 'Docker Desktop is not running.' }
-        }
-
-        const projectName = toProjectName(scenario.meta.name)
-        const zones = await resolveZones()
-        const scenarioDir = pathJoin(app.getPath('userData'), 'scenarios', projectName)
-        const composeYaml = generateCompose(scenario, projectName, scenarioDir, zones)
-
-        return await dockerClient.updateImages(projectName, composeYaml, (line: string) => {
-          mainWindow?.webContents.send('simulation:updateProgress', { line })
-        })
-      } catch (err) {
-        return { ok: false, error: `Image update failed: ${(err as Error).message}` }
       }
     }
   )

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -32,7 +32,7 @@ import type {
   ScenarioDeleteFileResult,
   SimulationStartResult,
   SimulationStopResult,
-  SimulationUpdateResult,
+  AppUpdateResult,
   SessionSummary,
   SessionSaveResult,
   SessionLoadResult,
@@ -60,7 +60,22 @@ const api = {
     /** Returns version strings for the about panel (app version, Electron, Node, platform). */
     info: (): Promise<AppInfo> => ipcRenderer.invoke('app:info'),
     /** Opens a URL in the system's default browser (used for documentation links). */
-    openExternal: (url: string): Promise<void> => ipcRenderer.invoke('app:openExternal', { url })
+    openExternal: (url: string): Promise<void> => ipcRenderer.invoke('app:openExternal', { url }),
+
+    /**
+     * "Update OTForge" self-updater: git pull + npm install in the project root,
+     * then (if a scenario is loaded and Docker is available) a docker compose
+     * pull for that scenario's images. Only works in dev mode (npm run dev from
+     * a git checkout) — check AppInfo.isDev before enabling the button.
+     * Progress is streamed via on.appUpdateProgress().
+     * @param scenario - The currently loaded scenario, if any (its images get
+     *   refreshed too); omit to only update source + dependencies.
+     */
+    update: (scenario?: OTForgeScenario): Promise<AppUpdateResult> =>
+      ipcRenderer.invoke('app:update', scenario),
+
+    /** Relaunches the app — call after app:update succeeds and the user confirms. */
+    relaunch: (): Promise<void> => ipcRenderer.invoke('app:relaunch')
   },
 
   // ── Docker health ─────────────────────────────────────────────────────────────
@@ -132,18 +147,7 @@ const api = {
      * Returns the current state and health of all containers in the active simulation.
      * Returns an empty array when no simulation is running.
      */
-    status: (): Promise<ContainerStatus[]> => ipcRenderer.invoke('simulation:status'),
-
-    /**
-     * Force-pulls the newest image for every service in the scenario via
-     * `docker compose pull`. Unlike start (which uses --pull missing), this
-     * always re-fetches each :latest tag, so students receive updated GHCR
-     * images that a cached tag would otherwise mask. Does not start containers.
-     * Progress is streamed via on.simulationUpdateProgress().
-     * @param scenario - The full scenario whose images to refresh.
-     */
-    updateImages: (scenario: OTForgeScenario): Promise<SimulationUpdateResult> =>
-      ipcRenderer.invoke('simulation:updateImages', scenario)
+    status: (): Promise<ContainerStatus[]> => ipcRenderer.invoke('simulation:status')
   },
 
   // ── Saved sessions (resume a lab later) ───────────────────────────────────────
@@ -727,16 +731,15 @@ const api = {
     },
 
     /**
-     * Fires for each output line emitted by `docker compose pull` during a
-     * toolbar-triggered "Update Images" action. Lets the renderer show the most
-     * recent Docker line in the update overlay.
+     * Fires for each output line emitted during an "Update OTForge" self-update
+     * (git pull, npm install, and any container image pull that follows).
      *
-     * @param cb - Callback receiving { line: string } — one Docker output line.
+     * @param cb - Callback receiving { line: string } — one output line.
      * @returns Unsubscribe function — call in useEffect cleanup.
      */
-    simulationUpdateProgress: (cb: (status: { line: string }) => void) => {
-      ipcRenderer.on('simulation:updateProgress', (_event, status) => cb(status))
-      return () => ipcRenderer.removeAllListeners('simulation:updateProgress')
+    appUpdateProgress: (cb: (status: { line: string }) => void) => {
+      ipcRenderer.on('app:updateProgress', (_event, status) => cb(status))
+      return () => ipcRenderer.removeAllListeners('app:updateProgress')
     }
   }
 }

--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -35,6 +35,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import type {
   DockerStatus,
+  AppInfo,
   OTForgeScenario,
   OTForgeMeta,
   DeviceConfig,
@@ -449,6 +450,8 @@ type View = 'launch' | 'canvas'
 export default function App() {
   const [view, setView] = useState<View>('launch')
   const [docker, setDocker] = useState<DockerStatus | null>(null)
+  /** Electron/app version metadata, including isDev (gates the Update OTForge button). */
+  const [appInfo, setAppInfo] = useState<AppInfo | null>(null)
   const [scenario, setScenario] = useState<OTForgeScenario | null>(null)
   const [selectedDevice, setSelectedDevice] = useState<DeviceConfig | null>(null)
   const [selectedZone, setSelectedZone] = useState<string | null>(null)
@@ -529,17 +532,20 @@ export default function App() {
   const [pullProgress, setPullProgress] = useState<string>('')
 
   /**
-   * True while a toolbar-triggered "Update Images" pull is in progress. Drives the
-   * "Updating Container Images" overlay. Independent of simStatus — the update runs
-   * with the simulation stopped and does not start any container.
+   * True while a toolbar-triggered "Update OTForge" self-update is in progress
+   * (git pull + npm install + container image refresh). Drives the "Updating
+   * OTForge" overlay. Independent of simStatus — the update runs with the
+   * simulation stopped and does not start any container.
    */
   const [updating, setUpdating] = useState<boolean>(false)
-  /** Most recent `docker compose pull` output line — shown in the update overlay. */
+  /** Most recent output line (git/npm/docker) — shown in the update overlay. */
   const [updateProgress, setUpdateProgress] = useState<string>('')
-  /** Transient success message shown as a toast after an image update completes. */
-  const [updateNotice, setUpdateNotice] = useState<string | null>(null)
-  /** Auto-dismiss timer for the update-success toast. */
-  const updateNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  /**
+   * Shown after a successful "Update OTForge" run — the updated main/renderer
+   * bundles only take effect after a relaunch, so this prompts the user to
+   * restart now (via app.relaunch()) or dismiss and restart later themselves.
+   */
+  const [showRestartPrompt, setShowRestartPrompt] = useState<boolean>(false)
 
   // attackLaunched state removed — toolbar button now opens AttackTerminalModal directly
   // so button color uses (attackTerminalDevice !== null) instead of a separate flag.
@@ -601,12 +607,15 @@ export default function App() {
 
   useEffect(() => {
     // Fetch app metadata, Docker status, and installed packs concurrently on first render
-    Promise.all([window.electronAPI.docker.check(), window.electronAPI.packs.list()]).then(
-      ([dockerStatus, packList]) => {
-        setDocker(dockerStatus)
-        setInstalledPacks(packList.packs)
-      }
-    )
+    Promise.all([
+      window.electronAPI.app.info(),
+      window.electronAPI.docker.check(),
+      window.electronAPI.packs.list()
+    ]).then(([info, dockerStatus, packList]) => {
+      setAppInfo(info)
+      setDocker(dockerStatus)
+      setInstalledPacks(packList.packs)
+    })
 
     // Subscribe to live container status push events from the main process
     const unsubStatus = window.electronAPI.on.containerStatusUpdate(status => {
@@ -645,15 +654,12 @@ export default function App() {
       }
     })
 
-    // Stream `docker compose pull` output during a toolbar "Update Images" action
-    // into the update overlay, using the same line-filtering as the start pull.
-    const unsubUpdate = window.electronAPI.on.simulationUpdateProgress(({ line }) => {
-      if (
-        line.length < 120 &&
-        /pulling|pull|download|extract|layer|image|pushed|digest|up to date/i.test(line)
-      ) {
-        setUpdateProgress(line)
-      }
+    // Stream git/npm/docker output during a toolbar "Update OTForge" action
+    // into the update overlay — unlike the simulation-start pull stream, every
+    // line here is relevant (git pull / npm install output, not mixed with
+    // unrelated container startup logs), so no content filtering is needed.
+    const unsubUpdate = window.electronAPI.on.appUpdateProgress(({ line }) => {
+      setUpdateProgress(line)
     })
 
     // Clean up IPC listeners when the component unmounts
@@ -1434,35 +1440,38 @@ export default function App() {
   }, [scenario, startSimulation])
 
   /**
-   * Toolbar "Update Images" handler.
+   * Toolbar "Update OTForge" handler — supersedes the old scenario-scoped
+   * "Update Images" button. Runs, in order: `git pull` in the project root,
+   * `npm install`, then (if a scenario is loaded and Docker is available) a
+   * `docker compose pull` for that scenario's images. Only enabled in dev mode
+   * (appInfo.isDev) and while the simulation is idle.
    *
-   * Runs `docker compose pull` for the loaded scenario so the local cache picks
-   * up newly published GHCR images that the default `pull_policy: if_not_present`
-   * would otherwise never re-fetch (e.g. an updated Kali attack-base image). Does
-   * not start any container — the refreshed image is used on the next Run.
-   * Only enabled while the simulation is idle.
+   * On success, shows the restart prompt — the updated main/renderer bundles
+   * only take effect after a relaunch.
    */
-  const handleUpdateImages = useCallback(async () => {
-    if (!scenario) return
+  const handleUpdateOTForge = useCallback(async () => {
     setSimError(null)
     setUpdateProgress('')
     setUpdating(true)
     try {
-      const result = await window.electronAPI.simulation.updateImages(scenario)
+      const result = await window.electronAPI.app.update(scenario ?? undefined)
       if (result.ok) {
-        setUpdateNotice('Container images are up to date.')
-        if (updateNoticeTimerRef.current) clearTimeout(updateNoticeTimerRef.current)
-        updateNoticeTimerRef.current = setTimeout(() => setUpdateNotice(null), 6000)
+        setShowRestartPrompt(true)
       } else {
-        setSimError(result.error ?? 'Image update failed.')
+        setSimError(result.error ?? 'Update failed.')
       }
     } catch (err) {
-      setSimError(`Image update failed: ${(err as Error).message}`)
+      setSimError(`Update failed: ${(err as Error).message}`)
     } finally {
       setUpdating(false)
       setUpdateProgress('')
     }
   }, [scenario])
+
+  /** Relaunches the app after the user confirms the post-update restart prompt. */
+  const handleRestartNow = useCallback(() => {
+    void window.electronAPI.app.relaunch()
+  }, [])
 
   /**
    * Stops the simulation:
@@ -1735,26 +1744,26 @@ export default function App() {
               Open
             </button>
             {/*
-             * Update Images — force-pulls the newest GHCR images for the loaded
-             * scenario. Needed because pull_policy: if_not_present never re-pulls a
-             * :latest tag that already exists locally, so a published image update
-             * (e.g. a new Kali attack-base) would otherwise never reach the student.
-             * Shown only with a scenario loaded; disabled unless idle + Docker up.
+             * Update OTForge — self-updater: git pull + npm install in the project
+             * root, then (if a scenario is loaded and Docker is up) a docker compose
+             * pull for that scenario's images. Supersedes the old scenario-scoped
+             * "Update Images" button — not gated on a scenario being loaded, since
+             * the source/dependency update doesn't need one. Only works in dev mode
+             * (npm run dev from a git checkout) — a packaged build has no .git
+             * directory or workspace package.json to update.
              */}
-            {scenario && (
+            {appInfo?.isDev && (
               <button
                 className="btn btn-sm btn-ghost"
-                onClick={handleUpdateImages}
-                disabled={!simIsIdle || !docker?.available || updating}
+                onClick={handleUpdateOTForge}
+                disabled={!simIsIdle || updating}
                 title={
-                  !docker?.available
-                    ? 'Docker is not running'
-                    : !simIsIdle
-                      ? 'Stop the simulation to update images'
-                      : 'Download the latest container images for this scenario from the registry'
+                  !simIsIdle
+                    ? 'Stop the simulation to update OTForge'
+                    : 'Pull the latest OTForge source, dependencies, and (if a scenario is loaded) its container images'
                 }
               >
-                {updating ? 'Updating…' : 'Update Images'}
+                {updating ? 'Updating…' : 'Update OTForge'}
               </button>
             )}
             {/*
@@ -2336,18 +2345,19 @@ export default function App() {
         </div>
       )}
       {/*
-       * "Updating Container Images" overlay — shown while a toolbar-triggered
-       * `docker compose pull` runs. Reuses the pull-overlay styles. Independent of
-       * simStatus since the update runs with the simulation stopped.
+       * "Updating OTForge" overlay — shown while a toolbar-triggered self-update
+       * (git pull + npm install + optional image refresh) runs. Reuses the
+       * pull-overlay styles. Independent of simStatus since the update runs
+       * with the simulation stopped.
        */}
       {updating && (
-        <div className="pull-overlay" role="alertdialog" aria-label="Updating images">
+        <div className="pull-overlay" role="alertdialog" aria-label="Updating OTForge">
           <div className="pull-overlay-card">
             <div className="pull-spinner" aria-hidden="true" />
             <div className="pull-overlay-text">
-              <strong>Updating Container Images</strong>
+              <strong>Updating OTForge</strong>
               <p>
-                Pulling the latest images for this scenario from the registry.
+                Pulling the latest source, dependencies, and container images.
                 <br />
                 This may take a few minutes depending on your connection speed.
               </p>
@@ -2356,23 +2366,49 @@ export default function App() {
           </div>
         </div>
       )}
-      {/* Update-complete toast — reuses the desktop-hint toast styling. */}
-      {updateNotice && (
-        <div className="desktop-hint-toast" role="status" aria-live="polite">
-          <div className="desktop-hint-toast-header">
-            <span className="desktop-hint-toast-title">✓ Images Updated</span>
-            <button
-              className="desktop-hint-toast-close"
-              onClick={() => {
-                if (updateNoticeTimerRef.current) clearTimeout(updateNoticeTimerRef.current)
-                setUpdateNotice(null)
-              }}
-              aria-label="Dismiss"
-            >
-              ×
-            </button>
+      {/*
+       * Restart prompt — shown after a successful "Update OTForge" run. The
+       * updated main/renderer bundles only take effect after a relaunch, so
+       * this is a confirmation dialog (not an auto-dismiss toast) with an
+       * explicit choice: restart now, or dismiss and restart later themselves.
+       */}
+      {showRestartPrompt && (
+        <div
+          role="alertdialog"
+          aria-label="Restart to apply update"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 600,
+            background: 'rgba(1, 4, 9, 0.7)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          <div
+            style={{
+              width: 'min(420px, 90vw)',
+              background: '#0d1117',
+              border: '1px solid #30363d',
+              borderRadius: 8,
+              padding: 20,
+              color: '#e6edf3'
+            }}
+          >
+            <strong style={{ fontSize: 16 }}>✓ OTForge Updated</strong>
+            <p style={{ marginTop: 8 }}>
+              The update is downloaded. Restart OTForge now to apply it, or restart later yourself.
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 16 }}>
+              <button className="btn btn-sm btn-ghost" onClick={() => setShowRestartPrompt(false)}>
+                Later
+              </button>
+              <button className="btn btn-sm btn-primary" onClick={handleRestartNow}>
+                Restart Now
+              </button>
+            </div>
           </div>
-          <div className="desktop-hint-toast-body">{updateNotice}</div>
         </div>
       )}
       {sessionOverlays}

--- a/packages/schema/src/ipc.ts
+++ b/packages/schema/src/ipc.ts
@@ -53,11 +53,6 @@ export interface SimulationStopResult {
   error?: string
 }
 
-export interface SimulationUpdateResult {
-  ok: boolean
-  error?: string
-}
-
 /**
  * Lightweight descriptor of a saved student session, returned by session:list.
  * Excludes the full scenario payload so the picker stays cheap to render.
@@ -107,6 +102,26 @@ export interface AppInfo {
   nodeVersion: string
   electronVersion: string
   platform: 'win32' | 'darwin' | 'linux'
+  /**
+   * True when running via `npm run dev` (electron-vite dev server) from a git
+   * checkout. False in a packaged build. The "Update OTForge" self-updater
+   * (app:update) only works in dev mode — a packaged build has no .git
+   * directory or workspace package.json to update.
+   */
+  isDev: boolean
+}
+
+/**
+ * Result of the "Update OTForge" self-updater (app:update): `git pull` +
+ * `npm install` in the project root, then (when a scenario is loaded and
+ * Docker is available) a `docker compose pull` for that scenario's images.
+ * `restartRequired` is true on success — the renderer should prompt the user
+ * to relaunch so the updated main/renderer bundles take effect.
+ */
+export interface AppUpdateResult {
+  ok: boolean
+  error?: string
+  restartRequired?: boolean
 }
 
 // ── PLC firmware import (Phase 9 add-on) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Supersedes the old scenario-scoped "Update Images" toolbar button. Agreed on 2026-07-05 but never built until now.

- Runs, in order: `git pull` in the project root, `npm install`, then (if a scenario is loaded and Docker is available) a `docker compose pull` for that scenario's images via the existing `DockerClient.updateImages()` path.
- Only available in dev mode (`npm run dev` from a git checkout) — a packaged build has no `.git` directory or workspace `package.json` to update, so `AppInfo` now carries `isDev` and the button only renders when it's true.
- Guards against a dirty working tree: `git status --porcelain` catches both uncommitted local edits and an unresolved merge conflict (conflicted files show as `UU` entries), so an instructor's local changes are never silently overwritten or merged over. `git pull` itself is the fallback safety net for anything the porcelain check misses.
- On success, shows a restart-confirmation dialog (not an auto-dismiss toast) since the updated main/renderer bundles only take effect after a relaunch via `app.relaunch()`.
- Removed the now-fully-superseded `simulation:updateImages` IPC handler, its preload method, the `simulationUpdateProgress` listener, and the `SimulationUpdateResult` type (all dead code after this change — confirmed unused before deleting).

## Test plan

- [x] `npm run typecheck` — clean (both packages)
- [x] `npx vitest run` (orchestrator) — 166/166 pass
- [x] `npm run lint` — no new warnings
- [x] **Verified live**: launched the real Electron app in dev mode, clicked the button with real uncommitted changes present on the branch — confirmed the full round-trip: button renders (gated on `isDev`), tooltip renders, the dirty-tree guard correctly blocks with the exact coded message ("You have uncommitted local changes..."), and the repo's working tree is untouched afterward (screenshot evidence in the session).
- [ ] **Not driven live**: the happy path (real `git pull` + `npm install` + container refresh + restart prompt) — running it for real would mutate the actual working repo/dependencies mid-verification. Recommend a manual test on a clean checkout with a pending upstream commit before relying on it with students.

🤖 Generated with [Claude Code](https://claude.com/claude-code)