### PR TITLE
fix: treat insider Kali as present on Attack Machine toolbar

### DIFF
--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -1349,29 +1349,30 @@ export default function App() {
   }, [])
 
   /**
-   * Removes all attack-machine devices from the scenario device list.
-   *
-   * Attack machines live only in scenario.devices.devices (they have no visual node
-   * on any canvas layer), so removal is a simple key filter on the devices map.
+   * Removes all attack-machine devices and any insider canvas nodes/edges.
    * Only callable when the simulation is idle — the button is not shown while running.
    */
   const handleAttackMachineRemove = useCallback(() => {
     setScenario(prev => {
       if (!prev) return prev
-      // Only remove attack-machine devices that have no visual canvas node — an
-      // Insider Threat mode attack machine dropped onto a Purdue tab DOES have one
-      // and is removed like any other device (select + delete on canvas), which
-      // already prunes visual.nodes/edges together with devices.devices. Filtering
-      // on visual node presence here (rather than removing every attack-machine
-      // device unconditionally) avoids orphaning an insider-placed node's visual
-      // entry while its backing device silently disappears.
-      const visualNodeIds = new Set(prev.visual.nodes.map(n => n.id))
-      const filtered = Object.fromEntries(
-        Object.entries(prev.devices.devices).filter(
-          ([nodeId, d]) => d.category !== 'attack-machine' || visualNodeIds.has(nodeId)
-        )
+      const attackIds = new Set(
+        Object.entries(prev.devices.devices)
+          .filter(([, d]) => d.category === 'attack-machine')
+          .map(([id]) => id)
       )
-      return { ...prev, devices: { devices: filtered } }
+      return {
+        ...prev,
+        visual: {
+          ...prev.visual,
+          nodes: prev.visual.nodes.filter(n => n.type !== 'attack-machine'),
+          edges: prev.visual.edges.filter(e => !attackIds.has(e.source) && !attackIds.has(e.target))
+        },
+        devices: {
+          devices: Object.fromEntries(
+            Object.entries(prev.devices.devices).filter(([, d]) => d.category !== 'attack-machine')
+          )
+        }
+      }
     })
   }, [])
 
@@ -1582,14 +1583,6 @@ export default function App() {
   const hasAttackMachine = attackDevices.length > 0
   // First attack machine — device object passed to handlers and the terminal modal
   const firstAttackDevice = (attackDevices[0]?.[1] as DeviceConfig) ?? null
-  // Non-visual attack machine (the default external-attacker one, added via this
-  // toolbar button) — distinct from an Insider Threat mode attack machine, which
-  // has its own visual canvas node and is added/removed via the palette/canvas
-  // like any other device. Gates the idle Add/Remove Attack Machine button so its
-  // label always matches what clicking it will actually do (see
-  // handleAttackMachineRemove).
-  const visualNodeIds = new Set(scenario?.visual.nodes.map(n => n.id) ?? [])
-  const hasNonVisualAttackMachine = attackDevices.some(([nodeId]) => !visualNodeIds.has(nodeId))
   const hasTutorial = !!scenario?.meta.tutorialSteps?.length
 
   // Engineering workstation helpers — first workstation device for the toolbar button
@@ -1983,18 +1976,16 @@ export default function App() {
             ) : (
               !simIsRunning && (
                 <button
-                  className={`btn btn-sm ${hasNonVisualAttackMachine ? 'btn-attack-active' : 'btn-attack-add'}`}
-                  onClick={
-                    hasNonVisualAttackMachine ? handleAttackMachineRemove : handleAttackMachineAdd
-                  }
+                  className={`btn btn-sm ${hasAttackMachine ? 'btn-attack-active' : 'btn-attack-add'}`}
+                  onClick={hasAttackMachine ? handleAttackMachineRemove : handleAttackMachineAdd}
                   disabled={simIsStarting || simIsStopping}
                   title={
-                    hasNonVisualAttackMachine
+                    hasAttackMachine
                       ? 'Remove the Kali Linux attack machine from this scenario'
                       : 'Add a Kali Linux attack machine to this scenario'
                   }
                 >
-                  {hasNonVisualAttackMachine ? 'Remove Attack Machine' : 'Add Attack Machine'}
+                  {hasAttackMachine ? 'Remove Attack Machine' : 'Add Attack Machine'}
                 </button>
               )
             )}


### PR DESCRIPTION
## Summary
- **Problem:** Unlocked teacher-copy scenarios that already include an insider attack-machine still show **Add Attack Machine**, so authors can press it as if none exists.
- **Cause:** The idle toolbar button gated on `hasNonVisualAttackMachine` (toolbar-only Kali). Insider placements have a canvas node, so that flag stayed false and Remove only cleared non-visual devices.
- **Solution:** Gate Add/Remove on `hasAttackMachine`, and make Remove prune attack-machine devices plus matching visual nodes/edges.
## Test plan
- [ ] Open an unlocked teacher-copy that already has an insider attack machine on the canvas
- [ ] Confirm toolbar shows solid teal **Remove Attack Machine** (not Add)
- [ ] Click Remove — canvas box and device both disappear; button returns to **Add Attack Machine**
- [ ] Add via toolbar, then Remove — still works for non-visual Kali