### PR TITLE
fix: resolve high-severity brace-expansion ReDoS via npm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "prettier": "^3.3.3",
     "typescript": "^5.7.3"
   },
+  "overrides": {
+    "brace-expansion": "^2.1.2"
+  },
   "lint-staged": {
     "packages/*/src/**/*.{ts,tsx}": [
       "eslint --fix",


### PR DESCRIPTION
## Summary
- `npm audit` flagged a high-severity ReDoS in `brace-expansion` (GHSA-3jxr-9vmj-r5cp), transitively pulled in by several dev-tooling packages (electron-builder's `@electron/asar`/`@electron/universal`, `eslint`, `glob`, `dir-compare`, `filelist`). All dev-tooling-only — not shipped in the app or reachable by students — but worth closing.
- `npm audit fix` can't help here: `.npmrc` sets `package-lock=false` (intentional, avoids cross-platform lockfile churn between Windows/Mac contributors) and `audit fix` requires a lockfile to compute its remediation.

## Fix
- Added a root `"overrides": { "brace-expansion": "^2.1.2" }` entry, which forces the patched version tree-wide without needing a lockfile at all.
- Found along the way: an incremental `npm install` after adding the override only patched 4 of the 8 vulnerable nested copies — a full clean reinstall (`rm -rf node_modules && npm install`) was required for the override to actually reach every one.

## Testing
- `npm audit` → 0 vulnerabilities (was 1 high) after a clean reinstall
- `tsc --noEmit` clean across `packages/schema`, `packages/orchestrator`, `packages/app` (both tsconfigs)
- 189/189 orchestrator tests passing

## Test plan
- [ ] After pulling this, run a clean `rm -rf node_modules && npm install --legacy-peer-deps --no-package-lock` (or just the normal `predev` script) and confirm `npm audit` reports 0 vulnerabilities
- [ ] Confirm `npm run dev` still starts the app normally (override is a patch-level bump within brace-expansion's stable 2.x line, no expected behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)