### PR TITLE
feat: real DCS controller — Modbus poll + OPC-UA aggregation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,8 @@ jobs:
             context: containers/profinet
           - image: otforge-camera
             context: containers/camera
+          - image: otforge-dcs
+            context: containers/dcs
           - image: otforge-firewall
             context: containers/firewall
           - image: otforge-switch

--- a/containers/dcs/Dockerfile
+++ b/containers/dcs/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-alpine
+
+WORKDIR /app
+
+# pymodbus 3.7.4 — used here as a CLIENT (polling connected field devices), unlike
+# containers/modbus's server-only usage. Same version pin for consistency; the
+# client-side API has been stable across the 3.x line regardless of the server-side
+# datastore changes documented in that container's Dockerfile.
+# asyncua (opcua-asyncio) 1.1.x — pure Python OPC UA 1.04 implementation, same as
+# containers/opcua. cryptography is required for its built-in certificate/PKI stack
+# even when security mode is None.
+RUN pip install --no-cache-dir "pymodbus==3.7.4" "asyncua==1.1.5" "cryptography>=42"
+
+COPY server.py .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+# Defaults — all overridable via docker-compose environment:
+ENV DEVICE_ID=dcs-1 \
+    DEVICE_CATEGORY=dcs-controller \
+    OPCUA_PORT=4840 \
+    OPCUA_NAMESPACE=urn:otforge:ics \
+    DCS_FIELD_DEVICES=""
+
+# OPC UA binary TCP endpoint
+EXPOSE 4840
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/containers/dcs/entrypoint.sh
+++ b/containers/dcs/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+echo "[ics-dcs] Device=${DEVICE_ID}  category=${DEVICE_CATEGORY}  port=${OPCUA_PORT}  ns=${OPCUA_NAMESPACE}"
+echo "[ics-dcs] Field devices: ${DCS_FIELD_DEVICES:-<none — DCS not wired to any field device>}"
+
+exec python3 /app/server.py

