### PR TITLE
fix: one Kali; compose down before up

### DIFF
--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -1288,6 +1288,7 @@ export default function App() {
    * zone which has no Purdue layer tab). It is added directly to scenario.devices
    * so the compose generator creates the Kali Linux container and noVNC port mapping
    * at simulation start. The device's IP defaults to 10.200.60.10 (attacker subnet).
+   * Replaces any existing attack-machine (toolbar or insider) so only one Kali exists.
    */
   const handleAttackMachineAdd = useCallback(() => {
     const nodeId = `attack-machine-${Date.now()}`
@@ -1326,7 +1327,20 @@ export default function App() {
       }
       return {
         ...base,
-        devices: { devices: { ...base.devices.devices, [nodeId]: device } }
+        visual: {
+          ...base.visual,
+          nodes: base.visual.nodes.filter(n => n.type !== 'attack-machine')
+        },
+        devices: {
+          devices: {
+            ...Object.fromEntries(
+              Object.entries(base.devices.devices).filter(
+                ([, d]) => d.category !== 'attack-machine'
+              )
+            ),
+            [nodeId]: device
+          }
+        }
       }
     })
   }, [])

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -1903,12 +1903,25 @@ export function ScadaCanvas({
 
       onScenarioChange(prev => {
         const base = prev ?? buildEmptyScenario()
+        // One Kali only: insider drop replaces any existing attack-machine.
+        const nodes =
+          category === 'attack-machine'
+            ? base.visual.nodes.filter(n => n.type !== 'attack-machine')
+            : base.visual.nodes
+        const devices =
+          category === 'attack-machine'
+            ? Object.fromEntries(
+                Object.entries(base.devices.devices).filter(
+                  ([, d]) => d.category !== 'attack-machine'
+                )
+              )
+            : base.devices.devices
         return {
           ...base,
           visual: {
             ...base.visual,
             nodes: [
-              ...base.visual.nodes,
+              ...nodes,
               {
                 id: nodeId,
                 type: category,
@@ -1918,7 +1931,7 @@ export function ScadaCanvas({
             ]
           },
           devices: {
-            devices: { ...base.devices.devices, [nodeId]: device }
+            devices: { ...devices, [nodeId]: device }
           }
         }
       })

--- a/packages/orchestrator/src/docker-client.ts
+++ b/packages/orchestrator/src/docker-client.ts
@@ -174,6 +174,17 @@ export class DockerClient {
       await mkdir(scenarioDir, { recursive: true })
       await writeFile(composeFile, composeYaml, 'utf-8')
 
+      // Best-effort: clear leftover containers/networks from an unclean stop so
+      // `up` does not fail with "network … has active endpoints".
+      try {
+        // codeql[js/shell-command-constructed-from-input] -- projectName is sanitized to [a-z0-9-] by toProjectName()
+        await run(
+          `docker compose -p ${projectName} -f "${composeFile}" down --volumes --remove-orphans`
+        )
+      } catch {
+        /* best-effort */
+      }
+
       // Classify images as missing (first install) or present (possible update) so
       // the overlay can show "Importing Containers" vs "Updating Containers".
       // If any image is missing, 'import' takes priority over 'update'.


### PR DESCRIPTION
## Summary
- Tear down leftover project containers/networks before `compose up` so unclean stops don't fail with "active endpoints"
- Toolbar add and insider drop replace any existing attack-machine so only one Kali can exist

## Test plan
- [ ] Start a scenario, kill the app without Stop, start again — no "active endpoints" / address-in-use errors
- [ ] Add Attack Machine via toolbar, then drop Insider Attack Machine — only one Kali in the scenario
- [ ] Drop Insider first, then toolbar Add — only one Kali