### PR TITLE
fix: Update OTForge dialog now reports container image refresh status

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -747,6 +747,14 @@ function registerIPCHandlers(): void {
       send('Installing dependencies (npm install)...')
       await runStreamedCommand('npm', ['install'], projectRoot, send)
 
+      // Tracks the container image pull outcome SEPARATELY from the overall
+      // source update — see AppUpdateResult.imageRefresh in packages/schema/
+      // src/ipc.ts for why this can't just be folded into `ok`. Every branch
+      // below sets exactly one of these two variables so the dialog text can
+      // tell the user honestly whether images were actually refreshed.
+      let imageRefresh: AppUpdateResult['imageRefresh']
+      let imageRefreshError: string | undefined
+
       if (scenario) {
         const dockerAvailable = await dockerClient.isAvailable()
         if (dockerAvailable) {
@@ -756,17 +764,36 @@ function registerIPCHandlers(): void {
           const scenarioDir = pathJoin(app.getPath('userData'), 'scenarios', projectName)
           const composeYaml = generateCompose(scenario, projectName, scenarioDir, zones)
           const imageResult = await dockerClient.updateImages(projectName, composeYaml, send)
-          if (!imageResult.ok) {
+          if (imageResult.ok) {
+            imageRefresh = 'ok'
+          } else {
+            imageRefresh = 'failed'
+            imageRefreshError = imageResult.error
             send(
               `Container image refresh failed: ${imageResult.error} (source update still applied)`
             )
           }
         } else {
+          imageRefresh = 'skipped-no-docker'
           send('Docker is not running — skipping container image refresh.')
         }
       } else {
+        imageRefresh = 'skipped-no-scenario'
         send('No scenario loaded — skipping container image refresh.')
       }
+
+      // Appended to whichever dialog shows below whenever images were NOT
+      // confirmed refreshed, so "up to date"/"restart required" never implies
+      // more than what actually happened. Left empty (no addendum) only when
+      // imageRefresh === 'ok'.
+      const imageRefreshNote =
+        imageRefresh === 'skipped-no-scenario'
+          ? '\n\nNote: no lab was open, so container images were NOT refreshed. Open a lab and click Update OTForge again to check for newer images.'
+          : imageRefresh === 'skipped-no-docker'
+            ? '\n\nNote: Docker was not running, so container images were NOT refreshed. Start Docker and click Update OTForge again to check for newer images.'
+            : imageRefresh === 'failed'
+              ? `\n\nNote: container image refresh FAILED (${imageRefreshError}). Source code is current, but you may still be running outdated containers — try Update OTForge again.`
+              : ''
 
       if (restartRequired) {
         await dialog.showMessageBox(mainWindow!, {
@@ -775,7 +802,8 @@ function registerIPCHandlers(): void {
           message: 'Update downloaded — restart required',
           detail:
             "This update changed OTForge's own code, so it needs to restart to take effect.\n\n" +
-            'Click OK, then stop this process (Ctrl+C) and run `npm run dev` again.',
+            'Click OK, then stop this process (Ctrl+C) and run `npm run dev` again.' +
+            imageRefreshNote,
           buttons: ['OK']
         })
         app.exit(0)
@@ -784,11 +812,12 @@ function registerIPCHandlers(): void {
           type: 'info',
           title: 'OTForge',
           message: 'OTForge is already up to date.',
+          detail: imageRefreshNote || undefined,
           buttons: ['OK']
         })
       }
 
-      return { ok: true, restartRequired }
+      return { ok: true, restartRequired, imageRefresh, imageRefreshError }
     } catch (err) {
       return { ok: false, error: `Update failed: ${(err as Error).message}` }
     }

--- a/packages/schema/src/ipc.ts
+++ b/packages/schema/src/ipc.ts
@@ -124,11 +124,23 @@ export interface AppInfo {
  * dialog. The renderer does not need to react to this field at all — by the
  * time app:update's promise resolves, the user has already been told
  * everything they need to know.
+ *
+ * `imageRefresh` reflects the SEPARATE outcome of the container image pull
+ * step, which does not affect `ok`/`restartRequired` at all — a scenario
+ * not being loaded, Docker not running, or `docker compose pull` failing are
+ * all still reported as an overall successful update, since the source/
+ * dependency update genuinely did succeed independently. This field exists
+ * so the main process's own dialog can say so honestly instead of always
+ * showing the same "up to date" message regardless of whether images were
+ * actually refreshed — a scenario that silently never got its images
+ * updated looks identical to a fully-current one otherwise.
  */
 export interface AppUpdateResult {
   ok: boolean
   error?: string
   restartRequired?: boolean
+  imageRefresh?: 'ok' | 'failed' | 'skipped-no-scenario' | 'skipped-no-docker'
+  imageRefreshError?: string
 }
 
 // ── PLC firmware import (Phase 9 add-on) ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- The "Update OTForge" dialog always said "up to date" / "restart required" regardless of whether container images were actually refreshed. A scenario not being loaded, Docker not running, or `docker compose pull` failing all silently skipped the image refresh while the dialog still implied everything was current.
- Found while diagnosing why one student in a class had a stale Suricata image that never generated alerts, despite reportedly using Update OTForge regularly — the likely cause is clicking it before opening a lab, which skips the image refresh entirely with no visible warning in the final dialog.

## Changes
- `packages/schema/src/ipc.ts`: `AppUpdateResult` gains `imageRefresh?: 'ok' | 'failed' | 'skipped-no-scenario' | 'skipped-no-docker'` and `imageRefreshError?: string`.
- `packages/app/src/main/index.ts`: the `app:update` handler now tracks which of those four states occurred and appends an explanatory note to whichever dialog is shown (restart-required or up-to-date) whenever images were NOT confirmed refreshed. No change to the `ok`/`restartRequired` semantics or the restart/exit behavior itself — this only makes the dialog text honest about the separate image-refresh outcome.

## Testing
- `tsc --noEmit` clean across `packages/schema`, `packages/app` (both tsconfig.json and tsconfig.node.json), and `packages/orchestrator`
- Existing test suite: 182/182 passing in `packages/orchestrator`, no regressions
- Verified the note-construction logic directly for all four `imageRefresh` states — each produces the expected, correctly-worded string; the `ok` case produces an empty note so the original "up to date" message is unchanged for the fully-current case
- Not verified: an actual interactive click-through of the native Electron dialog, since `dialog.showMessageBox` blocks on GUI input this environment can't provide. The dialog wiring itself (message/detail/buttons) is unchanged from the existing pattern already used for the two dialogs in this handler.

## Test plan
- [ ] Click Update OTForge with no scenario open — dialog should note images were not refreshed
- [ ] Click Update OTForge with Docker Desktop stopped — dialog should note Docker wasn't running
- [ ] Click Update OTForge with a scenario open and Docker running, source already current — plain "already up to date" dialog, unchanged from before
- [ ] Click Update OTForge when a new commit is pulled — restart-required dialog, unchanged from before

🤖 Generated with [Claude Code](https://claude.com/claude-code)