### PR TITLE
Fix insider Kali same-zone routes stolen via firewall

### DIFF
--- a/packages/orchestrator/src/__tests__/compose-generator.test.ts
+++ b/packages/orchestrator/src/__tests__/compose-generator.test.ts
@@ -609,6 +609,13 @@ describe('attack-machine — Insider Threat mode (visual zone placement)', () =>
     const nets = Object.keys(compose.services['kali-1'].networks)
     expect(nets).toEqual(['attacker-net', 'internet-dmz-net'])
   })
+
+  it('omits the insider drop-zone *_SUBNET env so entrypoint.sh will not steal the connected route', () => {
+    const env = gen(insiderScenario('ot')).services['kali-1'].environment ?? []
+    expect(env.some(e => e.startsWith('OT_SUBNET='))).toBe(false)
+    expect(env).toContain('CONTROL_SUBNET=10.200.20.0/24')
+    expect(env).toContain('PLANT_DMZ_SUBNET=10.200.30.0/24')
+  })
 })
 
 // ── PLC port publishing ───────────────────────────────────────────────────────

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -808,24 +808,17 @@ export function generateCompose(
         services[serviceName].environment = attackEnv
       }
 
-      // Inject static routes via the firewall gateway before the main entrypoint runs.
-      // Using compose entrypoint override avoids requiring an attack-base image rebuild
-      // when routing config changes. Routes OT/control/plant-dmz traffic through the
-      // firewall so nftables deny rules are effective for Tutorial 03 defense exercises.
+      // entrypoint.sh does `ip route replace $SUBNET via $FW_GW_IP` for each
+      // *_SUBNET env that is set. Omit the insider drop-tab subnet so the
+      // connected NIC route is not stolen (same-zone nmap showed filtered).
       const fwGwIp = `${attackerBase}.254`
-      services[serviceName].entrypoint = [
-        '/bin/sh',
-        '-c',
-        `ip route replace ${effectiveZones.ot.subnet} via ${fwGwIp} 2>/dev/null || true; ` +
-          `ip route replace ${effectiveZones.control.subnet} via ${fwGwIp} 2>/dev/null || true; ` +
-          `ip route replace ${effectiveZones['plant-dmz'].subnet} via ${fwGwIp} 2>/dev/null || true; ` +
-          `exec /entrypoint.sh`
-      ]
       const attackEnvFw: string[] = services[serviceName].environment ?? []
       attackEnvFw.push(`FW_GW_IP=${fwGwIp}`)
-      attackEnvFw.push(`OT_SUBNET=${effectiveZones.ot.subnet}`)
-      attackEnvFw.push(`CONTROL_SUBNET=${effectiveZones.control.subnet}`)
-      attackEnvFw.push(`PLANT_DMZ_SUBNET=${effectiveZones['plant-dmz'].subnet}`)
+      if (insiderZone !== 'ot') attackEnvFw.push(`OT_SUBNET=${effectiveZones.ot.subnet}`)
+      if (insiderZone !== 'control')
+        attackEnvFw.push(`CONTROL_SUBNET=${effectiveZones.control.subnet}`)
+      if (insiderZone !== 'plant-dmz')
+        attackEnvFw.push(`PLANT_DMZ_SUBNET=${effectiveZones['plant-dmz'].subnet}`)
       services[serviceName].environment = attackEnvFw
 
       // Point Kali's resolver at the scenario's dns-server so exercise hostnames


### PR DESCRIPTION
## Summary
- Insider Threat Kali on a Purdue drop-tab was routing same-zone traffic via the firewall on `attacker-net`, so nmap to a same-zone PLC showed **filtered** despite a canvas edge.
- Omit the drop-tab zone's `*_SUBNET` env so `entrypoint.sh` does not `ip route replace` over the connected NIC route; drop the redundant compose entrypoint route override.

## Test plan
- [ ] Place Insider Kali on OT tab with a PLC on OT; Start simulation
- [ ] In Kali: `ip route` — OT subnet should be connected (not via `10.200.60.254`)
- [ ] `nmap -sT <plc-ip> -p502` — not **filtered** (open/closed depending on PLC runtime)
- [ ] External (no visual) Kali still gets `OT_SUBNET` / `CONTROL_SUBNET` / `PLANT_DMZ_SUBNET` via firewall
- [ ] `npx vitest run src/__tests__/compose-generator.test.ts -t "omits the insider"` in `packages/orchestrator`