### PR TITLE
Add PROFINET DCP device — automotive/discrete-mfg schema gap

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,6 +46,8 @@ jobs:
             context: containers/iec61850
           - image: otforge-ethernetip
             context: containers/ethernetip
+          - image: otforge-profinet
+            context: containers/profinet
           - image: otforge-firewall
             context: containers/firewall
           - image: otforge-switch

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ scenarios/custom/
 # at least one student (likely from running a packaged build once) and, being
 # untracked, used to permanently trip the "Update OTForge" dirty-tree guard.
 resources.pak
+# Python bytecode cache — appears if anyone runs `python3 -m py_compile` locally
+# against a containers/*/server.py while testing.
+__pycache__/
+*.pyc

--- a/containers/profinet/Dockerfile
+++ b/containers/profinet/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.12-alpine
+
+# iproute2 provides the `ip` binary entrypoint.sh uses to set the container's
+# interface into promiscuous mode — required to receive DCP-Identify multicast
+# frames (destination MAC 01:0E:CF:00:00:00), which the kernel otherwise drops
+# before they reach our raw AF_PACKET socket (same fix already applied to
+# containers/zeek for the same underlying reason — see project_zeek_capture_fix).
+RUN apk add --no-cache iproute2
+
+WORKDIR /app
+
+COPY server.py .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+# Defaults — all overridable via docker-compose environment:
+ENV DEVICE_ID=profinet-1 \
+    DEVICE_CATEGORY=profinet-device \
+    PROFINET_IFACE=eth0 \
+    PROFINET_STATION_NAME=profinet-device-1 \
+    PROFINET_VENDOR_ID=42 \
+    PROFINET_DEVICE_ID=1
+
+# DCP runs directly over raw Ethernet (EtherType 0x8892) — no TCP/UDP port to expose.
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/containers/profinet/entrypoint.sh
+++ b/containers/profinet/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+echo "[ics-profinet] Device=${DEVICE_ID}  category=${DEVICE_CATEGORY}  iface=${PROFINET_IFACE}  station=${PROFINET_STATION_NAME}"
+
+# DCP-Identify requests go to multicast MAC 01:0E:CF:00:00:00, which the kernel
+# drops before it reaches our raw AF_PACKET socket unless the interface is in
+# promiscuous mode (the container never explicitly joins that multicast group).
+# Same reasoning/fix as containers/zeek's ZEEK_IFACE promisc handling.
+ip link set "${PROFINET_IFACE}" promisc on 2>/dev/null \
+    && echo "[ics-profinet] ${PROFINET_IFACE} set to promiscuous mode" \
+    || echo "[ics-profinet] Warning: could not set promisc on ${PROFINET_IFACE}"
+
+exec python3 /app/server.py

