### PR TITLE
Fix canvas edges vanishing after adding a connection

### DIFF
--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -793,6 +793,13 @@ export function ScadaCanvas({
   const prevLayerRef = useRef<NetworkZone | null>(null)
 
   /**
+   * Tracks node-graph identity for the sync effect. Edge-only scenario updates
+   * must not call setNodes — replacing every node object leaves React Flow edge
+   * paths bound to stale handle bounds (traces vanish until a layer-tab switch).
+   */
+  const prevNodeSyncKeyRef = useRef<string>('')
+
+  /**
    * Timer ref for auto-dismissing the invalid connection tooltip.
    * Stored in a ref so the previous timer can be cancelled before setting a new one
    * (prevents stale closures from clearing a tooltip the user just triggered).
@@ -1051,6 +1058,7 @@ export function ScadaCanvas({
     if (!scenario) {
       setNodes([])
       setEdges([])
+      prevNodeSyncKeyRef.current = ''
       // No nodes — show the full 25 × 25 canvas area so the user sees the grid
       setTimeout(() => {
         if (rfInstance.current) fitCanvasView(rfInstance.current)
@@ -1095,7 +1103,19 @@ export function ScadaCanvas({
         ? deviceNodes.map(n => (n.id === selId ? { ...n, selected: true } : n))
         : deviceNodes)
     ]
-    setNodes(allNodes)
+    // Skip setNodes when only edges changed (e.g. new connection). Remounting nodes
+    // on every edge edit desyncs RF handle bounds from edge SVG paths.
+    const nodeSyncKey = `${activeLayer}:${scenario.visual.nodes
+      .map(n => `${n.id}@${n.position.x},${n.position.y},${n.data.zone},${n.data.label}`)
+      .join('|')}:${(scenario.visual.siteRegions ?? [])
+      .map(r => `${r.id}@${r.position.x},${r.position.y},${r.width}x${r.height},${r.zone}`)
+      .join('|')}:${Object.values(scenario.devices.devices)
+      .map(d => `${d.nodeId}@${d.ipAddress}@${d.label ?? ''}`)
+      .join(',')}`
+    if (nodeSyncKey !== prevNodeSyncKeyRef.current) {
+      prevNodeSyncKeyRef.current = nodeSyncKey
+      setNodes(allNodes)
+    }
     // Mark every edge as reconnectable so the user can drag endpoints to reroute
     // connections without having to delete and recreate them (read-only mode excluded).
     setEdges(

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -303,6 +303,31 @@ function nodeRenderEqual(a: Node, b: Node): boolean {
   )
 }
 
+/** displayNodes also layers className / fillLevel / cross-layer stubs onto nodes. */
+function displayNodeEqual(a: Node, b: Node): boolean {
+  if (a.className !== b.className) return false
+  if (a.position.x !== b.position.x || a.position.y !== b.position.y) return false
+  if (!!a.selected !== !!b.selected) return false
+  if (!nodeRenderEqual(a, b)) return false
+  if (a.type === 'siteNode') return true
+  const ad = a.data as DeviceNodeData
+  const bd = b.data as DeviceNodeData
+  if ((ad.fillLevel ?? -1) !== (bd.fillLevel ?? -1)) return false
+  const az =
+    ad.crossLayerLinks
+      ?.map(l => l.zone)
+      .slice()
+      .sort()
+      .join(',') ?? ''
+  const bz =
+    bd.crossLayerLinks
+      ?.map(l => l.zone)
+      .slice()
+      .sort()
+      .join(',') ?? ''
+  return az === bz
+}
+
 /**
  * Default IP address for newly dropped devices, by zone.
  *
@@ -816,6 +841,13 @@ export function ScadaCanvas({
   const rfInstance = useRef<ReactFlowInstance | null>(null)
 
   /**
+   * Previous displayNodes array — reuse object refs when decorations are unchanged
+   * so cross-layer stub injection / pending-connection classNames don't remount
+   * every node and wipe edge paths.
+   */
+  const prevDisplayNodesRef = useRef<Node[]>([])
+
+  /**
    * Tracks the last layer that triggered a fitView call.
    * fitView must only run when the user switches layer tabs, NOT on every scenario
    * mutation (node added, node dragged, edge added). Without this guard, dropping a
@@ -1075,7 +1107,16 @@ export function ScadaCanvas({
       }
     }
 
-    return result
+    // Keep RF node object identity stable across decoration rebuilds (pending
+    // connection highlight, cross-layer stubs, tank fill). New object refs here
+    // are the same class of bug as setNodes(allNodes) — traces vanish until tab switch.
+    const prevById = new Map(prevDisplayNodesRef.current.map(n => [n.id, n]))
+    const reconciled = result.map(fresh => {
+      const prev = prevById.get(fresh.id)
+      return prev && displayNodeEqual(prev, fresh) ? prev : fresh
+    })
+    prevDisplayNodesRef.current = reconciled
+    return reconciled
   }, [nodes, pendingConnection, levelStates, edges, scenario, activeLayer, onLayerChange])
 
   // Sync canvas state when the scenario or active layer changes
@@ -1083,6 +1124,7 @@ export function ScadaCanvas({
     if (!scenario) {
       setNodes([])
       setEdges([])
+      prevDisplayNodesRef.current = []
       // No nodes — show the full 25 × 25 canvas area so the user sees the grid
       setTimeout(() => {
         if (rfInstance.current) fitCanvasView(rfInstance.current)

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -825,14 +825,6 @@ export function ScadaCanvas({
   const prevLayerRef = useRef<NetworkZone | null>(null)
 
   /**
-   * Tracks node-graph identity for the sync effect. Edge-only scenario updates
-   * must not call setNodes. When setNodes does run (drop/edit), existing node
-   * object refs are preserved by id — replacing every node leaves React Flow
-   * edge paths bound to stale handle bounds (traces vanish until a tab switch).
-   */
-  const prevNodeSyncKeyRef = useRef<string>('')
-
-  /**
    * Timer ref for auto-dismissing the invalid connection tooltip.
    * Stored in a ref so the previous timer can be cancelled before setting a new one
    * (prevents stale closures from clearing a tooltip the user just triggered).
@@ -1091,7 +1083,6 @@ export function ScadaCanvas({
     if (!scenario) {
       setNodes([])
       setEdges([])
-      prevNodeSyncKeyRef.current = ''
       // No nodes — show the full 25 × 25 canvas area so the user sees the grid
       setTimeout(() => {
         if (rfInstance.current) fitCanvasView(rfInstance.current)
@@ -1136,46 +1127,31 @@ export function ScadaCanvas({
         ? deviceNodes.map(n => (n.id === selId ? { ...n, selected: true } : n))
         : deviceNodes)
     ]
-    // Skip setNodes when only edges changed. When nodes must update (drop, edit),
-    // reuse existing node object refs by id — a full remount leaves RF edge paths
+    // Reuse existing node object refs by id. A full remount leaves RF edge paths
     // on stale handle bounds (traces vanish until a layer-tab switch).
-    const nodeSyncKey = `${activeLayer}:${scenario.visual.nodes
-      .map(n => `${n.id}@${n.position.x},${n.position.y},${n.data.zone},${n.data.label}`)
-      .join('|')}:${(scenario.visual.siteRegions ?? [])
-      .map(r => `${r.id}@${r.position.x},${r.position.y},${r.width}x${r.height},${r.zone}`)
-      .join('|')}:${Object.values(scenario.devices.devices)
-      .map(
-        d =>
-          `${d.nodeId}@${d.ipAddress}@${d.label ?? ''}@${d.category}@${d.sensor?.kind ?? ''}@${d.controller?.kind ?? ''}`
-      )
-      .join(',')}`
-    if (nodeSyncKey !== prevNodeSyncKeyRef.current) {
-      prevNodeSyncKeyRef.current = nodeSyncKey
-      setNodes(prev => {
-        const prevById = new Map(prev.map(n => [n.id, n]))
-        return allNodes.map(fresh => {
-          const existing = prevById.get(fresh.id)
-          if (!existing) return fresh
-          // Unchanged nodes keep the same object ref so RF handle bounds stay valid.
-          // (fresh.data is always a new object from scenarioToNodes — compare fields.)
-          const samePos =
-            existing.position.x === fresh.position.x && existing.position.y === fresh.position.y
-          const sameSel = !!existing.selected === !!fresh.selected
-          if (samePos && sameSel && nodeRenderEqual(existing, fresh)) return existing
-          return {
-            ...existing,
-            position: fresh.position,
-            data: fresh.data,
-            selected: fresh.selected,
-            width: fresh.width ?? existing.width,
-            height: fresh.height ?? existing.height,
-            zIndex: fresh.zIndex,
-            selectable: fresh.selectable,
-            draggable: fresh.draggable
-          }
-        })
+    setNodes(prev => {
+      const prevById = new Map(prev.map(n => [n.id, n]))
+      return allNodes.map(fresh => {
+        const existing = prevById.get(fresh.id)
+        if (!existing) return fresh
+        // fresh.data is always a new object from scenarioToNodes — compare fields.
+        const samePos =
+          existing.position.x === fresh.position.x && existing.position.y === fresh.position.y
+        const sameSel = !!existing.selected === !!fresh.selected
+        if (samePos && sameSel && nodeRenderEqual(existing, fresh)) return existing
+        return {
+          ...existing,
+          position: fresh.position,
+          data: fresh.data,
+          selected: fresh.selected,
+          width: fresh.width ?? existing.width,
+          height: fresh.height ?? existing.height,
+          zIndex: fresh.zIndex,
+          selectable: fresh.selectable,
+          draggable: fresh.draggable
+        }
       })
-    }
+    })
     // Mark every edge as reconnectable so the user can drag endpoints to reroute
     // connections without having to delete and recreate them (read-only mode excluded).
     setEdges(

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -272,6 +272,38 @@ function fitCanvasView(instance: ReactFlowInstance): void {
 }
 
 /**
+ * True when two React Flow nodes would render the same on canvas.
+ * Used to keep object identity across scenario sync so edge handle bounds stay valid.
+ */
+function nodeRenderEqual(a: Node, b: Node): boolean {
+  if (a.type !== b.type) return false
+  if (a.type === 'siteNode') {
+    const ar = (a.data as SiteNodeData).region
+    const br = (b.data as SiteNodeData).region
+    return (
+      ar.id === br.id &&
+      ar.label === br.label &&
+      ar.color === br.color &&
+      ar.width === br.width &&
+      ar.height === br.height &&
+      ar.zone === br.zone &&
+      (a.data as SiteNodeData).readOnly === (b.data as SiteNodeData).readOnly
+    )
+  }
+  const ad = a.data as DeviceNodeData
+  const bd = b.data as DeviceNodeData
+  return (
+    ad.zone === bd.zone &&
+    ad.label === bd.label &&
+    ad.device.category === bd.device.category &&
+    ad.device.ipAddress === bd.device.ipAddress &&
+    (ad.device.label ?? '') === (bd.device.label ?? '') &&
+    (ad.device.sensor?.kind ?? '') === (bd.device.sensor?.kind ?? '') &&
+    (ad.device.controller?.kind ?? '') === (bd.device.controller?.kind ?? '')
+  )
+}
+
+/**
  * Default IP address for newly dropped devices, by zone.
  *
  * Must match ZONE_DEFAULTS in packages/orchestrator/src/network-config.ts — both
@@ -794,8 +826,9 @@ export function ScadaCanvas({
 
   /**
    * Tracks node-graph identity for the sync effect. Edge-only scenario updates
-   * must not call setNodes — replacing every node object leaves React Flow edge
-   * paths bound to stale handle bounds (traces vanish until a layer-tab switch).
+   * must not call setNodes. When setNodes does run (drop/edit), existing node
+   * object refs are preserved by id — replacing every node leaves React Flow
+   * edge paths bound to stale handle bounds (traces vanish until a tab switch).
    */
   const prevNodeSyncKeyRef = useRef<string>('')
 
@@ -1103,8 +1136,9 @@ export function ScadaCanvas({
         ? deviceNodes.map(n => (n.id === selId ? { ...n, selected: true } : n))
         : deviceNodes)
     ]
-    // Skip setNodes when only edges changed (e.g. new connection). Remounting nodes
-    // on every edge edit desyncs RF handle bounds from edge SVG paths.
+    // Skip setNodes when only edges changed. When nodes must update (drop, edit),
+    // reuse existing node object refs by id — a full remount leaves RF edge paths
+    // on stale handle bounds (traces vanish until a layer-tab switch).
     const nodeSyncKey = `${activeLayer}:${scenario.visual.nodes
       .map(n => `${n.id}@${n.position.x},${n.position.y},${n.data.zone},${n.data.label}`)
       .join('|')}:${(scenario.visual.siteRegions ?? [])
@@ -1117,7 +1151,30 @@ export function ScadaCanvas({
       .join(',')}`
     if (nodeSyncKey !== prevNodeSyncKeyRef.current) {
       prevNodeSyncKeyRef.current = nodeSyncKey
-      setNodes(allNodes)
+      setNodes(prev => {
+        const prevById = new Map(prev.map(n => [n.id, n]))
+        return allNodes.map(fresh => {
+          const existing = prevById.get(fresh.id)
+          if (!existing) return fresh
+          // Unchanged nodes keep the same object ref so RF handle bounds stay valid.
+          // (fresh.data is always a new object from scenarioToNodes — compare fields.)
+          const samePos =
+            existing.position.x === fresh.position.x && existing.position.y === fresh.position.y
+          const sameSel = !!existing.selected === !!fresh.selected
+          if (samePos && sameSel && nodeRenderEqual(existing, fresh)) return existing
+          return {
+            ...existing,
+            position: fresh.position,
+            data: fresh.data,
+            selected: fresh.selected,
+            width: fresh.width ?? existing.width,
+            height: fresh.height ?? existing.height,
+            zIndex: fresh.zIndex,
+            selectable: fresh.selectable,
+            draggable: fresh.draggable
+          }
+        })
+      })
     }
     // Mark every edge as reconnectable so the user can drag endpoints to reroute
     // connections without having to delete and recreate them (read-only mode excluded).

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -1110,7 +1110,10 @@ export function ScadaCanvas({
       .join('|')}:${(scenario.visual.siteRegions ?? [])
       .map(r => `${r.id}@${r.position.x},${r.position.y},${r.width}x${r.height},${r.zone}`)
       .join('|')}:${Object.values(scenario.devices.devices)
-      .map(d => `${d.nodeId}@${d.ipAddress}@${d.label ?? ''}`)
+      .map(
+        d =>
+          `${d.nodeId}@${d.ipAddress}@${d.label ?? ''}@${d.category}@${d.sensor?.kind ?? ''}@${d.controller?.kind ?? ''}`
+      )
       .join(',')}`
     if (nodeSyncKey !== prevNodeSyncKeyRef.current) {
       prevNodeSyncKeyRef.current = nodeSyncKey


### PR DESCRIPTION
## Summary
- Scenario sync / `displayNodes` remounted canvas nodes, leaving React Flow edge paths on stale handle bounds (traces vanished until a layer-tab switch).
- Fix: reuse existing node object refs when syncing, and reuse `displayNodes` refs when pending-connection / cross-layer / fill decorations are unchanged.
- `nodeRenderEqual` covers label/IP/category/sensor.kind/controller.kind so Properties Panel edits still refresh icons.

## Test plan
- [x] Unlocked Author Copy → Author Mode → enable insider attacker → drag Kali → traces stay
- [x] Connect attacker → another device → traces stay
- [x] Cross-layer connect (HMI L3 → PLC L2) → existing traces stay
- [x] Re-tested after dropping redundant `nodeSyncKey`
- [ ] Switch layer tabs — edges still redraw correctly
- [ ] Edit device IP/label/sensor kind — canvas updates without wiping other edges