### PR TITLE
feat(canvas): add Insider Threat mode for the attack machine

### DIFF
--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -1207,12 +1207,13 @@ export default function App() {
    * the instructor clicks Scenario Builder, fills in the metadata, and clicks Save.
    * After that, `builderModeActive = true` unlocks the DevicePalette and canvas.
    *
-   * @param updated - The new OTForgeMeta object from the form.
+   * @param updated       - The new OTForgeMeta object from the form.
+   * @param insiderThreat - The new scenario.security.insiderThreat value.
    */
-  const handleMetadataSave = useCallback((updated: OTForgeMeta) => {
+  const handleMetadataSave = useCallback((updated: OTForgeMeta, insiderThreat: boolean) => {
     setScenario(prev => {
       if (!prev) return prev
-      return { ...prev, meta: updated }
+      return { ...prev, meta: updated, security: { ...prev.security, insiderThreat } }
     })
     setBuilderModeActive(true) // Scenario Builder saved → activate builder/edit mode
     setShowMetadataModal(false)
@@ -1340,8 +1341,18 @@ export default function App() {
   const handleAttackMachineRemove = useCallback(() => {
     setScenario(prev => {
       if (!prev) return prev
+      // Only remove attack-machine devices that have no visual canvas node — an
+      // Insider Threat mode attack machine dropped onto a Purdue tab DOES have one
+      // and is removed like any other device (select + delete on canvas), which
+      // already prunes visual.nodes/edges together with devices.devices. Filtering
+      // on visual node presence here (rather than removing every attack-machine
+      // device unconditionally) avoids orphaning an insider-placed node's visual
+      // entry while its backing device silently disappears.
+      const visualNodeIds = new Set(prev.visual.nodes.map(n => n.id))
       const filtered = Object.fromEntries(
-        Object.entries(prev.devices.devices).filter(([, d]) => d.category !== 'attack-machine')
+        Object.entries(prev.devices.devices).filter(
+          ([nodeId, d]) => d.category !== 'attack-machine' || visualNodeIds.has(nodeId)
+        )
       )
       return { ...prev, devices: { devices: filtered } }
     })
@@ -1555,6 +1566,14 @@ export default function App() {
   const hasAttackMachine = attackDevices.length > 0
   // First attack machine — device object passed to handlers and the terminal modal
   const firstAttackDevice = (attackDevices[0]?.[1] as DeviceConfig) ?? null
+  // Non-visual attack machine (the default external-attacker one, added via this
+  // toolbar button) — distinct from an Insider Threat mode attack machine, which
+  // has its own visual canvas node and is added/removed via the palette/canvas
+  // like any other device. Gates the idle Add/Remove Attack Machine button so its
+  // label always matches what clicking it will actually do (see
+  // handleAttackMachineRemove).
+  const visualNodeIds = new Set(scenario?.visual.nodes.map(n => n.id) ?? [])
+  const hasNonVisualAttackMachine = attackDevices.some(([nodeId]) => !visualNodeIds.has(nodeId))
   const hasTutorial = !!scenario?.meta.tutorialSteps?.length
 
   // Engineering workstation helpers — first workstation device for the toolbar button
@@ -1948,16 +1967,18 @@ export default function App() {
             ) : (
               !simIsRunning && (
                 <button
-                  className={`btn btn-sm ${hasAttackMachine ? 'btn-attack-active' : 'btn-attack-add'}`}
-                  onClick={hasAttackMachine ? handleAttackMachineRemove : handleAttackMachineAdd}
+                  className={`btn btn-sm ${hasNonVisualAttackMachine ? 'btn-attack-active' : 'btn-attack-add'}`}
+                  onClick={
+                    hasNonVisualAttackMachine ? handleAttackMachineRemove : handleAttackMachineAdd
+                  }
                   disabled={simIsStarting || simIsStopping}
                   title={
-                    hasAttackMachine
+                    hasNonVisualAttackMachine
                       ? 'Remove the Kali Linux attack machine from this scenario'
                       : 'Add a Kali Linux attack machine to this scenario'
                   }
                 >
-                  {hasAttackMachine ? 'Remove Attack Machine' : 'Add Attack Machine'}
+                  {hasNonVisualAttackMachine ? 'Remove Attack Machine' : 'Add Attack Machine'}
                 </button>
               )
             )}
@@ -2123,6 +2144,7 @@ export default function App() {
             activeLayer={activeLayer}
             readOnly={false}
             packDeviceTypes={allPackDeviceTypes}
+            insiderThreatMode={scenario?.security.insiderThreat ?? false}
           />
         ) : (
           <CanvasViewHint simRunning={simIsRunning} />
@@ -2251,6 +2273,7 @@ export default function App() {
           // setState(initialValue) would not reinitialize from the new blank meta.
           key={scenario.meta.createdAt}
           meta={scenario.meta}
+          insiderThreat={scenario.security.insiderThreat ?? false}
           onSave={handleMetadataSave}
           onClose={handleMetadataClose}
         />

--- a/packages/app/src/renderer/src/canvas/LayerTabBar.tsx
+++ b/packages/app/src/renderer/src/canvas/LayerTabBar.tsx
@@ -119,7 +119,14 @@ function inferLayerFromCategory(category: string): PurdueLayerZone {
  *
  * Reads each CanvasNode's data.zone when visual positions are saved.
  * Falls back to category-based inference when no visual layer exists yet.
- * Attack machines (zone='attacker') are excluded from all counts.
+ *
+ * The default (non-Insider-Threat) attack machine has no visual node at all
+ * (added via the toolbar button, not the palette), so it never appears here
+ * regardless of which branch runs. An Insider Threat mode attack machine
+ * (scenario.security.insiderThreat, dropped from the palette onto a Purdue
+ * tab) DOES have a visual node whose data.zone is that real tab — e.g.
+ * 'enterprise' — so it counts normally in the branch below like any other
+ * device. Nothing here ever produces zone='attacker'; there is no 6th tab.
  *
  * @param scenario - The active scenario, or null.
  * @returns A map from PurdueLayerZone to device count.
@@ -139,7 +146,6 @@ function countDevicesByLayer(scenario: OTForgeScenario | null): Record<PurdueLay
     for (const node of scenario.visual.nodes) {
       const z = node.data.zone as NetworkZone
       if (z in counts) counts[z as PurdueLayerZone]++
-      // attacker zone nodes are silently excluded from tab counts
     }
   } else {
     // No visual data yet — infer from device category

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -1822,7 +1822,17 @@ export function ScadaCanvas({
       const device: DeviceConfig = {
         nodeId,
         category,
-        ipAddress: nextAvailableIp(zone, existingDevices),
+        // Attack machine always gets an attacker-zone IP regardless of which Purdue
+        // tab it's dropped on (Insider Threat mode — see scenario.security.insiderThreat).
+        // attacker-net is the one zone network created without internal: true, so this
+        // is what preserves real internet/host routing for Kali. The device's VISUAL
+        // zone (below, used for node.data.zone) still tracks the drop location — that's
+        // what compose-generator.ts reads to grant real access to that zone too, on top
+        // of the default attacker-net + internet-dmz-net legs.
+        ipAddress:
+          category === 'attack-machine'
+            ? nextAvailableIp('attacker', existingDevices)
+            : nextAvailableIp(zone, existingDevices),
         // Pack device types supply their own default protocols; built-ins use the map.
         protocols: packDeviceType?.defaultProtocols ?? DEFAULT_PROTOCOLS[category],
         // dockerImage override: pack device types specify the exact image to use.

--- a/packages/app/src/renderer/src/index.css
+++ b/packages/app/src/renderer/src/index.css
@@ -4291,6 +4291,23 @@ code.prop-value {
   margin-bottom: 4px;
 }
 
+.meta-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.meta-checkbox-label input[type='checkbox'] {
+  accent-color: var(--accent-red);
+  cursor: pointer;
+  width: 15px;
+  height: 15px;
+}
+
 .meta-input {
   background: var(--bg-panel);
   border: 1px solid var(--border);

--- a/packages/app/src/renderer/src/metadata/MetadataModal.tsx
+++ b/packages/app/src/renderer/src/metadata/MetadataModal.tsx
@@ -33,8 +33,14 @@ export const SECTOR_OPTIONS: { value: Sector; label: string }[] = [
 interface MetadataModalProps {
   /** Current scenario metadata to pre-populate the form. */
   meta: OTForgeMeta
-  /** Called with the updated meta object when the user clicks Save. */
-  onSave: (updated: OTForgeMeta) => void
+  /** Current scenario.security.insiderThreat value (defaults to false when unset). */
+  insiderThreat: boolean
+  /**
+   * Called with the updated meta object and insiderThreat flag when the user
+   * clicks Save. insiderThreat is a separate parameter (not part of meta)
+   * because it lives on scenario.security, not scenario.meta.
+   */
+  onSave: (updated: OTForgeMeta, insiderThreat: boolean) => void
   /** Called when the modal is dismissed without saving. */
   onClose: () => void
 }
@@ -49,12 +55,13 @@ interface MetadataModalProps {
  *   - Sector         — select; determines which sector-specific tools/icons apply.
  *   - Mission Brief  — multiline markdown; displayed in Student mode side panel.
  */
-export function MetadataModal({ meta, onSave, onClose }: MetadataModalProps) {
+export function MetadataModal({ meta, insiderThreat, onSave, onClose }: MetadataModalProps) {
   const [name, setName] = useState(meta.name)
   const [description, setDescription] = useState(meta.description)
   const [author, setAuthor] = useState(meta.author)
   const [sector, setSector] = useState<Sector>(meta.sector)
   const [brief, setBrief] = useState(meta.brief)
+  const [insider, setInsider] = useState(insiderThreat)
 
   /**
    * Ref to the Scenario Name input — focused automatically on mount so the user
@@ -87,15 +94,18 @@ export function MetadataModal({ meta, onSave, onClose }: MetadataModalProps) {
   function handleSave() {
     const trimmedName = name.trim()
     if (!trimmedName) return
-    onSave({
-      ...meta,
-      name: trimmedName,
-      description: description.trim(),
-      author: author.trim(),
-      sector,
-      brief: brief.trim(),
-      updatedAt: new Date().toISOString()
-    })
+    onSave(
+      {
+        ...meta,
+        name: trimmedName,
+        description: description.trim(),
+        author: author.trim(),
+        sector,
+        brief: brief.trim(),
+        updatedAt: new Date().toISOString()
+      },
+      insider
+    )
   }
 
   return (
@@ -186,6 +196,27 @@ export function MetadataModal({ meta, onSave, onClose }: MetadataModalProps) {
                 ))}
               </select>
             </div>
+          </div>
+
+          {/* Insider Threat Mode */}
+          <div className="meta-field">
+            <label className="meta-checkbox-label" htmlFor="meta-insider-threat">
+              <input
+                id="meta-insider-threat"
+                type="checkbox"
+                checked={insider}
+                onChange={e => setInsider(e.target.checked)}
+              />
+              Insider Threat Mode
+            </label>
+            <p className="meta-hint">
+              By default the attack machine represents an external attacker — it has no canvas node
+              and only reaches the internet-dmz zone, so students must pivot inward through a
+              realistic compromise chain. Enable this to instead place the attack machine directly
+              on any Purdue layer (dragged from the device palette like any other device), modeling
+              an attacker who already has an internal foothold. The layer it is placed on grants it
+              real network access there, in addition to its default legs.
+            </p>
           </div>
 
           {/* Mission Brief */}

--- a/packages/app/src/renderer/src/palette/DevicePalette.tsx
+++ b/packages/app/src/renderer/src/palette/DevicePalette.tsx
@@ -37,6 +37,13 @@ interface PaletteSection {
   items: { category: DeviceCategory; label: string }[]
   /** Which layers this section is shown on. Omit to show on all layers. */
   layers?: NetworkZone[]
+  /**
+   * When true, this section is only shown when scenario.security.insiderThreat
+   * is enabled — see the "Insider Threat" section below. Omit `layers` on such
+   * a section so it's eligible on every Purdue tab; DevicePalette's insiderThreatMode
+   * prop is the actual gate.
+   */
+  insiderOnly?: boolean
 }
 
 /**
@@ -201,6 +208,20 @@ const PALETTE: PaletteSection[] = [
       { category: 'dns-server', label: 'DNS Server' },
       { category: 'firewall', label: 'Firewall' }
     ]
+  },
+  // ── Insider Threat (scenario.security.insiderThreat only) ───────────────────
+  // No `layers` restriction — eligible on every Purdue tab. Normally the attack
+  // machine has no canvas node at all (added via the toolbar "Add Attack Machine"
+  // button, external-attacker model — see project_network_access_architecture).
+  // When insiderThreat is enabled, dragging this onto any tab places the attack
+  // machine there instead, granting it real network access to that zone in
+  // addition to its default attacker-net/internet-dmz-net legs (compose-generator.ts
+  // reads the dropped node's zone to add this — its IP stays in the attacker
+  // subnet regardless of drop location, preserving real internet/host routing).
+  {
+    label: 'Insider Threat',
+    insiderOnly: true,
+    items: [{ category: 'attack-machine', label: 'Attack Machine (Insider)' }]
   }
 ]
 
@@ -242,7 +263,9 @@ const PALETTE_COLORS: Partial<Record<DeviceCategory, string>> = {
   'email-server': '#f78166',
   'internet-server': '#f78166',
   // DNS server — same orange family as other Internet DMZ devices (Phase 12)
-  'dns-server': '#f78166'
+  'dns-server': '#f78166',
+  // Attack machine (Insider Threat mode) — matches LAYER_COLORS.attacker
+  'attack-machine': '#f85149'
 }
 
 /**
@@ -334,6 +357,12 @@ interface DevicePaletteProps {
    * bottom of the palette when any matching types are present.
    */
   packDeviceTypes?: ResolvedPackDeviceType[]
+  /**
+   * scenario.security.insiderThreat — gates the "Insider Threat" palette section
+   * (the attack machine, normally added only via the toolbar button with no
+   * canvas node, becomes a normal draggable item on every Purdue tab).
+   */
+  insiderThreatMode?: boolean
 }
 
 /**
@@ -347,13 +376,16 @@ interface DevicePaletteProps {
 export function DevicePalette({
   activeLayer,
   readOnly = false,
-  packDeviceTypes = []
+  packDeviceTypes = [],
+  insiderThreatMode = false
 }: DevicePaletteProps) {
   // In Student mode the MissionPanel occupies this column; hide the palette entirely.
   if (readOnly) return null
 
   const visibleSections = PALETTE.filter(
-    section => !section.layers || section.layers.includes(activeLayer)
+    section =>
+      (!section.layers || section.layers.includes(activeLayer)) &&
+      (!section.insiderOnly || insiderThreatMode)
   )
 
   // Filter pack device types to those whose category belongs to the active layer.

--- a/packages/orchestrator/src/__tests__/compose-generator.test.ts
+++ b/packages/orchestrator/src/__tests__/compose-generator.test.ts
@@ -421,6 +421,58 @@ describe('attack-machine device', () => {
   })
 })
 
+describe('attack-machine — Insider Threat mode (visual zone placement)', () => {
+  /**
+   * Insider Threat mode (scenario.security.insiderThreat) lets the attack machine
+   * be dropped from the palette directly onto an internal Purdue tab instead of
+   * added via the toolbar (which never creates a visual node — see
+   * ScadaCanvas.tsx onDrop). Its canvas node's zone should grant it a real,
+   * additional network leg there, on top of the default attacker-net +
+   * internet-dmz-net dual-homing every attack machine gets.
+   */
+  function insiderScenario(zone: NetworkZone): OTForgeScenario {
+    const scenario = makeScenario([
+      ['kali-1', { category: 'attack-machine', ipAddress: '10.200.60.10' }]
+    ])
+    scenario.visual.nodes = [
+      {
+        id: 'kali-1',
+        type: 'attack-machine',
+        position: { x: 0, y: 0 },
+        data: { label: 'Kali', zone }
+      }
+    ]
+    return scenario
+  }
+
+  it('adds the dropped-tab zone as a third network leg', () => {
+    const compose = gen(insiderScenario('enterprise'))
+    const nets = Object.keys(compose.services['kali-1'].networks)
+    expect(nets).toEqual(
+      expect.arrayContaining(['attacker-net', 'internet-dmz-net', 'enterprise-net'])
+    )
+  })
+
+  it('assigns the insider leg an IP in the .200-.239 extra-network range', () => {
+    const compose = gen(insiderScenario('enterprise'))
+    expect(compose.services['kali-1'].networks['enterprise-net'].ipv4_address).toBe('10.200.40.200')
+  })
+
+  it('does not duplicate/conflict when dropped on the internet-dmz tab (already a default leg)', () => {
+    const compose = gen(insiderScenario('internet-dmz'))
+    const nets = Object.keys(compose.services['kali-1'].networks)
+    expect(nets).toEqual(['attacker-net', 'internet-dmz-net'])
+  })
+
+  it('still attaches only the two default legs when no visual node exists (default external-attacker case)', () => {
+    const compose = gen(
+      makeScenario([['kali-1', { category: 'attack-machine', ipAddress: '10.200.60.10' }]])
+    )
+    const nets = Object.keys(compose.services['kali-1'].networks)
+    expect(nets).toEqual(['attacker-net', 'internet-dmz-net'])
+  })
+})
+
 // ── PLC port publishing ───────────────────────────────────────────────────────
 
 describe('PLC port publishing', () => {

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -746,6 +746,31 @@ export function generateCompose(
         'attacker-net': { ipv4_address: device.ipAddress },
         'internet-dmz-net': { ipv4_address: `${internetDmzBase}.250` }
       }
+
+      // Insider Threat mode (scenario.security.insiderThreat): the attack machine
+      // was dragged from the palette directly onto an internal Purdue tab instead
+      // of added via the toolbar (which has no visual node at all — see
+      // ScadaCanvas.tsx's onDrop, which keeps this device's IP in the attacker
+      // subnet regardless of drop location specifically so the dual-homing above
+      // still works). Its canvas node's zone records where it was placed; grant
+      // real Docker network access there too, on top of the two legs above, using
+      // the same auto-IP-in-.200-.239 convention as the generic extraNetworks
+      // handling further down this loop. 'attacker'/'internet-dmz' are skipped —
+      // already covered by the two legs above.
+      const insiderZone = scenario.visual.nodes.find(n => n.id === nodeId)?.data.zone
+      if (insiderZone && insiderZone !== 'attacker' && insiderZone !== 'internet-dmz') {
+        const insiderNetName = `${insiderZone}-net`
+        const insiderBase = effectiveZones[insiderZone].subnet.replace('.0/24', '')
+        let insiderHost = 200
+        const usedSet = usedIpsPerNet.get(insiderNetName) ?? new Set<number>()
+        while (usedSet.has(insiderHost) && insiderHost < 240) insiderHost++
+        usedSet.add(insiderHost)
+        usedIpsPerNet.set(insiderNetName, usedSet)
+        services[serviceName].networks[insiderNetName] = {
+          ipv4_address: `${insiderBase}.${insiderHost}`
+        }
+      }
+
       services[serviceName].cap_add = ['NET_ADMIN', 'NET_RAW']
       // Port 6080: noVNC WebSocket bridge served by our custom otforge-attack-base image
       services[serviceName].ports = [`${webPort}:6080`]

--- a/packages/schema/src/icslab.ts
+++ b/packages/schema/src/icslab.ts
@@ -792,6 +792,23 @@ export interface SecurityLayer {
     influxdbEnabled: boolean
     lokiEnabled: boolean
   }
+  /**
+   * When true, the attack machine can be placed directly on any Purdue layer
+   * tab (dragged from the device palette like any other device) to model an
+   * insider threat — an attacker who already has a foothold inside the
+   * network, rather than the default external-attacker kill-chain model where
+   * the attack machine has no visual canvas node and only reaches the
+   * internet-dmz zone.
+   *
+   * compose-generator.ts detects an attack-machine device whose canvas zone
+   * (from scenario.visual.nodes) differs from the default 'attacker' zone and
+   * automatically adds that zone to the device's extraNetworks, so the
+   * placement grants real Docker network access, not just a visual position.
+   *
+   * Defaults to false/undefined so existing scenarios keep the external-only
+   * behavior unless an author explicitly opts in.
+   */
+  insiderThreat?: boolean
 }
 
 // ── Device type registry ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #38, with a design change from the literal request.

The reporter asked to restore the removed attacker-subnet tab so the attack machine could be wired to any Purdue layer. That tab was removed deliberately — the attack machine models an external attacker who must pivot inward through a realistic compromise chain (only reaching internet-dmz directly). Restoring a free-standing tab would let students just wire it straight to any internal device, undermining that lesson.

Instead: a new `scenario.security.insiderThreat` toggle (Edit Scenario modal) lets an author place the attack machine directly onto any **existing** Purdue tab — dragged from the palette like any other device — instead of adding a 6th tab. The canvas has no cross-tab wiring (`onConnect` only works between nodes visible on the same tab — confirmed by reading `scenarioToEdges`'s same-layer filter), so this is the only design that actually lets an insider-placed attacker be wired to devices on its own Purdue layer.

The placement grants **real** Docker network access, not just a visual position: `compose-generator.ts` reads the dropped node's canvas zone and adds it as a third network leg (auto-IP in the existing `.200-.239` extra-network range), on top of the default `attacker-net` + `internet-dmz-net` dual-homing every attack machine gets. The device's IP stays in the attacker subnet regardless of where it's dropped (`ScadaCanvas.tsx` `onDrop` special-cases this) specifically so it keeps real internet/host routing — `attacker-net` is the one zone network created without `internal: true`.

Also fixed a related dangling-reference risk found while implementing this: the toolbar "Remove Attack Machine" button removed every attack-machine device unconditionally, which would have orphaned an insider-placed device's visual canvas node (only its backing `DeviceConfig` would disappear) if both kinds coexisted. Scoped it to non-visual devices only — an insider-placed one is now removed like any other device, by selecting and deleting its node.

## Test plan

- [x] `npm run typecheck` — clean (all packages)
- [x] `npm run lint` — no new warnings
- [x] `npx vitest run` (orchestrator) — 170/170 pass (4 new tests covering the network-leg derivation: correct 3rd leg, correct `.200` IP, no duplicate leg when dropped on internet-dmz, unchanged default behavior with no visual node)
- [x] **Verified live**: built and ran the real app, enabled Insider Threat Mode, dragged the attack machine onto the Enterprise tab, confirmed the Properties Panel showed `zone: enterprise` / `IP: 10.200.60.10` (attacker subnet preserved), then ran the actual simulation and confirmed via `docker inspect` that the `enterprise-net` leg is genuinely attached to the running container

🤖 Generated with [Claude Code](https://claude.com/claude-code)