### PR TITLE
Fix Update OTForge: false auto-restart promise never resolves

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -691,14 +691,20 @@ function registerIPCHandlers(): void {
    * check misses (e.g. diverged history) — it fails loudly rather than
    * force-merging.
    *
-   * On success, restartRequired is always true, purely as a signal for the
-   * renderer's informational message — nothing calls app.relaunch() here.
-   * electron-vite dev already watches main/preload source files and restarts
-   * the Electron process on its own the instant git pull changes them, so a
-   * manual relaunch would race that automatic one; confirmed live that doing
-   * so hangs the relaunched instance (it starts without the dev-server context
-   * electron-vite's own supervisor sets up). Progress lines are streamed to
-   * the renderer over 'app:updateProgress'.
+   * Whether a restart is actually needed is decided by comparing the git HEAD
+   * commit before and after `git pull` — if it moved, source changed and the
+   * running process is stale. (electron-vite dev's own file watcher was
+   * assumed to auto-restart Electron on a main-process change from `git pull`;
+   * confirmed live with a real dev server that it does not, so this handler
+   * owns the restart decision entirely rather than relying on that.) When a
+   * restart is needed, a native dialog tells the user to run `npm run dev`
+   * again, then the app exits right after. Deliberately not spawning `npm run
+   * dev` back up automatically — that would mean handing off to a detached
+   * process the user can't see the console output of, right as this one
+   * disappears; simpler and more transparent to have the user run it
+   * themselves. When nothing changed, a native "already up to date" dialog is shown
+   * instead and the app keeps running. Progress lines are streamed to the
+   * renderer over 'app:updateProgress' throughout.
    */
   ipcMain.handle('app:update', async (_e, scenario?: OTForgeScenario): Promise<AppUpdateResult> => {
     if (!is.dev) {
@@ -730,8 +736,13 @@ function registerIPCHandlers(): void {
     }
 
     try {
+      const { stdout: beforeHead } = await execAsync('git rev-parse HEAD', { cwd: projectRoot })
+
       send('Pulling latest source (git pull)...')
       await runStreamedCommand('git', ['pull'], projectRoot, send)
+
+      const { stdout: afterHead } = await execAsync('git rev-parse HEAD', { cwd: projectRoot })
+      const restartRequired = beforeHead.trim() !== afterHead.trim()
 
       send('Installing dependencies (npm install)...')
       await runStreamedCommand('npm', ['install'], projectRoot, send)
@@ -757,17 +768,27 @@ function registerIPCHandlers(): void {
         send('No scenario loaded — skipping container image refresh.')
       }
 
-      // No automatic app.relaunch()/app.exit() here — deliberately. electron-vite
-      // dev already watches main/preload source files and restarts the Electron
-      // process on its own the moment git pull changes them; the pull above
-      // already happened by the time we get here, so that restart is already
-      // in flight (or was already applied, if nothing main-process-side
-      // changed). A manual relaunch races that automatic one — confirmed to
-      // hang the relaunched instance (it launched without the dev server
-      // context electron-vite's own supervisor sets up). restartRequired
-      // stays as a signal for the renderer's informational message, not an
-      // instruction to actually call anything.
-      return { ok: true, restartRequired: true }
+      if (restartRequired) {
+        await dialog.showMessageBox(mainWindow!, {
+          type: 'info',
+          title: 'OTForge Updated',
+          message: 'Update downloaded — restart required',
+          detail:
+            "This update changed OTForge's own code, so it needs to restart to take effect.\n\n" +
+            'Click OK, then stop this process (Ctrl+C) and run `npm run dev` again.',
+          buttons: ['OK']
+        })
+        app.exit(0)
+      } else {
+        await dialog.showMessageBox(mainWindow!, {
+          type: 'info',
+          title: 'OTForge',
+          message: 'OTForge is already up to date.',
+          buttons: ['OK']
+        })
+      }
+
+      return { ok: true, restartRequired }
     } catch (err) {
       return { ok: false, error: `Update failed: ${(err as Error).message}` }
     }

--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -540,12 +540,6 @@ export default function App() {
   const [updating, setUpdating] = useState<boolean>(false)
   /** Most recent output line (git/npm/docker) — shown in the update overlay. */
   const [updateProgress, setUpdateProgress] = useState<string>('')
-  /**
-   * Shown after a successful "Update OTForge" run — the updated main/renderer
-   * bundles only take effect after a relaunch, so this prompts the user to
-   * restart now (via app.relaunch()) or dismiss and restart later themselves.
-   */
-  const [showRestartPrompt, setShowRestartPrompt] = useState<boolean>(false)
 
   // attackLaunched state removed — toolbar button now opens AttackTerminalModal directly
   // so button color uses (attackTerminalDevice !== null) instead of a separate flag.
@@ -1457,8 +1451,11 @@ export default function App() {
    * `docker compose pull` for that scenario's images. Only enabled in dev mode
    * (appInfo.isDev) and while the simulation is idle.
    *
-   * On success, shows a purely informational update-complete notice — see the
-   * comment above that dialog for why there is no automatic relaunch.
+   * On success, the main process itself shows a native "Restart required" or
+   * "Already up to date" dialog and, when a restart is required, exits the
+   * app right after — nothing further to do here on success. If the app is
+   * exiting, this promise may never resolve; the `finally` block simply never
+   * runs in that case, which is harmless since the window is closing anyway.
    */
   const handleUpdateOTForge = useCallback(async () => {
     setSimError(null)
@@ -1466,9 +1463,7 @@ export default function App() {
     setUpdating(true)
     try {
       const result = await window.electronAPI.app.update(scenario ?? undefined)
-      if (result.ok) {
-        setShowRestartPrompt(true)
-      } else {
+      if (!result.ok) {
         setSimError(result.error ?? 'Update failed.')
       }
     } catch (err) {
@@ -2380,57 +2375,6 @@ export default function App() {
                 This may take a few minutes depending on your connection speed.
               </p>
               {updateProgress && <p className="pull-progress-line">{updateProgress}</p>}
-            </div>
-          </div>
-        </div>
-      )}
-      {/*
-       * Update-complete notice — shown after a successful "Update OTForge" run.
-       * Purely informational: electron-vite dev already watches main/preload
-       * source files and restarts Electron on its own the instant git pull
-       * changes them, so there is no "Restart Now" action to offer — a manual
-       * app.relaunch() here would race that automatic restart and hang
-       * (confirmed live). If nothing seems to happen within a few seconds
-       * (e.g. only renderer files changed, which Vite HMRs without a restart
-       * at all), the user's fallback is to stop and re-run `npm run dev`.
-       */}
-      {showRestartPrompt && (
-        <div
-          role="alertdialog"
-          aria-label="Update complete"
-          style={{
-            position: 'fixed',
-            inset: 0,
-            zIndex: 600,
-            background: 'rgba(1, 4, 9, 0.7)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}
-        >
-          <div
-            style={{
-              width: 'min(420px, 90vw)',
-              background: '#0d1117',
-              border: '1px solid #30363d',
-              borderRadius: 8,
-              padding: 20,
-              color: '#e6edf3'
-            }}
-          >
-            <strong style={{ fontSize: 16 }}>✓ OTForge Updated</strong>
-            <p style={{ marginTop: 8 }}>
-              The update is downloaded. OTForge will restart automatically in a few seconds if
-              anything in the app itself changed. If it does not, stop this process and run{' '}
-              <code>npm run dev</code> again to apply it.
-            </p>
-            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 16 }}>
-              <button
-                className="btn btn-sm btn-primary"
-                onClick={() => setShowRestartPrompt(false)}
-              >
-                Got it
-              </button>
             </div>
           </div>
         </div>

--- a/packages/schema/src/ipc.ts
+++ b/packages/schema/src/ipc.ts
@@ -116,13 +116,14 @@ export interface AppInfo {
  * `npm install` in the project root, then (when a scenario is loaded and
  * Docker is available) a `docker compose pull` for that scenario's images.
  *
- * `restartRequired` is true on success but is informational only — nothing
- * calls app.relaunch(). electron-vite dev already watches main/preload
- * source files and restarts Electron on its own the instant git pull changes
- * them; a manual relaunch races that automatic one and hangs (confirmed
- * live — the manually relaunched instance starts without the dev-server
- * context electron-vite's own supervisor sets up). The renderer just shows
- * an informational message when this is true.
+ * `restartRequired` reflects whether `git pull` actually moved the local
+ * HEAD commit — i.e. whether source changed and the running process is now
+ * stale. The main process itself decides what to do with this: it shows a
+ * native "restart required" or "already up to date" dialog and, when a
+ * restart is required, calls app.exit() right after the user dismisses the
+ * dialog. The renderer does not need to react to this field at all — by the
+ * time app:update's promise resolves, the user has already been told
+ * everything they need to know.
  */
 export interface AppUpdateResult {
   ok: boolean


### PR DESCRIPTION
## Summary
- Verified live (real dev server, two different file-write methods) that electron-vite dev's main-process watcher does **not** restart Electron when `git pull` changes `main/index.ts` — confirmed zero rebuild activity over repeated ~20s waits. The prior "will restart automatically in a few seconds" message was therefore always hitting its own fallback case, leaving users staring at a dialog that never resolved.
- `app:update` now compares git HEAD before/after `git pull` to decide whether a restart is actually needed, instead of assuming one always is.
- When a restart is needed: a native `dialog.showMessageBox` tells the user to run `npm run dev` again, then `app.exit(0)` is called right after they dismiss it.
- When nothing changed: a native "OTForge is already up to date" dialog is shown instead, and the app keeps running (no exit).
- Removed the renderer-side informational modal and `showRestartPrompt` state entirely — the main process now owns the whole completion UX via the same `dialog.showMessageBox` pattern already used for the memory-warning dialog in this file.

## Test plan
- [x] `npm run typecheck` clean in `packages/app`
- [x] `packages/schema` build clean
- [x] eslint clean on all three changed files
- [ ] Manual: click Update OTForge with nothing new upstream → confirm "already up to date" dialog appears and the app stays open/interactive afterward
- [ ] Manual: click Update OTForge when a real upstream commit exists → confirm "restart required" dialog appears, and clicking OK closes the app cleanly

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>