### PR TITLE
fix(app): stop Update OTForge's relaunch from hanging the app

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -152,6 +152,13 @@ function getProjectRoot(): string {
  * Windows resolve `npm` (a .cmd shim) the same way `git` resolves as a normal
  * binary, without hardcoding a platform-specific executable name.
  *
+ * `command` and `args` are joined into a single string rather than passed as
+ * `spawn(command, args, { shell: true })` — Node deprecates (DEP0190) passing a
+ * separate args array alongside shell: true, since the shell only ever sees the
+ * concatenated string anyway (no real escaping happens). Safe here because
+ * every caller passes fixed literal tokens ('pull', 'install', ...), never
+ * user-supplied or path-derived values that could contain shell metacharacters.
+ *
  * Rejects with an Error including the last few output lines if the process
  * exits non-zero, so the renderer can show a useful message instead of a bare
  * exit code.
@@ -164,7 +171,7 @@ function runStreamedCommand(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const allLines: string[] = []
-    const child = spawn(command, args, { cwd, shell: true })
+    const child = spawn([command, ...args].join(' '), { cwd, shell: true })
 
     const processChunk = (buf: Buffer): void => {
       buf
@@ -653,8 +660,13 @@ function registerIPCHandlers(): void {
    * porcelain check misses (e.g. diverged history) — it fails loudly rather
    * than force-merging.
    *
-   * On success, restartRequired is always true — the updated main/renderer
-   * bundles only take effect after a relaunch. Progress lines are streamed to
+   * On success, restartRequired is always true, purely as a signal for the
+   * renderer's informational message — nothing calls app.relaunch() here.
+   * electron-vite dev already watches main/preload source files and restarts
+   * the Electron process on its own the instant git pull changes them, so a
+   * manual relaunch would race that automatic one; confirmed live that doing
+   * so hangs the relaunched instance (it starts without the dev-server context
+   * electron-vite's own supervisor sets up). Progress lines are streamed to
    * the renderer over 'app:updateProgress'.
    */
   ipcMain.handle('app:update', async (_e, scenario?: OTForgeScenario): Promise<AppUpdateResult> => {
@@ -712,21 +724,20 @@ function registerIPCHandlers(): void {
         send('No scenario loaded — skipping container image refresh.')
       }
 
+      // No automatic app.relaunch()/app.exit() here — deliberately. electron-vite
+      // dev already watches main/preload source files and restarts the Electron
+      // process on its own the moment git pull changes them; the pull above
+      // already happened by the time we get here, so that restart is already
+      // in flight (or was already applied, if nothing main-process-side
+      // changed). A manual relaunch races that automatic one — confirmed to
+      // hang the relaunched instance (it launched without the dev server
+      // context electron-vite's own supervisor sets up). restartRequired
+      // stays as a signal for the renderer's informational message, not an
+      // instruction to actually call anything.
       return { ok: true, restartRequired: true }
     } catch (err) {
       return { ok: false, error: `Update failed: ${(err as Error).message}` }
     }
-  })
-
-  /**
-   * Relaunches the app — used by the "Restart to apply" prompt after
-   * app:update completes. Separate from app:update itself so the renderer can
-   * show a confirmation prompt before the process actually restarts, rather
-   * than the window disappearing out from under the update-complete message.
-   */
-  ipcMain.handle('app:relaunch', (): void => {
-    app.relaunch()
-    app.exit(0)
   })
 
   // ── Docker health check ───────────────────────────────────────────────────────

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -72,10 +72,7 @@ const api = {
      *   refreshed too); omit to only update source + dependencies.
      */
     update: (scenario?: OTForgeScenario): Promise<AppUpdateResult> =>
-      ipcRenderer.invoke('app:update', scenario),
-
-    /** Relaunches the app — call after app:update succeeds and the user confirms. */
-    relaunch: (): Promise<void> => ipcRenderer.invoke('app:relaunch')
+      ipcRenderer.invoke('app:update', scenario)
   },
 
   // ── Docker health ─────────────────────────────────────────────────────────────

--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -1457,8 +1457,8 @@ export default function App() {
    * `docker compose pull` for that scenario's images. Only enabled in dev mode
    * (appInfo.isDev) and while the simulation is idle.
    *
-   * On success, shows the restart prompt — the updated main/renderer bundles
-   * only take effect after a relaunch.
+   * On success, shows a purely informational update-complete notice — see the
+   * comment above that dialog for why there is no automatic relaunch.
    */
   const handleUpdateOTForge = useCallback(async () => {
     setSimError(null)
@@ -1478,11 +1478,6 @@ export default function App() {
       setUpdateProgress('')
     }
   }, [scenario])
-
-  /** Relaunches the app after the user confirms the post-update restart prompt. */
-  const handleRestartNow = useCallback(() => {
-    void window.electronAPI.app.relaunch()
-  }, [])
 
   /**
    * Stops the simulation:
@@ -2390,15 +2385,19 @@ export default function App() {
         </div>
       )}
       {/*
-       * Restart prompt — shown after a successful "Update OTForge" run. The
-       * updated main/renderer bundles only take effect after a relaunch, so
-       * this is a confirmation dialog (not an auto-dismiss toast) with an
-       * explicit choice: restart now, or dismiss and restart later themselves.
+       * Update-complete notice — shown after a successful "Update OTForge" run.
+       * Purely informational: electron-vite dev already watches main/preload
+       * source files and restarts Electron on its own the instant git pull
+       * changes them, so there is no "Restart Now" action to offer — a manual
+       * app.relaunch() here would race that automatic restart and hang
+       * (confirmed live). If nothing seems to happen within a few seconds
+       * (e.g. only renderer files changed, which Vite HMRs without a restart
+       * at all), the user's fallback is to stop and re-run `npm run dev`.
        */}
       {showRestartPrompt && (
         <div
           role="alertdialog"
-          aria-label="Restart to apply update"
+          aria-label="Update complete"
           style={{
             position: 'fixed',
             inset: 0,
@@ -2421,14 +2420,16 @@ export default function App() {
           >
             <strong style={{ fontSize: 16 }}>✓ OTForge Updated</strong>
             <p style={{ marginTop: 8 }}>
-              The update is downloaded. Restart OTForge now to apply it, or restart later yourself.
+              The update is downloaded. OTForge will restart automatically in a few seconds if
+              anything in the app itself changed. If it does not, stop this process and run{' '}
+              <code>npm run dev</code> again to apply it.
             </p>
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 16 }}>
-              <button className="btn btn-sm btn-ghost" onClick={() => setShowRestartPrompt(false)}>
-                Later
-              </button>
-              <button className="btn btn-sm btn-primary" onClick={handleRestartNow}>
-                Restart Now
+              <button
+                className="btn btn-sm btn-primary"
+                onClick={() => setShowRestartPrompt(false)}
+              >
+                Got it
               </button>
             </div>
           </div>

--- a/packages/schema/src/ipc.ts
+++ b/packages/schema/src/ipc.ts
@@ -115,8 +115,14 @@ export interface AppInfo {
  * Result of the "Update OTForge" self-updater (app:update): `git pull` +
  * `npm install` in the project root, then (when a scenario is loaded and
  * Docker is available) a `docker compose pull` for that scenario's images.
- * `restartRequired` is true on success — the renderer should prompt the user
- * to relaunch so the updated main/renderer bundles take effect.
+ *
+ * `restartRequired` is true on success but is informational only — nothing
+ * calls app.relaunch(). electron-vite dev already watches main/preload
+ * source files and restarts Electron on its own the instant git pull changes
+ * them; a manual relaunch races that automatic one and hangs (confirmed
+ * live — the manually relaunched instance starts without the dev-server
+ * context electron-vite's own supervisor sets up). The renderer just shows
+ * an informational message when this is true.
  */
 export interface AppUpdateResult {
   ok: boolean


### PR DESCRIPTION
## Summary

Reported after using the feature for real: everything works up until clicking "Restart App," then the reopened window hangs. Manually stopping and re-running `npm run dev` works fine, which was the key clue.

**Root cause:** `electron-vite dev` already watches main/preload source files and restarts the Electron process on its own the instant `git pull` changes them. The IPC handler's `app.relaunch()` + `app.exit(0)` raced that automatic restart — the manually relaunched instance starts without the dev-server context electron-vite's own supervisor sets up (e.g. `ELECTRON_RENDERER_URL`), so it hangs instead of loading. This is inherent to `npm run dev`'s process model (electron-vite's CLI is the actual supervisor, not the Electron process itself), not something a different relaunch() call ordering can fix — the self-update feature is dev-mode only in the first place (packaged builds have no `.git` to update), so there's no non-conflicting path to trigger it.

**Fix:** removed the `app:relaunch` IPC handler, its preload method, and the renderer's "Restart Now" action entirely. The post-update dialog is now purely informational: OTForge restarts on its own (electron-vite's watcher) if main/preload files changed, or nothing needs to happen at all if only renderer files changed (already Vite-HMR'd) — the fallback for either case not visibly working is to stop and re-run `npm run dev`, which was already confirmed to work.

**Also fixed:** a real Node deprecation warning (DEP0190) surfaced while testing this — `runStreamedCommand` was passing `spawn()` a separate args array alongside `shell: true`, which Node warns against since the shell only ever sees the concatenated string anyway. Joined command+args into a single string instead — safe here since every caller passes fixed literal tokens (`'pull'`, `'install'`), never user-supplied values.

## Test plan

- [x] `npm run typecheck` — clean (all packages)
- [x] `npm run lint` — no new warnings
- [x] `npx vitest run` (orchestrator) — 170/170 pass
- [x] **Verified live**: built and ran the real app, clicked Update OTForge with a clean git tree — confirmed the full flow (git pull → npm install → informational "OTForge Updated" dialog with only a "Got it" button, no restart action) completes correctly, and clicking "Got it" leaves the app fully interactive (switched Purdue tabs afterward to confirm genuine responsiveness, not a frozen frame) — no hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)