--- a/containers/dcs/server.py
+++ b/containers/dcs/server.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+server.py — Real DCS (Distributed Control System) controller for the ICS Simulator.
+
+Models a real-world DCS (Honeywell Experion, Emerson DeltaV, ABB 800xA style):
+polls the field devices wired to it over Modbus TCP, then re-exposes what it
+reads as a browseable OPC UA namespace, exactly the "field I/O in, operator/
+historian view out" role a real DCS plays. This is the "aggregation and
+visibility" layer connectionRules.ts already describes for dcs-controller —
+until now the device category existed only as a bare, unconfigured stub.
+
+Scope (read-only upward, deliberately — see containers/dcs/README-less design
+note below): this container polls field devices and mirrors their state via
+OPC UA. It does NOT write setpoints back down to the field devices yet — that
+is a natural follow-up once this read path is proven, not something silently
+half-implemented here. Two independent, already-real attack surfaces exist
+without it: (1) this OPC UA server itself, unauthenticated by default exactly
+like containers/opcua's scada-server, and (2) the field device's own Modbus
+server (smart-controller), already directly attackable — this DCS's OPC UA
+readout is what would show an analyst the effect of that Modbus attack.
+
+Node layout (all under ns=<OPCUA_NAMESPACE>):
+    Objects/
+      FieldDevices/
+        <nodeId>/
+          Coil0        — BOOL,  mirrors the field device's Modbus coil 0 (FC01)
+          HoldingReg0  — FLOAT, mirrors the field device's Modbus holding register 0 (FC03)
+
+Environment variables:
+    DEVICE_ID          — node identifier string, used in the server display name
+    DEVICE_CATEGORY    — logged at startup for Docker Compose traceability
+    OPCUA_PORT         — TCP port for the OPC UA binary endpoint (default 4840)
+    OPCUA_NAMESPACE    — namespace URI registered with the server (default urn:otforge:ics)
+    DCS_FIELD_DEVICES  — comma-separated "nodeId|ip" pairs, one per field device this
+                         DCS is wired to on the canvas (compose-generator.ts derives
+                         this from canvas edges — see connectionRules.ts's
+                         dcs-controller.sensor entry). Empty/unset means the DCS was
+                         placed but not wired to anything yet; the server still starts
+                         cleanly with an empty namespace.
+
+Protocol references: Modbus Application Protocol Specification (field I/O polling),
+OPC UA Part 4 (Services) / Part 6 (Mappings) — same as containers/opcua.
+Library versions: pymodbus 3.7.4 (client mode — containers/modbus only uses its
+server-side API), asyncua 1.1.x.
+"""
+
+import asyncio
+import logging
+import os
+
+from asyncua import Server, ua
+from pymodbus.client import AsyncModbusTcpClient
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("ics-dcs")
+
+DEVICE_ID  = os.getenv("DEVICE_ID", "dcs-1")
+CATEGORY   = os.getenv("DEVICE_CATEGORY", "dcs-controller")
+PORT       = int(os.getenv("OPCUA_PORT", "4840"))
+NAMESPACE  = os.getenv("OPCUA_NAMESPACE", "urn:otforge:ics")
+
+MODBUS_PORT = 502
+# Field devices in this simulator are seeded at Modbus unit id 1 by default
+# (see e.g. compose-generator.ts's MODBUS_UNIT_ID default) — this DCS polls
+# that default unit id. A field device configured with a non-default unit id
+# will simply time out and be logged as unreachable, same as any other polling
+# error; making the unit id itself configurable per field device is a
+# reasonable follow-up if that assumption ever stops holding.
+FIELD_DEVICE_UNIT_ID = 1
+
+POLL_INTERVAL_SECONDS = 2
+# Generous but bounded — a stalled connect() must not stall polling every
+# other field device behind it.
+POLL_TIMEOUT_SECONDS = 3
+
+
+def parse_field_devices(raw: str) -> list[tuple[str, str]]:
+    """
+    Parses DCS_FIELD_DEVICES ("nodeId|ip,nodeId|ip,...") into a list of
+    (nodeId, ip) tuples. Malformed entries are logged and skipped rather than
+    raising — one bad entry must not take down the whole DCS.
+    """
+    devices: list[tuple[str, str]] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        parts = entry.split("|")
+        if len(parts) != 2:
+            log.warning("Skipping malformed DCS_FIELD_DEVICES entry: %r", entry)
+            continue
+        node_id, ip = parts[0].strip(), parts[1].strip()
+        if node_id and ip:
+            devices.append((node_id, ip))
+    return devices
+
+
+# ── Modbus polling ────────────────────────────────────────────────────────────
+
+async def poll_field_device(node_id: str, ip: str) -> tuple[bool | None, float | None]:
+    """
+    Opens a fresh Modbus TCP client connection to one field device, reads
+    Coil 0 (FC01) and Holding Register 0 (FC03), then closes the connection.
+
+    Reconnecting every poll cycle (rather than holding a persistent client
+    per field device) trades a little efficiency for much simpler, more
+    robust recovery: a field device that's mid-restart, not up yet, or
+    briefly unreachable just produces one skipped poll, not a client left in
+    a broken state that needs its own reconnect logic.
+
+    Returns (coil0, holding_reg0) — either element is None if that specific
+    read failed or the device was unreachable at all (both None in that case).
+    """
+    client = AsyncModbusTcpClient(ip, port=MODBUS_PORT, timeout=POLL_TIMEOUT_SECONDS)
+    coil0: bool | None = None
+    hr0: float | None = None
+    try:
+        await client.connect()
+        if not client.connected:
+            log.warning("%s (%s): connection failed", node_id, ip)
+            return None, None
+
+        coil_result = await client.read_coils(0, count=1, slave=FIELD_DEVICE_UNIT_ID)
+        if not coil_result.isError():
+            coil0 = bool(coil_result.bits[0])
+
+        hr_result = await client.read_holding_registers(0, count=1, slave=FIELD_DEVICE_UNIT_ID)
+        if not hr_result.isError():
+            hr0 = float(hr_result.registers[0])
+    except Exception as exc:  # noqa: BLE001 — one field device's failure must not crash the poll loop
+        log.warning("%s (%s): poll error — %s", node_id, ip, exc)
+    finally:
+        client.close()
+
+    return coil0, hr0
+
+
+async def poll_loop(field_devices: list[tuple[str, str]], opcua_nodes: dict[str, dict[str, object]]) -> None:
+    """
+    Background task — polls every field device every POLL_INTERVAL_SECONDS.
+
+    Each field device's poll+write is wrapped in its own try/except so one
+    device's failure (a bad write, a dropped connection mid-cycle, anything
+    unexpected) can't silently kill polling for every other device forever —
+    this task is a fire-and-forget asyncio.create_task() with no supervisor,
+    so an uncaught exception here would end the loop permanently with only an
+    "exception was never retrieved" warning as evidence.
+    """
+    if not field_devices:
+        log.info("No field devices configured — DCS namespace will stay empty until wired to something.")
+        return
+
+    while True:
+        for node_id, ip in field_devices:
+            try:
+                coil0, hr0 = await poll_field_device(node_id, ip)
+                nodes = opcua_nodes[node_id]
+                if coil0 is not None:
+                    await nodes["coil0"].write_value(ua.Variant(coil0, ua.VariantType.Boolean))
+                if hr0 is not None:
+                    # Explicit Variant typing required — a bare Python float writes as
+                    # Double (type 11), which asyncua rejects with BadTypeMismatch
+                    # against a node created with varianttype=ua.VariantType.Float
+                    # (type 10). Confirmed live: an unwrapped write here crashed this
+                    # entire background task on the very first poll cycle.
+                    await nodes["holding_reg0"].write_value(ua.Variant(hr0, ua.VariantType.Float))
+            except Exception as exc:  # noqa: BLE001 — one field device's OPC UA write failing must not end polling for the rest
+                log.warning("%s: OPC UA write error — %s", node_id, exc)
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+
+
+# ── Server setup ──────────────────────────────────────────────────────────────
+
+async def main() -> None:
+    """
+    Start the OPC UA server, register one object per configured field device,
+    then run the Modbus poll loop forever alongside it.
+
+    Security is intentionally left at SecurityMode=None / SecurityPolicy=None,
+    same as containers/opcua — mirrors the common real-world default and is
+    the actual attack surface this device is meant to teach.
+    """
+    field_devices = parse_field_devices(os.getenv("DCS_FIELD_DEVICES", ""))
+    log.info(
+        "Field devices wired to this DCS: %s",
+        ", ".join(f"{n}@{ip}" for n, ip in field_devices) or "(none)",
+    )
+
+    server = Server()
+    await server.init()
+
+    server.set_endpoint(f"opc.tcp://0.0.0.0:{PORT}/otforge/{DEVICE_ID}")
+    server.set_server_name(f"OTForge DCS Controller — {DEVICE_ID}")
+
+    idx = await server.register_namespace(NAMESPACE)
+
+    objects = server.nodes.objects
+    field_devices_folder = await objects.add_object(idx, "FieldDevices")
+
+    # Build one Coil0/HoldingReg0 node pair per field device. Read-only (no
+    # set_writable()) — this DCS only mirrors what it polls in this pass, see
+    # the module docstring for why write-down is deferred rather than faked.
+    opcua_nodes: dict[str, dict[str, object]] = {}
+    for node_id, _ip in field_devices:
+        device_folder = await field_devices_folder.add_object(idx, node_id)
+        coil_node = await device_folder.add_variable(idx, "Coil0", False, varianttype=ua.VariantType.Boolean)
+        hr_node = await device_folder.add_variable(idx, "HoldingReg0", 0.0, varianttype=ua.VariantType.Float)
+        opcua_nodes[node_id] = {"coil0": coil_node, "holding_reg0": hr_node}
+
+    log.info(
+        "OPC UA server ready — endpoint opc.tcp://0.0.0.0:%d  ns=%d (%s)",
+        PORT, idx, NAMESPACE,
+    )
+
+    async with server:
+        asyncio.create_task(poll_loop(field_devices, opcua_nodes))
+        log.info("Poll loop running — field devices refreshed every %ds", POLL_INTERVAL_SECONDS)
+        await asyncio.Future()  # run until cancelled
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/orchestrator/src/__tests__/compose-generator.test.ts
+++ b/packages/orchestrator/src/__tests__/compose-generator.test.ts
@@ -825,6 +825,82 @@ describe('environment variable injection', () => {
   })
 })
 
+describe('dcs-controller — real device', () => {
+  it('gives dcs-controller the otforge-dcs image — a real container, not the alpine stub', () => {
+    const compose = gen(
+      makeScenario([['dcs-1', { category: 'dcs-controller', ipAddress: '10.200.10.10' }]])
+    )
+    expect(compose.services['dcs-1']).toBeDefined()
+    expect(compose.services['dcs-1'].image).toBe('ghcr.io/iburres/otforge-dcs:latest')
+  })
+
+  it('assigns the 128m/0.5 resource limit to dcs-controller', () => {
+    const compose = gen(
+      makeScenario([['dcs-1', { category: 'dcs-controller', ipAddress: '10.200.10.10' }]])
+    )
+    expect(compose.services['dcs-1'].deploy.resources.limits.memory).toBe('128m')
+    expect(compose.services['dcs-1'].deploy.resources.limits.cpus).toBe('0.5')
+  })
+
+  it('injects DCS_FIELD_DEVICES from a single edge to a smart-controller', () => {
+    const scenario = makeScenario([
+      ['dcs-1', { category: 'dcs-controller', ipAddress: '10.200.10.10' }],
+      [
+        'pump-1',
+        { category: 'smart-controller', ipAddress: '10.200.10.11', controller: { kind: 'pump' } }
+      ]
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'dcs-1', target: 'pump-1', data: { protocol: 'modbus-tcp' } }
+    ]
+    const env = gen(scenario).services['dcs-1'].environment ?? []
+    expect(env).toContain('DCS_FIELD_DEVICES=pump-1|10.200.10.11')
+  })
+
+  it('injects DCS_FIELD_DEVICES as a comma-separated list from multiple edges', () => {
+    const scenario = makeScenario([
+      ['dcs-1', { category: 'dcs-controller', ipAddress: '10.200.10.10' }],
+      [
+        'pump-1',
+        { category: 'smart-controller', ipAddress: '10.200.10.11', controller: { kind: 'pump' } }
+      ],
+      ['sensor-1', { category: 'smart-sensor', ipAddress: '10.200.10.12' }]
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'dcs-1', target: 'pump-1', data: { protocol: 'modbus-tcp' } },
+      { id: 'e2', source: 'sensor-1', target: 'dcs-1', data: { protocol: 'modbus-tcp' } }
+    ]
+    const env = gen(scenario).services['dcs-1'].environment ?? []
+    const fieldDevicesEnv = env.find(v => v.startsWith('DCS_FIELD_DEVICES='))
+    expect(fieldDevicesEnv).toBeDefined()
+    const entries = fieldDevicesEnv!.slice('DCS_FIELD_DEVICES='.length).split(',')
+    expect(entries).toEqual(
+      expect.arrayContaining(['pump-1|10.200.10.11', 'sensor-1|10.200.10.12'])
+    )
+    expect(entries).toHaveLength(2)
+  })
+
+  it('omits DCS_FIELD_DEVICES entirely when the DCS has no connecting edges', () => {
+    const compose = gen(
+      makeScenario([['dcs-1', { category: 'dcs-controller', ipAddress: '10.200.10.10' }]])
+    )
+    const env = compose.services['dcs-1'].environment ?? []
+    expect(env.some(v => v.startsWith('DCS_FIELD_DEVICES'))).toBe(false)
+  })
+
+  it('does not pull an edge to an unrelated category (e.g. hmi) into the field-device list', () => {
+    const scenario = makeScenario([
+      ['dcs-1', { category: 'dcs-controller', ipAddress: '10.200.10.10' }],
+      ['hmi-1', { category: 'hmi', ipAddress: '10.200.20.10' }]
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'dcs-1', target: 'hmi-1', data: { protocol: 'opc-ua' } }
+    ]
+    const env = gen(scenario).services['dcs-1'].environment ?? []
+    expect(env.some(v => v.startsWith('DCS_FIELD_DEVICES'))).toBe(false)
+  })
+})
+
 // ── DNS device env vars ───────────────────────────────────────────────────────
 
 describe('DNS device environment variable injection', () => {

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -64,8 +64,10 @@ const DEVICE_IMAGES: Record<DeviceCategory, string> = {
   'process-unit': 'ghcr.io/iburres/otforge-process:latest',
   // STUB: Safety PLC / SIS — same OpenPLC runtime until otforge-safety-plc is built.
   'safety-plc': 'ghcr.io/iburres/otforge-openplc:latest',
-  // STUB: DCS Controller — pymodbus on Alpine until otforge-dcs image is built.
-  'dcs-controller': 'ghcr.io/iburres/alpine:latest',
+  // Real DCS Controller — polls connected field devices over Modbus TCP and
+  // re-exposes them via an OPC-UA server (containers/dcs), mirroring how a
+  // real DCS (DeltaV/Experion/800xA) aggregates field I/O.
+  'dcs-controller': 'ghcr.io/iburres/otforge-dcs:latest',
   // BACnet/IP device — bacpypes3 Python server on Alpine (containers/bacnet)
   sensor: 'ghcr.io/iburres/otforge-bacnet:latest',
   // STUB: IIoT sensor — MQTT publisher stub until otforge-iiot-sensor is built.
@@ -151,7 +153,7 @@ const DEVICE_LIMITS: Record<DeviceCategory, { memory: number; cpus: string }> = 
   'iec104-rtu': { memory: 80, cpus: '0.25' }, // pure-Python IEC 104 on Alpine (Phase 10)
   'process-unit': { memory: 96, cpus: '0.25' }, // pymodbus + physics loop on Alpine (Phase 11)
   'safety-plc': { memory: 128, cpus: '0.5' }, // Safety PLC / SIS — same budget as process PLC
-  'dcs-controller': { memory: 128, cpus: '0.5' }, // DCS Controller — OPC-UA server + loop logic
+  'dcs-controller': { memory: 128, cpus: '0.5' }, // Real DCS — Modbus client poll loop + OPC-UA server
   sensor: { memory: 96, cpus: '0.25' }, // BACnet/IP bacpypes3 Python server
   'iiot-sensor': { memory: 64, cpus: '0.1' }, // IIoT sensor — lightweight MQTT publish loop
   'iot-gateway': { memory: 96, cpus: '0.2' }, // IoT gateway — MQTT broker + protocol bridge
@@ -446,6 +448,39 @@ export function generateCompose(
     }
   }
 
+  // ── DCS controller → field device map ──────────────────────────────────────
+  // Scan canvas edges to find which smart-controller/smart-sensor field
+  // devices (if any) each dcs-controller is directly wired to. Used below to
+  // inject DCS_FIELD_DEVICES so the DCS's Modbus client poll loop knows which
+  // field devices to read at container startup — see containers/dcs/server.py.
+  //
+  // Unlike the PLC↔process-unit map above, this is a direct-edge-only,
+  // one-to-many relationship (no coilSource indirection): a DCS only sees
+  // whatever is actually wired to it on the canvas, matching a real DCS's
+  // I/O scope and connectionRules.ts's existing dcs-controller.sensor entry.
+  const dcsToFieldDeviceNodeIds = new Map<string, string[]>()
+  const isFieldDevice = (category: string): boolean =>
+    category === 'smart-controller' || category === 'smart-sensor'
+  for (const edge of scenario.visual.edges) {
+    const srcDevice = scenario.devices.devices[edge.source]
+    const tgtDevice = scenario.devices.devices[edge.target]
+    if (!srcDevice || !tgtDevice) continue
+    let dcsNodeId: string | null = null
+    let fieldNodeId: string | null = null
+    if (srcDevice.category === 'dcs-controller' && isFieldDevice(tgtDevice.category)) {
+      dcsNodeId = edge.source
+      fieldNodeId = edge.target
+    } else if (tgtDevice.category === 'dcs-controller' && isFieldDevice(srcDevice.category)) {
+      dcsNodeId = edge.target
+      fieldNodeId = edge.source
+    }
+    if (dcsNodeId && fieldNodeId) {
+      const existing = dcsToFieldDeviceNodeIds.get(dcsNodeId) ?? []
+      existing.push(fieldNodeId)
+      dcsToFieldDeviceNodeIds.set(dcsNodeId, existing)
+    }
+  }
+
   // ── IP deduplication ────────────────────────────────────────────────────────
   // Tracks host octets already assigned per Docker network so that stale or
   // duplicate IPs in the scenario JSON never produce an invalid compose file.
@@ -640,6 +675,30 @@ export function generateCompose(
       if (device.controller.liftMethod)
         ctrlEnv.push(`CONTROLLER_LIFT_METHOD=${device.controller.liftMethod}`)
       services[serviceName].environment = ctrlEnv
+    }
+
+    // DCS controller — inject the field devices (smart-controller/smart-sensor)
+    // this DCS is directly wired to, so containers/dcs/server.py knows which
+    // Modbus TCP hosts to poll at startup. Omitted entirely when the DCS has
+    // no connecting edges yet — the container still starts cleanly with an
+    // empty namespace (see server.py's module docstring).
+    if (device.category === 'dcs-controller') {
+      const fieldDeviceNodeIds = dcsToFieldDeviceNodeIds.get(nodeId) ?? []
+      if (fieldDeviceNodeIds.length > 0) {
+        const fieldDeviceEntries = fieldDeviceNodeIds.map(fieldNodeId => {
+          const fieldIp =
+            claimedDeviceIps.get(fieldNodeId) ??
+            resolveDeviceIp(
+              scenario.devices.devices[fieldNodeId].ipAddress,
+              scenario,
+              effectiveZones
+            )
+          return `${sanitizeServiceName(fieldNodeId)}|${fieldIp}`
+        })
+        const dcsEnv: string[] = services[serviceName].environment ?? []
+        dcsEnv.push(`DCS_FIELD_DEVICES=${fieldDeviceEntries.join(',')}`)
+        services[serviceName].environment = dcsEnv
+      }
     }
 
     // Process-unit containers publish their Modbus TCP port (502) on a deterministic


### PR DESCRIPTION
## Summary
- `dcs-controller` was fully wired into the authoring UI (palette, real icon, connection rules across every layer, an attack-machine target list promising "OPC-UA credential attacks, Modbus setpoint manipulation") but backed by `ghcr.io/iburres/alpine:latest` — a bare container with no server process at all. Top item on the target-sectors roadmap: chemical-batch and power-generation were both marked PARTIAL specifically because of this gap.
- `containers/dcs/` is a real device: polls the `smart-controller`/`smart-sensor` field devices wired to it (derived automatically from canvas edges — no new authored config, no schema changes) over Modbus TCP, then re-exposes `Coil0`/`HoldingReg0` per field device via an unauthenticated OPC-UA server, mirroring how a real DCS (DeltaV/Experion/800xA) aggregates field I/O.
- **Scope, deliberately kept small:** read-only upward polling only. No write-down (OPC-UA write → Modbus write to the field device) in this pass — a clean, separately-scoped follow-up once this read path is proven. This is still fully meaningful pedagogically: "OPC-UA credential attacks" hits the DCS's own unauthenticated server directly, and "Modbus setpoint manipulation" hits the field device's own Modbus server directly (already real via `smart-controller`) — the DCS's value here is being a real, attackable aggregation point whose OPC-UA readout would show an analyst the effect of that Modbus attack.

## Changes
- `containers/dcs/` (new): `python:3.12-alpine` + `pymodbus==3.7.4` (client mode — new usage pattern for this project, existing containers are server-only) + `asyncua==1.1.5`. `server.py` polls each configured field device every 2s and mirrors state via OPC-UA.
- `packages/orchestrator/src/compose-generator.ts`: image mapping (alpine stub → `otforge-dcs`), new edge-derived `dcsToFieldDeviceNodeIds` map (same pattern as the existing PLC↔process-unit map, generalized to one-to-many), new `DCS_FIELD_DEVICES` env injection (`nodeId|ip,nodeId|ip`, mirrors the existing `WS_PLC_WEBUIS` convention).
- `packages/orchestrator/src/__tests__/compose-generator.test.ts`: 6 new tests — real image, resource limits, single/multiple field-device env derivation, no env var when unwired, and an edge to an unrelated category doesn't get pulled in.
- `.github/workflows/docker.yml`: `otforge-dcs` added to the build matrix.

## Bug found and fixed during live verification
An unwrapped Python `float` written to an OPC-UA node explicitly typed `Float` at creation raises `BadTypeMismatch` (asyncua infers `Double` from a bare Python float). This crashed the entire poll loop silently on the very first write — it's a fire-and-forget `asyncio.create_task()` with no supervisor, so the only trace was an "exception was never retrieved" log line. Fixed with explicit `ua.Variant(value, ua.VariantType.Float)` typing, plus wrapping each field device's poll+write in its own try/except so one device's failure can't end polling for the rest.

## Testing
- `tsc --noEmit` clean across `packages/schema`, `packages/orchestrator`, `packages/app` (both tsconfigs) — no schema/app changes needed, confirmed nothing else broke
- 189/189 orchestrator tests passing (6 new)
- Built the image locally, confirmed clean startup with an empty field-device list
- **Live end-to-end verification:** generated a real compose file via the actual `generateCompose()` (a temporary scratch test, removed before commit) for a DCS wired to a `smart-controller` pump, ran both containers, wrote the pump's Modbus coil directly, and confirmed the DCS's OPC-UA readout picked up the change on its next poll cycle — `Coil0` went `False → True` after a live Modbus write, `HoldingReg0` correctly stayed `0.0` (unset rated flow)

## Test plan
- [ ] Drag a DCS Controller onto the OT layer, wire a `modbus-tcp` edge to a `smart-controller` (pump/valve), run the simulation
- [ ] Confirm the DCS container logs show it polling the field device
- [ ] Connect an OPC-UA client (UA Expert, asyncua) to the DCS's endpoint and confirm `Objects/FieldDevices/<nodeId>/Coil0` and `HoldingReg0` reflect the field device's real state
- [ ] Write the field device's Modbus coil directly and confirm the DCS's OPC-UA readout updates within ~2s
- [ ] Confirm a DCS with no wired field devices still starts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)