--- a/containers/profinet/server.py
+++ b/containers/profinet/server.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""
+server.py — PROFINET DCP (Discovery and Configuration Protocol) IO device.
+
+Implements DCP only, over a raw AF_PACKET Ethernet socket (EtherType 0x8892 —
+no IP/UDP framing at all, straight Ethernet payload). PROFINET's full stack
+has two more layers above this:
+    - Context Manager (DCE/RPC over UDP 34964) — establishes the Application
+      Relationship (AR) between an IO Controller (PLC) and this IO Device
+      before any process data can flow.
+    - RT (Real-Time) cyclic data — raw Ethernet frames, sub-millisecond cycle
+      times, the actual I/O exchange a live PLC would scan.
+Both are a much larger undertaking (real-time framing + connection-oriented
+state machine) — the same kind of scope cut this project already made for
+EtherNet/IP Class 1 cyclic I/O and IEC 61850 GOOSE/Sampled Values.
+
+DCP on its own is still a complete, real, and pedagogically useful protocol
+surface: it is how every PROFINET engineering tool (Siemens' Primary Setup
+Tool, TIA Portal's "Accessible Devices") discovers devices on a segment and
+assigns their station name / IP address — and it does so with **zero
+authentication**. Anyone on the same Ethernet segment can:
+    - Identify (fingerprint) every PROFINET device with one multicast frame.
+    - Set (rename) a device's NameOfStation.
+    - Set (reassign) a device's IP address.
+    - Reset a device to factory settings.
+This device implements all four, faithfully reproducing that lack of
+authentication — the same property this project's other protocol servers
+(EtherNet/IP Set_Attribute_Single, IEC 61850 SetDataValues) demonstrate.
+
+Services implemented (DCP ServiceID):
+    Identify (5) — multicast request (dst MAC 01:0E:CF:00:00:00), unicast
+                   response carrying NameOfStation, Device ID, Device Role,
+                   and IP Parameter blocks — a complete device fingerprint.
+    Get      (3) — unicast request for specific blocks, or all of them.
+    Set      (4) — unicast request to change NameOfStation, IP Parameter,
+                   trigger Reset to Factory Settings, or Flash (Signal) the
+                   device's identification LED (logged only — no real LED).
+    Hello    (6) — sent once at startup (unsolicited device announcement);
+                   received Hello frames from other devices are logged only.
+
+Environment variables (all have defaults):
+    DEVICE_ID             — string label used in logging
+    DEVICE_CATEGORY       — device category for traceability
+    PROFINET_IFACE        — network interface to bind the raw socket to (default eth0)
+    PROFINET_STATION_NAME — initial NameOfStation
+    PROFINET_VENDOR_ID    — 16-bit Vendor ID reported in the Device ID block
+    PROFINET_DEVICE_ID    — 16-bit Device ID reported in the Device ID block
+
+Protocol reference: IEC 61158-6-10 (PROFINET DCP), IEC 61784-2. FrameIDs and
+block layout also documented in Wireshark's packet-dcp.c dissector.
+"""
+
+import logging
+import os
+import socket
+import struct
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("ics-profinet")
+
+DEVICE_ID_LABEL = os.getenv("DEVICE_ID", "profinet-1")
+CATEGORY        = os.getenv("DEVICE_CATEGORY", "profinet-device")
+IFACE           = os.getenv("PROFINET_IFACE", "eth0")
+VENDOR_ID       = int(os.getenv("PROFINET_VENDOR_ID", "42"))
+DEVICE_ID_NUM   = int(os.getenv("PROFINET_DEVICE_ID", "1"))
+DEFAULT_STATION_NAME = os.getenv("PROFINET_STATION_NAME", "profinet-device-1")
+
+# ── Wire-format constants ─────────────────────────────────────────────────────
+ETHERTYPE_PROFINET = 0x8892
+DCP_MULTICAST_MAC = bytes.fromhex("010ECF000000")
+
+# DCP FrameIDs (2 bytes, immediately after the Ethernet EtherType)
+FRAME_ID_HELLO       = 0xFEFF
+FRAME_ID_IDENTIFY_REQ = 0xFEFE
+FRAME_ID_IDENTIFY_RSP = 0xFEFD
+FRAME_ID_GET_SET     = 0xFEFC
+
+# DCP ServiceID
+SVC_GET      = 3
+SVC_SET      = 4
+SVC_IDENTIFY = 5
+SVC_HELLO    = 6
+
+# DCP ServiceType
+SVC_TYPE_REQUEST  = 0
+SVC_TYPE_RESPONSE = 1
+
+# DCP Option/Suboption pairs implemented here
+OPT_IP = 1
+SUBOPT_IP_PARAMETER = 2
+
+OPT_DEVICE_PROPERTIES = 2
+SUBOPT_NAME_OF_STATION = 1
+SUBOPT_DEVICE_ID = 2
+SUBOPT_DEVICE_ROLE = 3
+
+OPT_CONTROL = 5
+SUBOPT_CONTROL_RESET_FACTORY = 3
+SUBOPT_CONTROL_SIGNAL = 4
+
+OPT_ALL_SELECTOR = 0xFF
+SUBOPT_ALL_SELECTOR = 0xFF
+
+# ── Device state (mutable via unauthenticated DCP Set — faithful to the real protocol) ──
+_state = {
+    "station_name": DEFAULT_STATION_NAME,
+    "ip": "0.0.0.0",
+    "subnet_mask": "255.255.255.0",
+    "gateway": "0.0.0.0",
+}
+_factory_defaults = {}  # captured once at startup, restored by Reset to Factory Settings
+
+
+def _get_own_mac(iface: str) -> bytes:
+    """Reads the interface's MAC address straight from sysfs — no extra deps needed."""
+    with open(f"/sys/class/net/{iface}/address", encoding="ascii") as f:
+        mac_str = f.read().strip()
+    return bytes(int(b, 16) for b in mac_str.split(":"))
+
+
+def _get_own_ip() -> str:
+    """
+    Returns the container's primary IPv4 address via the standard UDP-connect
+    trick: connect() on a UDP socket only sets local routing state in the
+    kernel, it never actually sends a packet on the wire, so this works even
+    with an unreachable destination.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("10.255.255.255", 1))
+        return s.getsockname()[0]
+    except OSError:
+        return "0.0.0.0"
+    finally:
+        s.close()
+
+
+def _mac_str(mac: bytes) -> str:
+    return ":".join(f"{b:02x}" for b in mac)
+
+
+# ── DCP block (TLV) encoding ───────────────────────────────────────────────────
+
+def _pack_block(option: int, suboption: int, block_info_or_qualifier: int, data: bytes) -> bytes:
+    """
+    Packs one DCP block: Option(1) + Suboption(1) + DCPBlockLength(2) +
+    BlockInfo/BlockQualifier(2) + data, padded to an even total length.
+    DCPBlockLength covers everything after itself (BlockInfo/Qualifier + data).
+    """
+    body = struct.pack(">H", block_info_or_qualifier) + data
+    block = struct.pack(">BBH", option, suboption, len(body)) + body
+    if len(block) % 2 != 0:
+        block += b"\x00"
+    return block
+
+
+def _build_name_of_station_block() -> bytes:
+    return _pack_block(
+        OPT_DEVICE_PROPERTIES, SUBOPT_NAME_OF_STATION, 0,
+        _state["station_name"].encode("ascii", errors="replace"),
+    )
+
+
+def _build_device_id_block() -> bytes:
+    return _pack_block(
+        OPT_DEVICE_PROPERTIES, SUBOPT_DEVICE_ID, 0,
+        struct.pack(">HH", VENDOR_ID, DEVICE_ID_NUM),
+    )
+
+
+def _build_device_role_block() -> bytes:
+    # Role byte 0x01 = IO Device (as opposed to IO Controller/Supervisor).
+    return _pack_block(OPT_DEVICE_PROPERTIES, SUBOPT_DEVICE_ROLE, 0, bytes([0x01, 0x00]))
+
+
+def _build_ip_block() -> bytes:
+    data = (
+        socket.inet_aton(_state["ip"])
+        + socket.inet_aton(_state["subnet_mask"])
+        + socket.inet_aton(_state["gateway"])
+    )
+    return _pack_block(OPT_IP, SUBOPT_IP_PARAMETER, 0, data)
+
+
+def _all_blocks() -> bytes:
+    return (
+        _build_name_of_station_block()
+        + _build_device_id_block()
+        + _build_device_role_block()
+        + _build_ip_block()
+    )
+
+
+_BLOCK_BUILDERS = {
+    (OPT_DEVICE_PROPERTIES, SUBOPT_NAME_OF_STATION): _build_name_of_station_block,
+    (OPT_DEVICE_PROPERTIES, SUBOPT_DEVICE_ID): _build_device_id_block,
+    (OPT_DEVICE_PROPERTIES, SUBOPT_DEVICE_ROLE): _build_device_role_block,
+    (OPT_IP, SUBOPT_IP_PARAMETER): _build_ip_block,
+}
+
+
+# ── DCP block (TLV) parsing ────────────────────────────────────────────────────
+
+def _parse_get_request_blocks(data: bytes) -> list:
+    """Get-request blocks carry no body — just Option(1)+Suboption(1)+Length(2)=0."""
+    blocks = []
+    pos = 0
+    while pos + 4 <= len(data):
+        option, suboption, length = struct.unpack_from(">BBH", data, pos)
+        pos += 4 + length + (length % 2)
+        blocks.append((option, suboption))
+    return blocks
+
+
+def _parse_set_request_blocks(data: bytes) -> list:
+    """Set-request blocks carry BlockQualifier(2) + the new value."""
+    blocks = []
+    pos = 0
+    while pos + 4 <= len(data):
+        option, suboption, length = struct.unpack_from(">BBH", data, pos)
+        pos += 4
+        body = data[pos:pos + length]
+        pos += length + (length % 2)
+        qualifier, block_data = (0, b"") if len(body) < 2 else (
+            struct.unpack_from(">H", body, 0)[0], body[2:]
+        )
+        blocks.append((option, suboption, qualifier, block_data))
+    return blocks
+
+
+# ── Raw Ethernet frame send/receive ────────────────────────────────────────────
+
+_sock: socket.socket
+_own_mac: bytes
+
+
+def _send_dcp_frame(dst_mac: bytes, frame_id: int, service_id: int,
+                     service_type: int, xid: int, blocks: bytes) -> None:
+    dcp_header = struct.pack(">BBIHH", service_id, service_type, xid, 0, len(blocks))
+    eth_payload = struct.pack(">H", frame_id) + dcp_header + blocks
+    frame = dst_mac + _own_mac + struct.pack(">H", ETHERTYPE_PROFINET) + eth_payload
+    _sock.send(frame)
+
+
+def _handle_identify(src_mac: bytes, xid: int) -> None:
+    log.info("DCP Identify from %s -> responding with full device fingerprint", _mac_str(src_mac))
+    _send_dcp_frame(src_mac, FRAME_ID_IDENTIFY_RSP, SVC_IDENTIFY, SVC_TYPE_RESPONSE, xid, _all_blocks())
+
+
+def _handle_get(src_mac: bytes, xid: int, data: bytes) -> None:
+    requested = _parse_get_request_blocks(data)
+    if not requested or (OPT_ALL_SELECTOR, SUBOPT_ALL_SELECTOR) in requested:
+        response = _all_blocks()
+    else:
+        response = b"".join(
+            _BLOCK_BUILDERS[key]() for key in requested if key in _BLOCK_BUILDERS
+        )
+    log.info("DCP Get from %s: requested=%s", _mac_str(src_mac), requested or "ALL")
+    _send_dcp_frame(src_mac, FRAME_ID_GET_SET, SVC_GET, SVC_TYPE_RESPONSE, xid, response)
+
+
+def _handle_set(src_mac: bytes, xid: int, data: bytes) -> None:
+    applied = _parse_set_request_blocks(data)
+    response_blocks = bytearray()
+
+    for option, suboption, _qualifier, value in applied:
+        if (option, suboption) == (OPT_DEVICE_PROPERTIES, SUBOPT_NAME_OF_STATION):
+            new_name = value.decode("ascii", errors="replace")
+            log.warning(
+                "UNAUTHENTICATED DCP Set from %s: station renamed '%s' -> '%s'",
+                _mac_str(src_mac), _state["station_name"], new_name,
+            )
+            _state["station_name"] = new_name
+
+        elif (option, suboption) == (OPT_IP, SUBOPT_IP_PARAMETER) and len(value) >= 12:
+            new_ip = socket.inet_ntoa(value[0:4])
+            new_mask = socket.inet_ntoa(value[4:8])
+            new_gw = socket.inet_ntoa(value[8:12])
+            log.warning(
+                "UNAUTHENTICATED DCP Set from %s: IP reassigned %s -> %s (mask=%s gw=%s)",
+                _mac_str(src_mac), _state["ip"], new_ip, new_mask, new_gw,
+            )
+            _state["ip"], _state["subnet_mask"], _state["gateway"] = new_ip, new_mask, new_gw
+
+        elif (option, suboption) == (OPT_CONTROL, SUBOPT_CONTROL_RESET_FACTORY):
+            log.warning("UNAUTHENTICATED DCP Set from %s: Reset to Factory Settings", _mac_str(src_mac))
+            _state.update(_factory_defaults)
+
+        elif (option, suboption) == (OPT_CONTROL, SUBOPT_CONTROL_SIGNAL):
+            log.info("DCP Set from %s: Flash/Signal requested (no physical LED to flash)", _mac_str(src_mac))
+
+        else:
+            log.info("DCP Set from %s: unsupported block option=0x%02x suboption=0x%02x — ignored",
+                      _mac_str(src_mac), option, suboption)
+            continue
+
+        response_blocks += _pack_block(option, suboption, 0, b"")  # BlockInfo=0 (success)
+
+    _send_dcp_frame(src_mac, FRAME_ID_GET_SET, SVC_SET, SVC_TYPE_RESPONSE, xid, bytes(response_blocks))
+
+
+def _send_hello() -> None:
+    """
+    Unsolicited device announcement, sent once at startup — the same frame a
+    real IO Device broadcasts on link-up so an engineering tool can discover
+    it without sending an explicit Identify request first. Periodic
+    re-announcement is omitted (DCP-only scope, not full RT).
+    """
+    _send_dcp_frame(DCP_MULTICAST_MAC, FRAME_ID_HELLO, SVC_HELLO, SVC_TYPE_REQUEST, 0, _all_blocks())
+    log.info("Sent DCP Hello (station=%s)", _state["station_name"])
+
+
+def main() -> None:
+    global _sock, _own_mac
+
+    try:
+        _own_mac = _get_own_mac(IFACE)
+    except OSError as err:
+        log.error("Could not read MAC address for interface %s: %s", IFACE, err)
+        sys.exit(1)
+
+    ip = _get_own_ip()
+    if ip != "0.0.0.0":
+        prefix = ".".join(ip.split(".")[:3])
+        _state["ip"] = ip
+        _state["gateway"] = f"{prefix}.1"
+    _factory_defaults.update(_state)
+
+    log.info(
+        "PROFINET DCP device starting -- id=%s  category=%s  iface=%s  mac=%s",
+        DEVICE_ID_LABEL, CATEGORY, IFACE, _mac_str(_own_mac),
+    )
+    log.info("  NameOfStation=%s  VendorID=0x%04x  DeviceID=0x%04x",
+              _state["station_name"], VENDOR_ID, DEVICE_ID_NUM)
+    log.info("  IP=%s mask=%s gateway=%s", _state["ip"], _state["subnet_mask"], _state["gateway"])
+
+    try:
+        _sock = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(ETHERTYPE_PROFINET))
+        _sock.bind((IFACE, 0))
+    except PermissionError:
+        log.error(
+            "Permission denied opening a raw AF_PACKET socket — this container "
+            "needs cap_add: [NET_RAW] (and NET_ADMIN for promiscuous mode)."
+        )
+        sys.exit(1)
+
+    log.info("Listening for DCP frames on %s (EtherType 0x%04x)", IFACE, ETHERTYPE_PROFINET)
+    _send_hello()
+
+    while True:
+        frame = _sock.recv(2048)
+        if len(frame) < 16:
+            continue
+        dst_mac = frame[0:6]
+        if dst_mac != _own_mac and dst_mac != DCP_MULTICAST_MAC:
+            continue  # not addressed to us and not the DCP multicast group
+
+        src_mac = frame[6:12]
+        payload = frame[14:]
+        frame_id = struct.unpack_from(">H", payload, 0)[0]
+        dcp = payload[2:]
+        if len(dcp) < 10:
+            continue
+        service_id, service_type, xid, _resp_delay, data_len = struct.unpack_from(">BBIHH", dcp, 0)
+        block_data = dcp[10:10 + data_len]
+
+        if service_type != SVC_TYPE_REQUEST:
+            continue  # ignore anything that isn't a request (e.g. our own reflected frames)
+
+        if frame_id == FRAME_ID_IDENTIFY_REQ and service_id == SVC_IDENTIFY:
+            _handle_identify(src_mac, xid)
+        elif frame_id == FRAME_ID_GET_SET and dst_mac == _own_mac and service_id == SVC_GET:
+            _handle_get(src_mac, xid, block_data)
+        elif frame_id == FRAME_ID_GET_SET and dst_mac == _own_mac and service_id == SVC_SET:
+            _handle_set(src_mac, xid, block_data)
+        elif frame_id == FRAME_ID_HELLO and src_mac != _own_mac:
+            # Our own Hello (sent at startup) loops back to this same raw socket —
+            # AF_PACKET sees everything on the interface, including our own sends.
+            log.info("Observed DCP Hello from %s (informational only)", _mac_str(src_mac))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/app/src/renderer/src/canvas/PipeEdge.tsx
+++ b/packages/app/src/renderer/src/canvas/PipeEdge.tsx
@@ -89,6 +89,7 @@ const PIPE_COLORS: Record<Protocol, string> = {
   s7comm: '#79b8ff', // Siemens S7comm — blue (Phase 10)
   'iec-104': '#e3b341', // IEC 60870-5-104 — gold (Phase 10)
   mqtt: '#e87040', // MQTT — orange; IIoT sensor/gateway pub/sub
+  profinet: '#00a0e3', // PROFINET — Siemens/PI brand blue
   none: '#484f58'
 }
 
@@ -104,7 +105,8 @@ const PROTOCOL_LABELS: Partial<Record<Protocol, string>> = {
   iec61850: 'IEC 61850',
   s7comm: 'S7comm', // Phase 10
   'iec-104': 'IEC 104', // Phase 10
-  mqtt: 'MQTT' // IIoT pub/sub
+  mqtt: 'MQTT', // IIoT pub/sub
+  profinet: 'PROFINET'
 }
 
 /** Bright green used when a coil-driven flow is active (legacy / fluidType 'none'). */

--- a/packages/app/src/renderer/src/canvas/ProtocolEdge.tsx
+++ b/packages/app/src/renderer/src/canvas/ProtocolEdge.tsx
@@ -109,6 +109,7 @@ const PROTOCOL_COLORS: Partial<Record<Protocol, string>> = {
   s7comm: '#79b8ff', // Siemens S7comm — blue (Phase 10)
   'iec-104': '#e3b341', // IEC 60870-5-104 — gold (Phase 10)
   mqtt: '#e87040', // MQTT — orange; IIoT broker-based pub/sub
+  profinet: '#00a0e3', // PROFINET — Siemens/PI brand blue
   none: '#484f58'
 }
 

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -336,6 +336,7 @@ const DEFAULT_PROTOCOLS: Record<DeviceCategory, Protocol[]> = {
   ied: ['dnp3'],
   'iec61850-ied': ['iec61850'],
   'ethernetip-adapter': ['ethernet-ip'], // real otforge-ethernetip container, scanned by a PLC
+  'profinet-device': ['profinet'], // real otforge-profinet container (DCP only), scanned by a PLC
   'safety-plc': ['modbus-tcp'], // SIS — same Modbus transport as standard PLC
   'dcs-controller': ['opc-ua'], // DCS prefers OPC-UA upward by convention
   'legacy-plc': ['s7comm'], // Siemens S7 — S7comm primary protocol (Phase 10)
@@ -385,6 +386,7 @@ const CATEGORY_LABELS: Record<DeviceCategory, string> = {
   ied: 'IED',
   'iec61850-ied': 'IEC 61850 IED',
   'ethernetip-adapter': 'EtherNet/IP Adapter',
+  'profinet-device': 'PROFINET Device',
   'safety-plc': 'Safety PLC',
   'dcs-controller': 'DCS Ctrl',
   'legacy-plc': 'S7 PLC', // Phase 10

--- a/packages/app/src/renderer/src/canvas/connectionRules.ts
+++ b/packages/app/src/renderer/src/canvas/connectionRules.ts
@@ -75,6 +75,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['modbus-tcp', 'iec61850'],
     'iec61850-ied': ['iec61850'],
     'ethernetip-adapter': ['ethernet-ip'], // PLC is the EtherNet/IP scanner for remote I/O
+    'profinet-device': ['profinet'], // PLC is the PROFINET IO Controller for this IO device
     plc: ['modbus-tcp', 'ethernet-ip'], // peer-to-peer PLC network
     'safety-plc': ['ethernet-ip', 'modbus-tcp'], // PLC shares data with adjacent SIS
     'legacy-plc': ['s7comm', 'modbus-tcp'], // PLC → Siemens S7 peer (Phase 10)
@@ -143,6 +144,18 @@ export const VALID_CONNECTIONS: Partial<
   // I/O — see containers/ethernetip/server.py) — the adapter itself never
   // initiates a connection, it only responds to its scanning PLC.
   'ethernetip-adapter': {
+    switch: ['none'],
+    router: ['none'],
+    firewall: ['none'],
+    'ids-ips': ['none']
+  },
+
+  // ── PROFINET IO device (real DCP only — see containers/profinet/) ──────────
+  // Discovery and Configuration Protocol only: device identify plus the
+  // unauthenticated station-name/IP "Set" requests. AR establishment and RT
+  // cyclic I/O are deferred, so — like the EtherNet/IP adapter above — this
+  // device only responds to its IO Controller (PLC), it never initiates.
+  'profinet-device': {
     switch: ['none'],
     router: ['none'],
     firewall: ['none'],
@@ -498,6 +511,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'], // Ethernet to IED configuration tool
     'iec61850-ied': ['none', 'iec61850'], // MMS engineering client (e.g. libiec61850 tools)
     'ethernetip-adapter': ['none', 'ethernet-ip'], // EtherNet/IP config tool (e.g. RSLinx/RSLogix-style client)
+    'profinet-device': ['none', 'profinet'], // PROFINET DCP config tool (e.g. Siemens PST-style station naming/IP tool)
     sensor: ['none', 'bacnet'], // BAS engineering client (e.g. bacpypes3 tools)
     'safety-plc': ['none'], // SIS engineering console (TriStation, Safety Builder)
     'dcs-controller': ['none'], // DCS engineering workstation (DeltaV Explorer, Experion)
@@ -589,6 +603,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'],
     'iec61850-ied': ['none'],
     'ethernetip-adapter': ['none'],
+    'profinet-device': ['none'],
     'safety-plc': ['none'],
     'dcs-controller': ['none'],
     'legacy-plc': ['none'], // Phase 10
@@ -627,6 +642,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'],
     'iec61850-ied': ['none'],
     'ethernetip-adapter': ['none'],
+    'profinet-device': ['none'],
     'safety-plc': ['none'],
     'dcs-controller': ['none'],
     'legacy-plc': ['none'], // Phase 10
@@ -665,6 +681,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'],
     'iec61850-ied': ['none'],
     'ethernetip-adapter': ['none'],
+    'profinet-device': ['none'],
     'safety-plc': ['none'],
     'dcs-controller': ['none'],
     'legacy-plc': ['none'], // Phase 10
@@ -703,6 +720,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'],
     'iec61850-ied': ['none'],
     'ethernetip-adapter': ['none'],
+    'profinet-device': ['none'],
     'safety-plc': ['none'],
     'dcs-controller': ['none'],
     'legacy-plc': ['none'], // Phase 10
@@ -778,6 +796,9 @@ export const VALID_CONNECTIONS: Partial<
     // Unauthenticated Set_Attribute_Single write to the adapter's Output Assembly —
     // the same write path a legitimate scanning PLC uses, but from an unauthorized host.
     'ethernetip-adapter': ['ethernet-ip', 'none'],
+    // Unauthenticated DCP Set — rename the station or reassign its IP with zero
+    // credentials, the same way a legitimate engineering tool would configure it.
+    'profinet-device': ['profinet', 'none'],
     // TRITON/TRISIS attack vector: TriStation protocol injection into SIS — Schneider Triconex, 2017
     'safety-plc': ['modbus-tcp', 'modbus-rtu', 'ethernet-ip', 'opc-ua', 'none'],
     // DCS attacks: OPC-UA credential attacks, Modbus setpoint manipulation
@@ -951,6 +972,7 @@ const CATEGORY_NAMES: Record<DeviceCategory, string> = {
   ied: 'IED',
   'iec61850-ied': 'IEC 61850 IED',
   'ethernetip-adapter': 'EtherNet/IP Adapter',
+  'profinet-device': 'PROFINET Device',
   'safety-plc': 'Safety PLC / SIS',
   'dcs-controller': 'DCS Controller',
   'legacy-plc': 'Siemens S7 PLC', // Phase 10
@@ -1023,6 +1045,10 @@ const DEVICE_CABLE_CAPABILITIES: Record<DeviceCategory, Set<CableType>> = {
   // EtherNet/IP remote I/O adapter: standard Ethernet only (wireless EtherNet/IP is
   // not common in OT deployments) + mains power for the field enclosure/DIN rail.
   'ethernetip-adapter': new Set(['cat5e', 'cat6', 'cat6a', 'mmf', 'smf', 'ac']),
+  // PROFINET IO device: standard Ethernet only — RT cyclic timing requirements
+  // (even for the DCP-only scope here) make wireless media unrealistic in real
+  // deployments — + mains power for the field enclosure/DIN rail.
+  'profinet-device': new Set(['cat5e', 'cat6', 'cat6a', 'mmf', 'smf', 'ac']),
   // Safety PLC: same port set as PLC; isolated physical network segment per ISA-84
   'safety-plc': new Set(['rs485', 'rs232', 'cat5e', 'cat6', 'ac']),
   // DCS Controller: larger system, fiber uplinks to DCS node bus are common

--- a/packages/app/src/renderer/src/icons/DeviceIcons.tsx
+++ b/packages/app/src/renderer/src/icons/DeviceIcons.tsx
@@ -909,6 +909,7 @@ const ICON_MAP: Record<DeviceCategory, () => JSX.Element> = {
   ied: IedSvg,
   'iec61850-ied': IedSvg,
   'ethernetip-adapter': RtuSvg, // remote I/O adapter — reuses the generic remote-terminal icon
+  'profinet-device': RtuSvg, // PROFINET IO device — reuses the generic remote-terminal icon, same as the EtherNet/IP adapter
   'safety-plc': SafetyPlcSvg, // IEC 61511 Safety PLC / SIS — Triconex, Siemens Safety
   'dcs-controller': DcsControllerSvg, // Distributed Control System — DeltaV, Experion, 800xA
   'legacy-plc': LegacyPlcSvg, // Siemens S7-300/400/1200/1500 via S7comm (Phase 10)

--- a/packages/app/src/renderer/src/palette/DevicePalette.tsx
+++ b/packages/app/src/renderer/src/palette/DevicePalette.tsx
@@ -76,7 +76,8 @@ const PALETTE: PaletteSection[] = [
       { category: 'rtu', label: 'RTU' },
       { category: 'ied', label: 'IED (DNP3)' },
       { category: 'iec61850-ied', label: 'IEC 61850 IED' },
-      { category: 'ethernetip-adapter', label: 'EtherNet/IP Adapter' }
+      { category: 'ethernetip-adapter', label: 'EtherNet/IP Adapter' },
+      { category: 'profinet-device', label: 'PROFINET Device' }
     ]
   },
   {

--- a/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
+++ b/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
@@ -50,6 +50,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   ied: 'Intelligent Electronic Device (DNP3)',
   'iec61850-ied': 'IEC 61850 IED (MMS) — substation automation',
   'ethernetip-adapter': 'EtherNet/IP Adapter (CIP) — remote I/O',
+  'profinet-device': 'PROFINET Device (DCP) — discovery/naming only',
   hmi: 'Human Machine Interface',
   historian: 'Data Historian',
   sensor: 'BACnet Device — building automation (generic / AHU / VAV / chiller / zone sensor)',

--- a/packages/orchestrator/src/__tests__/compose-generator.test.ts
+++ b/packages/orchestrator/src/__tests__/compose-generator.test.ts
@@ -421,6 +421,57 @@ describe('attack-machine device', () => {
   })
 })
 
+describe('profinet-device', () => {
+  it('uses the otforge-profinet image', () => {
+    const compose = gen(
+      makeScenario([['pn-1', { category: 'profinet-device', ipAddress: '10.200.10.10' }]])
+    )
+    expect(compose.services['pn-1'].image).toBe('ghcr.io/iburres/otforge-profinet:latest')
+  })
+
+  it('assigns 64m memory limit (hand-rolled raw-socket DCP server on Alpine)', () => {
+    const compose = gen(
+      makeScenario([['pn-1', { category: 'profinet-device', ipAddress: '10.200.10.10' }]])
+    )
+    expect(compose.services['pn-1'].deploy.resources.limits.memory).toBe('64m')
+  })
+
+  it('grants NET_ADMIN and NET_RAW for its raw AF_PACKET DCP socket', () => {
+    const compose = gen(
+      makeScenario([['pn-1', { category: 'profinet-device', ipAddress: '10.200.10.10' }]])
+    )
+    expect(compose.services['pn-1'].cap_add).toContain('NET_ADMIN')
+    expect(compose.services['pn-1'].cap_add).toContain('NET_RAW')
+  })
+
+  it('injects PROFINET_STATION_NAME, PROFINET_VENDOR_ID, PROFINET_DEVICE_ID when a profinet config is present', () => {
+    const compose = gen(
+      makeScenario([
+        [
+          'pn-1',
+          {
+            category: 'profinet-device',
+            ipAddress: '10.200.10.10',
+            profinet: { stationName: 'press-station-3', vendorId: 42, deviceId: 7 }
+          }
+        ]
+      ])
+    )
+    const env = compose.services['pn-1'].environment ?? []
+    expect(env).toContain('PROFINET_STATION_NAME=press-station-3')
+    expect(env).toContain('PROFINET_VENDOR_ID=42')
+    expect(env).toContain('PROFINET_DEVICE_ID=7')
+  })
+
+  it('does not inject PROFINET_* vars when no profinet config is present', () => {
+    const compose = gen(
+      makeScenario([['pn-1', { category: 'profinet-device', ipAddress: '10.200.10.10' }]])
+    )
+    const env = compose.services['pn-1'].environment ?? []
+    expect(env.some(e => e.startsWith('PROFINET_'))).toBe(false)
+  })
+})
+
 describe('attack-machine — Insider Threat mode (visual zone placement)', () => {
   /**
    * Insider Threat mode (scenario.security.insiderThreat) lets the attack machine

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -54,6 +54,8 @@ const DEVICE_IMAGES: Record<DeviceCategory, string> = {
   'iec61850-ied': 'ghcr.io/iburres/otforge-iec61850:latest',
   // EtherNet/IP (CIP) remote I/O adapter — hand-rolled asyncio server on Alpine (containers/ethernetip)
   'ethernetip-adapter': 'ghcr.io/iburres/otforge-ethernetip:latest',
+  // PROFINET IO device — hand-rolled DCP-only raw-socket server on Alpine (containers/profinet)
+  'profinet-device': 'ghcr.io/iburres/otforge-profinet:latest',
   // Phase 10: Conpot legacy device emulation (S7comm + IEC 104)
   'legacy-plc': 'ghcr.io/iburres/otforge-conpot:latest',
   'iec104-rtu': 'ghcr.io/iburres/otforge-conpot:latest',
@@ -140,6 +142,7 @@ const DEVICE_LIMITS: Record<DeviceCategory, { memory: number; cpus: string }> = 
   ied: { memory: 80, cpus: '0.25' }, // pure-Python DNP3 on Alpine
   'iec61850-ied': { memory: 128, cpus: '0.25' }, // libiec61850 MMS server on Debian
   'ethernetip-adapter': { memory: 64, cpus: '0.25' }, // hand-rolled asyncio ENIP/CIP server on Alpine
+  'profinet-device': { memory: 64, cpus: '0.25' }, // hand-rolled raw-socket DCP server on Alpine
   'legacy-plc': { memory: 80, cpus: '0.25' }, // pure-Python S7comm on Alpine (Phase 10)
   'iec104-rtu': { memory: 80, cpus: '0.25' }, // pure-Python IEC 104 on Alpine (Phase 10)
   'process-unit': { memory: 96, cpus: '0.25' }, // pymodbus + physics loop on Alpine (Phase 11)
@@ -669,6 +672,14 @@ export function generateCompose(
     // Switch and router containers need NET_ADMIN for iproute2 / ip_forward sysctl
     // and NET_RAW for tcpdump packet capture by students during traffic analysis labs.
     if (device.category === 'switch' || device.category === 'router') {
+      services[serviceName].cap_add = ['NET_ADMIN', 'NET_RAW']
+    }
+
+    // PROFINET IO device speaks DCP over a raw AF_PACKET socket (EtherType 0x8892,
+    // no IP/UDP framing) — NET_RAW for the raw socket itself, NET_ADMIN for the
+    // multicast MAC filter (SIOCADDMULTI) needed to receive DCP-Identify multicast
+    // requests. See containers/profinet/server.py.
+    if (device.category === 'profinet-device') {
       services[serviceName].cap_add = ['NET_ADMIN', 'NET_RAW']
     }
 
@@ -1529,6 +1540,14 @@ function buildDeviceEnv(
   if (device.ethernetip) {
     env.push(`ENIP_PORT=${device.ethernetip.port}`)
     env.push(`ENIP_SLOT=${device.ethernetip.slot}`)
+  }
+
+  // PROFINET DCP configuration — consumed by containers/profinet/server.py.
+  // No port: DCP runs directly over raw Ethernet (EtherType 0x8892), not TCP/UDP.
+  if (device.profinet) {
+    env.push(`PROFINET_STATION_NAME=${device.profinet.stationName}`)
+    env.push(`PROFINET_VENDOR_ID=${device.profinet.vendorId}`)
+    env.push(`PROFINET_DEVICE_ID=${device.profinet.deviceId}`)
   }
 
   // Siemens S7comm configuration — consumed by containers/conpot/server.py

--- a/packages/schema/src/icslab.ts
+++ b/packages/schema/src/icslab.ts
@@ -21,6 +21,7 @@ export type Protocol =
   | 'bacnet'
   | 'ethernet-ip'
   | 'iec61850'
+  | 'profinet' // PROFINET DCP (Discovery and Configuration Protocol) — device discovery/naming/IP assignment over raw Ethernet, EtherType 0x8892
   | 's7comm' // Siemens S7 Communication (S7-300/400/1200/1500, port 102)
   | 'iec-104' // IEC 60870-5-104 telecontrol protocol (port 2404)
   | 'mqtt' // Message Queuing Telemetry Transport — IIoT sensors, cloud gateways, broker-based pub/sub
@@ -75,6 +76,7 @@ export type DeviceCategory =
   | 'ied' // Intelligent Electronic Device — DNP3 outstation (protection relay / bay controller)
   | 'iec61850-ied' // IEC 61850 IED — MMS server (substation automation: power gen + distribution)
   | 'ethernetip-adapter' // EtherNet/IP (CIP) remote I/O adapter — explicit messaging only, no Class 1 cyclic I/O
+  | 'profinet-device' // PROFINET IO device — DCP discovery/naming/IP assignment only, no AR establishment or RT cyclic I/O
   | 'safety-plc' // Safety Instrumented System / Safety PLC (IEC 61511) — Triconex, Siemens Safety
   | 'dcs-controller' // Distributed Control System controller — Honeywell, Emerson DeltaV, ABB 800xA
   | 'legacy-plc' // Siemens S7-300/400/1200/1500 via S7comm (Phase 10)
@@ -371,6 +373,38 @@ export interface EtherNetIPConfig {
    * Needed by FUXA and pycomm3 when forming CIP connection paths.
    */
   slot: number
+}
+
+/**
+ * PROFINET DCP (Discovery and Configuration Protocol) configuration for a
+ * PROFINET IO device.
+ *
+ * PROFINET is the dominant Ethernet-based fieldbus in automotive and discrete
+ * manufacturing (Siemens-centric, competing with EtherNet/IP in that space).
+ * Its full stack has three layers:
+ *   - DCP — device discovery plus station-name/IP assignment, raw Ethernet
+ *     frames (EtherType 0x8892), no authentication in the base spec.
+ *   - Context Manager (DCE/RPC over UDP 34964) — establishes the Application
+ *     Relationship (AR) between an IO Controller (PLC) and an IO Device
+ *     before cyclic data can flow.
+ *   - RT (Real-Time) cyclic data — raw Ethernet frames, sub-millisecond
+ *     cycle times, the actual process I/O exchange.
+ *
+ * This device implements DCP only: Identify (discovery), Get, and Set —
+ * including the unauthenticated station-name and IP "Set" requests that let
+ * anyone on the segment rename or re-address a real device with no
+ * credentials, a well-known PROFINET security property worth demonstrating
+ * on its own. AR establishment and RT cyclic data are a much larger
+ * undertaking (the same scope cut this project already made for EtherNet/IP
+ * Class 1 I/O and IEC 61850 GOOSE/SV) and are deferred.
+ */
+export interface ProfinetConfig {
+  /** NameOfStation — PROFINET's primary device identifier, set via DCP instead of a hostname. */
+  stationName: string
+  /** Vendor ID (16-bit) reported in the DCP Device ID block — GSDML-matched to a device type on a real network. */
+  vendorId: number
+  /** Device ID (16-bit) reported alongside vendorId — together identify the specific device model. */
+  deviceId: number
 }
 
 export interface PLCProgramConfig {
@@ -729,6 +763,7 @@ export interface DeviceConfig {
   opcua?: OpcUaConfig
   bacnet?: BacnetConfig // BACnet/IP config (sensor devices)
   ethernetip?: EtherNetIPConfig // EtherNet/IP CIP config (plc, rtu devices)
+  profinet?: ProfinetConfig // PROFINET DCP config (profinet-device devices)
   s7?: S7Config // Siemens S7comm config (legacy-plc devices, Phase 10)
   iec104?: Iec104Config // IEC 60870-5-104 config (iec104-rtu devices, Phase 10)
   processUnit?: ProcessUnitConfig // Physics process simulation config (Phase 11)


### PR DESCRIPTION
## Summary
- Adds a real PROFINET IO device to the schema/orchestrator/UI, closing the automotive/discrete-manufacturing gap from the target-sectors roadmap (PROFINET was the last big protocol coverage item).
- Scoped to **DCP (Discovery and Configuration Protocol) only** — implemented over a raw AF_PACKET Ethernet socket (EtherType 0x8892, no IP/UDP framing), the same real-but-partial approach already used for EtherNet/IP Class 1 I/O (deferred) and IEC 61850 GOOSE/SV (deferred). The two layers above DCP — DCE/RPC Application Relationship establishment and RT cyclic I/O — are a much larger real-time/connection-oriented undertaking.
- DCP alone is complete, real, and pedagogically valuable on its own: any PROFINET engineering tool discovers devices and reassigns their station name/IP with **zero authentication**. This device implements Identify, Get, Set (station rename, IP reassignment, factory reset, LED signal/flash), and Hello — faithfully reproducing that lack of authentication.

## Changes
- `packages/schema`: `'profinet'` Protocol, `'profinet-device'` DeviceCategory, `ProfinetConfig` (stationName/vendorId/deviceId)
- `containers/profinet/`: hand-rolled raw-socket DCP server, no third-party PROFINET stack (Dockerfile, entrypoint.sh sets the interface promiscuous — same fix already applied to Zeek — server.py)
- `packages/orchestrator/src/compose-generator.ts`: image, resource limits (64m/0.25cpu), `cap_add: [NET_ADMIN, NET_RAW]` for the raw socket, `PROFINET_*` env injection
- `packages/orchestrator/src/__tests__/compose-generator.test.ts`: 5 new unit tests (image, resource limit, cap_add, env injection present/absent)
- `packages/app`: palette entry, connection rules (PLC = IO Controller; engineering workstation config tool; attack-machine unauthenticated DCP Set attack vector), device icon, protocol/pipe edge colors, properties panel label
- `.github/workflows/docker.yml`: `otforge-profinet` build matrix entry
- `.gitignore`: ignore `__pycache__/`/`*.pyc` (picked up while testing the container locally)

## Test plan
- [x] `npm run typecheck` clean in `packages/app`, `packages/orchestrator`, `packages/schema`
- [x] eslint clean on all changed files
- [x] orchestrator test suite: 175/175 passing (170 existing + 5 new)
- [x] **Live protocol test** in a scratch Docker network (device container with `NET_ADMIN`+`NET_RAW`, separate raw-socket test client): sent a real DCP-Identify multicast request → got a correct unicast response (NameOfStation, Device ID, Device Role, IP Parameter blocks, verified byte-for-byte via `tcpdump`); DCP-Get (All) → same fingerprint; DCP-Set (unauthenticated station rename `test-device-1` → `pwned-by-dcp`) → success ack; follow-up DCP-Get → confirmed the rename actually persisted
- [ ] CI image build (`otforge-profinet` matrix entry) — will run on merge to main

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>