### PR TITLE
fix: Update OTForge uses npm update, not npm install

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -744,8 +744,23 @@ function registerIPCHandlers(): void {
       const { stdout: afterHead } = await execAsync('git rev-parse HEAD', { cwd: projectRoot })
       const restartRequired = beforeHead.trim() !== afterHead.trim()
 
-      send('Installing dependencies (npm install)...')
-      await runStreamedCommand('npm', ['install'], projectRoot, send)
+      // `npm update`, not `npm install`. A plain install treats an already-
+      // installed version that still satisfies its declared range as "good
+      // enough" and won't touch it, even when a newer non-breaking patch has
+      // been published upstream — confirmed live: a student hit a stale,
+      // vulnerable transitive brace-expansion left behind by repeated
+      // `npm install` runs (had to `rm -rf node_modules` to actually clear
+      // it). `npm update` re-resolves every dependency against its declared
+      // range and upgrades to the newest version that still satisfies it,
+      // fixing exactly that case without deleting anything — important since
+      // this runs from inside the already-running app; a full node_modules
+      // wipe here would try to delete the currently-executing Electron
+      // binary out from under itself. Confirmed live: reproduced the exact
+      // stale-dependency state, ran `npm update` against it, and verified
+      // both `npm audit` (0 vulnerabilities) and a full `build:win` package
+      // (electron-builder run to completion) afterward.
+      send('Updating dependencies (npm update)...')
+      await runStreamedCommand('npm', ['update'], projectRoot, send)
 
       // Tracks the container image pull outcome SEPARATELY from the overall
       // source update — see AppUpdateResult.imageRefresh in packages/schema/


### PR DESCRIPTION
## Summary
- A student hit a high-severity `npm audit` finding (`brace-expansion` ReDoS, GHSA-3jxr-9vmj-r5cp) that persisted across multiple Update OTForge clicks on Mac. Root cause: `npm install` treats an already-satisfying installed version as good enough and won't touch it, even once a newer non-breaking patch has been published upstream (`brace-expansion@1.1.16` in this case) — so the button's own `npm install` step could never actually pick up the fix.
- Only a full `rm -rf node_modules && npm install` reliably resolved it, but that's not safe to run from *inside* the already-running app: a full wipe would try to delete the currently-executing Electron binary out from under itself.
- `npm update` re-resolves every dependency against its declared semver range and upgrades to the newest version still satisfying it — closes the same gap without deleting anything, safe to run live.

## Important context — a previous attempt at this same bug broke the build
Before this fix, I tried adding a `package.json` `overrides` entry forcing `brace-expansion` to `^2.1.2` tree-wide. That passed typecheck/lint/unit tests but broke `electron-builder`'s own packaging on all three platforms (`(0 , brace_expansion_1.expand) is not a function` — it forced a breaking major-version bump onto a dependency incompatible with the new export shape). That PR was reverted; this is the actual fix.

Given that history, I verified this one much more carefully before opening the PR — see Testing below.

## Testing
- Reproduced the exact stale-dependency state by hand (manually downgraded an installed `brace-expansion` copy's version string to the vulnerable range), confirmed `npm audit` flagged it (matching what the student saw), then ran `npm update` against it and confirmed `npm audit` → 0 vulnerabilities.
- Ran a full `npm run build:win` (the exact step that broke with the previous fix attempt) afterward — `electron-builder` completed through to a signed installer with no errors.
- `tsc --noEmit` clean across `packages/schema`, `packages/orchestrator`, `packages/app` (both tsconfigs)
- 189/189 orchestrator tests passing (unaffected, no existing tests cover this specific handler)

## Test plan
- [ ] Click Update OTForge and confirm the progress overlay now shows "Updating dependencies (npm update)..." instead of "Installing dependencies (npm install)..."
- [ ] Confirm the update completes normally and the app remains usable afterward (dependencies updated live, no restart needed unless source also changed)
- [ ] On a machine with a known stale/vulnerable dependency, confirm `npm audit` reports it resolved after clicking Update

🤖 Generated with [Claude Code](https://claude.com/claude-code)