### PR TITLE
feat: edge-aware auto OpenPLC ST when no program is saved

### DIFF
--- a/packages/app/electron.vite.config.ts
+++ b/packages/app/electron.vite.config.ts
@@ -108,7 +108,9 @@ export default defineConfig({
     resolve: {
       alias: {
         '@renderer': resolve(__dirname, 'src/renderer/src'),
-        '@schema': resolve(__dirname, '../schema/src')
+        '@schema': resolve(__dirname, '../schema/src'),
+        // Bundle the pure gen helper — do not import @otforge/orchestrator (CJS/Docker).
+        '@plc-gen': resolve(__dirname, '../orchestrator/src/plc-program-gen.ts')
       }
     }
   }

--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -383,11 +383,13 @@ function StatusBar({
  */
 function PlcIdeModal({
   device,
+  scenario,
   simRunning,
   onProgramChange,
   onClose
 }: {
   device: DeviceConfig
+  scenario: OTForgeScenario
   simRunning: boolean
   onProgramChange: (nodeId: string, program: PLCProgramConfig) => void
   onClose: () => void
@@ -426,6 +428,7 @@ function PlcIdeModal({
         {/* Single-column Save Program body rendered by PlcIdePanel in modal mode */}
         <PlcIdePanel
           device={device}
+          scenario={scenario}
           simRunning={simRunning}
           onProgramChange={onProgramChange}
           modal={true}
@@ -2224,9 +2227,10 @@ export default function App() {
         onDelete={handleDelete}
       />
       {/* PLC IDE full-screen modal — fixed overlay rendered on top of the workspace */}
-      {plcIdeDevice && (
+      {plcIdeDevice && scenario && (
         <PlcIdeModal
           device={plcIdeDevice}
+          scenario={scenario}
           simRunning={simStatus === 'running'}
           onProgramChange={handleProgramChange}
           onClose={handleClosePlcIde}

--- a/packages/app/src/renderer/src/properties/PlcIdePanel.tsx
+++ b/packages/app/src/renderer/src/properties/PlcIdePanel.tsx
@@ -30,60 +30,14 @@
  */
 
 import { useState, useCallback, useId } from 'react'
-import type { DeviceConfig, PLCProgramConfig, Protocol, ImportedRoutine } from '@otforge/schema'
-
-// ── Default ST program template ───────────────────────────────────────────────
-
-const DEFAULT_ST_PROGRAM = `(* ============================================================
-   OTForge — PLC Program Template
-   Language: IEC 61131-3 Structured Text (ST)
-
-   Instructions:
-   1. Declare your process variables in the VAR block.
-      - Use AT %IX0.0 for digital inputs  (sensors, switches)
-      - Use AT %QX0.0 for digital outputs (pumps, valves)
-      - Use AT %IW0   for analog inputs   (4–20 mA, 0–10 V)
-      - Use AT %MW0   for memory words    (setpoints, counters)
-   2. Write your control logic below END_VAR.
-   3. Add variable bindings in the table, then click Save
-      to store the program in the scenario.
-   4. Click Deploy to push the program to a running container.
-   ============================================================ *)
-
-PROGRAM main
-  VAR
-    (* Process inputs — read from Modbus Input/Coil registers *)
-    level_high  AT %IX0.0 : BOOL;   (* High-level float switch    *)
-    level_low   AT %IX0.1 : BOOL;   (* Low-level float switch     *)
-    flow_rate   AT %IW0   : WORD;   (* Flow rate 0–1000 (L/min×10)*)
-
-    (* Process outputs — written to Modbus Coil/HR registers *)
-    pump_run    AT %QX0.0 : BOOL;   (* Start pump                 *)
-    inlet_valve AT %QX0.1 : BOOL;   (* Open inlet valve           *)
-    alarm_out   AT %QX0.2 : BOOL;   (* Activate alarm horn        *)
-
-    (* Internal memory — setpoints configurable via HMI *)
-    flow_setpt  AT %MW0   : WORD := 500;  (* Low-flow alarm threshold   *)
-  END_VAR
-
-  (* ── Control logic ──────────────────────────────────────────── *)
-
-  (* Start pump when tank is low; stop when tank is full *)
-  IF NOT level_high AND level_low THEN
-    pump_run    := TRUE;
-    inlet_valve := TRUE;
-  END_IF;
-
-  IF level_high THEN
-    pump_run    := FALSE;
-    inlet_valve := FALSE;
-  END_IF;
-
-  (* Raise alarm if flow drops below setpoint while pump is running *)
-  alarm_out := pump_run AND (flow_rate < flow_setpt);
-
-END_PROGRAM
-`
+import type {
+  DeviceConfig,
+  PLCProgramConfig,
+  Protocol,
+  ImportedRoutine,
+  OTForgeScenario
+} from '@otforge/schema'
+import { buildAutoPlcProgram, toB64, fromB64 } from '@plc-gen'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -101,6 +55,8 @@ interface VarRow {
 
 export interface PlcIdePanelProps {
   device: DeviceConfig
+  /** Full scenario — used to seed edge-aware auto ST when no plcProgram is saved. */
+  scenario: OTForgeScenario
   simRunning: boolean
   onProgramChange: (nodeId: string, program: PLCProgramConfig) => void
   /** When true, renders in the full-screen two-column IDE modal layout. */
@@ -570,15 +526,18 @@ function RoutinePickerModal({
  */
 export function PlcIdePanel({
   device,
+  scenario,
   simRunning,
   onProgramChange,
   modal = false
 }: PlcIdePanelProps) {
+  const auto = !device.plcProgram?.source ? buildAutoPlcProgram(scenario, device.nodeId) : null
   const initialSource = device.plcProgram?.source
-    ? atob(device.plcProgram.source)
-    : DEFAULT_ST_PROGRAM
-  const initialRows: VarRow[] =
-    device.plcProgram?.variables.map((v, i) => schemaVarToRow(v, i)) ?? []
+    ? fromB64(device.plcProgram.source)
+    : fromB64(auto!.source)
+  const initialRows: VarRow[] = (
+    device.plcProgram?.variables?.length ? device.plcProgram.variables : (auto?.variables ?? [])
+  ).map((v, i) => schemaVarToRow(v, i))
 
   const [source, setSource] = useState(initialSource)
   const [varRows, setVarRows] = useState<VarRow[]>(initialRows)
@@ -598,16 +557,20 @@ export function PlcIdePanel({
   const buildProgram = useCallback(
     (): PLCProgramConfig => ({
       language: 'st',
-      source: btoa(source),
+      source: toB64(source),
       variables: varRows.map(rowToSchemaVar)
     }),
     [source, varRows]
   )
 
   const handleSave = useCallback(() => {
-    onProgramChange(device.nodeId, buildProgram())
-    setStatusMsg('Program saved. Restart simulation to deploy to PLC.')
-    setTimeout(() => setStatusMsg(null), 4000)
+    try {
+      onProgramChange(device.nodeId, buildProgram())
+      setStatusMsg('Program saved. Restart simulation to deploy to PLC.')
+      setTimeout(() => setStatusMsg(null), 4000)
+    } catch (err) {
+      setStatusMsg(`Save failed: ${(err as Error).message}`)
+    }
   }, [buildProgram, device.nodeId, onProgramChange])
 
   const handleOpenWebUI = useCallback(() => {

--- a/packages/app/tsconfig.web.json
+++ b/packages/app/tsconfig.web.json
@@ -1,13 +1,15 @@
 {
   "extends": "@electron-toolkit/tsconfig/tsconfig.web.json",
   "include": [
-    "src/renderer/src/**/*"
+    "src/renderer/src/**/*",
+    "../orchestrator/src/plc-program-gen.ts"
   ],
   "compilerOptions": {
     "composite": true,
     "paths": {
       "@renderer/*": ["./src/renderer/src/*"],
-      "@schema/*": ["../schema/src/*"]
+      "@schema/*": ["../schema/src/*"],
+      "@plc-gen": ["../orchestrator/src/plc-program-gen.ts"]
     }
   }
 }

--- a/packages/orchestrator/src/__tests__/compose-generator.test.ts
+++ b/packages/orchestrator/src/__tests__/compose-generator.test.ts
@@ -800,10 +800,21 @@ describe('environment variable injection', () => {
     expect(env).toContain('PLC_VAR_COUNT=2')
   })
 
-  it('does NOT inject INITIAL_PROGRAM_B64 when plcProgram has no source', () => {
-    const compose = gen(makeScenario([['plc-1', { category: 'plc', ipAddress: '10.200.10.10' }]]))
-    const env = compose.services['plc-1'].environment ?? []
-    expect(env.some(v => v.startsWith('INITIAL_PROGRAM_B64'))).toBe(false)
+  it('injects edge-aware auto ST when PLC has no authored plcProgram', () => {
+    const scenario = makeScenario([
+      ['plc-1', { category: 'plc', ipAddress: '10.200.10.10' }],
+      [
+        'pump-1',
+        { category: 'smart-controller', ipAddress: '10.200.10.11', controller: { kind: 'pump' } }
+      ]
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'plc-1', target: 'pump-1', data: { protocol: 'modbus-tcp' } }
+    ]
+    const b64 = (gen(scenario).services['plc-1'].environment ?? [])
+      .find(v => v.startsWith('INITIAL_PROGRAM_B64='))
+      ?.slice('INITIAL_PROGRAM_B64='.length)
+    expect(Buffer.from(b64!, 'base64').toString()).toContain('pump_1_run AT %QX0.0')
   })
 })
 

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -31,6 +31,7 @@
 import yaml from 'js-yaml'
 import type { OTForgeScenario, DeviceCategory, NetworkZone } from '@otforge/schema'
 import { ZONE_DEFAULTS } from './network-config'
+import { buildAutoPlcProgram } from './plc-program-gen'
 
 /**
  * Maps each DeviceCategory to its Docker image reference on GHCR.
@@ -1556,12 +1557,12 @@ function ipToInt(ip: string): number {
  * configure the server process when the container starts.
  *
  * @param device   - The device configuration to generate env vars for.
- * @param _scenario - Full scenario (reserved for future cross-device references).
+ * @param scenario - Full scenario (PLC auto-ST walks edges for coil bindings).
  * @returns Array of "KEY=VALUE" strings for the compose environment field.
  */
 function buildDeviceEnv(
   device: OTForgeScenario['devices']['devices'][string],
-  _scenario: OTForgeScenario
+  scenario: OTForgeScenario
 ): string[] {
   const env: string[] = [
     `DEVICE_ID=${device.nodeId}`,
@@ -1704,17 +1705,14 @@ function buildDeviceEnv(
     env.push(`MAIL_DOMAIN=${device.mail.domain}`)
   }
 
-  // PLC program pre-load (Phase 4):
-  //   If the device has a saved Structured Text program, inject it as a base64-
-  //   encoded environment variable. The OpenPLC entrypoint.sh reads this variable,
-  //   decodes it to a .st file, and pre-loads it into the runtime at container
-  //   startup — so the PLC runs the user's program from the very first second.
-  //   The source field in PLCProgramConfig is already base64-encoded (btoa in the UI).
-  if (device.plcProgram?.source) {
-    env.push(`INITIAL_PROGRAM_B64=${device.plcProgram.source}`)
-    // Inject variable binding count for informational logging in entrypoint.sh.
-    // Optional-chain guards scenarios that omit the variables array (e.g. hand-authored JSON).
-    env.push(`PLC_VAR_COUNT=${device.plcProgram.variables?.length ?? 0}`)
+  // PLC program pre-load: authored plcProgram wins; otherwise edge-aware ST so
+  // OpenPLC auto-starts (502 binds) with coils for connected pumps/valves.
+  if (device.category === 'plc' || device.category === 'safety-plc') {
+    const program = device.plcProgram?.source
+      ? device.plcProgram
+      : buildAutoPlcProgram(scenario, device.nodeId)
+    env.push(`INITIAL_PROGRAM_B64=${program.source}`)
+    env.push(`PLC_VAR_COUNT=${program.variables?.length ?? 0}`)
   }
 
   return env

--- a/packages/orchestrator/src/plc-program-gen.ts
+++ b/packages/orchestrator/src/plc-program-gen.ts
@@ -1,0 +1,156 @@
+/**
+ * Edge-aware OpenPLC ST for PLCs with no authored plcProgram.
+ * Coils from coilSource edges + PLC↔pump/valve links; spare coil if none (502 binds).
+ */
+
+import type { CanvasEdge, OTForgeScenario, PLCProgramConfig } from '@otforge/schema'
+
+const ACTUATOR = new Set(['pump', 'valve', 'vfd', 'actuator'])
+
+/** UTF-8 base64 — plain btoa throws on non-Latin1 (crashed Save Program on old template). */
+export function toB64(text: string): string {
+  if (typeof Buffer !== 'undefined') return Buffer.from(text, 'utf8').toString('base64')
+  const bytes = new TextEncoder().encode(text)
+  let bin = ''
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return btoa(bin)
+}
+
+export function fromB64(b64: string): string {
+  if (typeof Buffer !== 'undefined') return Buffer.from(b64, 'base64').toString('utf8')
+  const bin = atob(b64)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+  return new TextDecoder().decode(bytes)
+}
+
+function peerKind(scenario: OTForgeScenario, id: string): string | null {
+  const k = scenario.devices.devices[id]?.controller?.kind
+  if (k && ACTUATOR.has(k)) return k
+  const t = scenario.visual.nodes.find(n => n.id === id)?.type
+  return t && ACTUATOR.has(t) ? t : null
+}
+
+function otherEnd(edge: CanvasEdge, id: string): string | null {
+  if (edge.source === id) return edge.target
+  if (edge.target === id) return edge.source
+  return null
+}
+
+function iecAddr(i: number): string {
+  return `%QX${Math.floor(i / 8)}.${i % 8}`
+}
+
+function ident(id: string, kind: string | null): string {
+  const base =
+    id
+      .replace(/[^a-zA-Z0-9_]/g, '_')
+      .replace(/^(\d)/, '_$1')
+      .toLowerCase() || 'coil'
+  return `${base}_${kind === 'valve' ? 'open' : 'run'}`
+}
+
+/** Coil map for a PLC — explicit coilSource first, then direct actuator edges. */
+function inferPlcCoilBindings(
+  scenario: OTForgeScenario,
+  plcId: string
+): Array<{ coilIndex: number; peerId: string; varName: string }> {
+  const byCoil = new Map<number, { coilIndex: number; peerId: string; varName: string }>()
+  const used = new Set<string>()
+
+  const put = (coilIndex: number, peerId: string): void => {
+    const kind = peerKind(scenario, peerId)
+    const cur = byCoil.get(coilIndex)
+    if (cur && peerKind(scenario, cur.peerId) && !kind) return
+    byCoil.set(coilIndex, { coilIndex, peerId, varName: ident(peerId, kind) })
+    used.add(peerId)
+  }
+
+  for (const edge of scenario.visual.edges) {
+    const cs = edge.data.coilSource
+    if (!cs || cs.nodeId !== plcId) continue
+    const a = otherEnd(edge, plcId)
+    const peer =
+      (a && peerKind(scenario, a) ? a : null) ??
+      (peerKind(scenario, edge.source) ? edge.source : null) ??
+      (peerKind(scenario, edge.target) ? edge.target : null) ??
+      a ??
+      edge.target
+    put(cs.coilIndex, peer)
+  }
+
+  let next = 0
+  for (const edge of scenario.visual.edges) {
+    const peer = otherEnd(edge, plcId)
+    if (!peer || !peerKind(scenario, peer) || used.has(peer)) continue
+    if (edge.data.coilSource?.nodeId === plcId) continue
+    while (byCoil.has(next)) next++
+    put(next++, peer)
+  }
+
+  return [...byCoil.values()].sort((a, b) => a.coilIndex - b.coilIndex)
+}
+
+function linkedToProcessUnit(scenario: OTForgeScenario, plcId: string): boolean {
+  for (const e of scenario.visual.edges) {
+    const cats = [e.source, e.target].map(id => scenario.devices.devices[id]?.category)
+    const touchesPu = cats.includes('process-unit')
+    if (!touchesPu) continue
+    if (e.data.coilSource?.nodeId === plcId || e.source === plcId || e.target === plcId) return true
+  }
+  return false
+}
+
+/** Minimal ST + variable map. Author plcProgram.source must win at the call site. */
+export function buildAutoPlcProgram(scenario: OTForgeScenario, plcId: string): PLCProgramConfig {
+  let bindings = inferPlcCoilBindings(scenario, plcId)
+  if (bindings.length === 0) {
+    bindings = [{ coilIndex: 0, peerId: plcId, varName: 'spare_0' }]
+  }
+
+  const vars: string[] = []
+  const logic: string[] = []
+  const variables: PLCProgramConfig['variables'] = []
+
+  for (const b of bindings) {
+    vars.push(`    ${b.varName} AT ${iecAddr(b.coilIndex)} : BOOL;`)
+    variables.push({
+      name: b.varName,
+      type: 'BOOL',
+      address: iecAddr(b.coilIndex),
+      protocol: 'modbus-tcp',
+      protocolAddress: String(b.coilIndex)
+    })
+  }
+
+  // ponytail: first 4 coils → process-sim master outs; expand if >4 actuators matter
+  if (linkedToProcessUnit(scenario, plcId)) {
+    for (let i = 0; i < Math.min(4, bindings.length); i++) {
+      const out = `${bindings[i].varName}_out`
+      vars.push(`    ${out} AT %QX100.${i} : BOOL;`)
+      logic.push(`  ${out} := ${bindings[i].varName};`)
+    }
+    vars.push(`    level_raw AT %IW100 : INT;`, `    tank_level AT %QW0 : INT;`)
+    logic.push(`  tank_level := level_raw;`)
+  }
+
+  const st = `(* auto-generated — override via Save Program *)
+PROGRAM main
+  VAR
+${vars.join('\n')}
+  END_VAR
+${logic.length ? '\n' + logic.join('\n') + '\n' : ''}
+END_PROGRAM
+
+CONFIGURATION config0
+  TASK task0(INTERVAL := T#100ms, PRIORITY := 0);
+  PROGRAM inst0 WITH task0 : main;
+END_CONFIGURATION
+`
+
+  return {
+    language: 'st',
+    source: toB64(st),
+    variables
+  }
+}


### PR DESCRIPTION
## Summary
- When a PLC has no authored `plcProgram`, compose now injects edge-aware Structured Text (coils for connected pumps/valves/vfd/actuators; spare coil if none) so OpenPLC auto-starts and Modbus 502 binds.
- Save Program seeds from the **same** generator (and uses UTF-8-safe base64 — plain `btoa` was crashing the UI on the old Unicode template).
- Authored / saved programs still win and are never overwritten.

## Pedagogy note (for maintainers / instructors)
This is a **starting point**, not a finished control program. Students can open Save Program, see how canvas edges map to `%QX` coils, then edit and re-save.

Whether that fits a given course depends on the instructor’s trajectory with OTForge:
- **Teach ST / PLC programming** — use auto-ST as a scaffold, then have students rewrite or extend it (or clear it and write from scratch in OpenPLC / Save Program). Labs like OpenPLC Lab already ship authored programs; those are unchanged.
- **“Just works” / attack-focused labs** — leave auto-ST in place so pumps/valves and recon (nmap, coil writes) work without a programming unit. Authors can still Save Program once to freeze a known baseline into the `.otflab`.

Happy to gate this behind a scenario flag or opt-out if you’d rather keep blank PLCs for ST-only courses.

## Test plan
- [ ] New scenario: PLC + smart-controller pump edge, no Save Program → Start sim → OpenPLC running with `pump_*_run` coil; `nmap` 502 not closed for lack of program
- [ ] Save Program opens showing auto-ST (not the old tutorial template); Save persists; restart sim still uses saved ST
- [ ] Scenario with authored `plcProgram` (e.g. OpenPLC Lab / ICS Lab 01) unchanged
- [ ] Save Program with non-ASCII comments does not crash the UI
- [ ] `npx vitest run src/__tests__/compose-generator.test.ts -t "edge-aware"` in `packages/orchestrator`