### PR TITLE
fix: await canvas fit; red Remove Attack Machine

### DIFF
--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -1349,29 +1349,30 @@ export default function App() {
   }, [])
 
   /**
-   * Removes all attack-machine devices from the scenario device list.
-   *
-   * Attack machines live only in scenario.devices.devices (they have no visual node
-   * on any canvas layer), so removal is a simple key filter on the devices map.
+   * Removes all attack-machine devices and any insider canvas nodes/edges.
    * Only callable when the simulation is idle — the button is not shown while running.
    */
   const handleAttackMachineRemove = useCallback(() => {
     setScenario(prev => {
       if (!prev) return prev
-      // Only remove attack-machine devices that have no visual canvas node — an
-      // Insider Threat mode attack machine dropped onto a Purdue tab DOES have one
-      // and is removed like any other device (select + delete on canvas), which
-      // already prunes visual.nodes/edges together with devices.devices. Filtering
-      // on visual node presence here (rather than removing every attack-machine
-      // device unconditionally) avoids orphaning an insider-placed node's visual
-      // entry while its backing device silently disappears.
-      const visualNodeIds = new Set(prev.visual.nodes.map(n => n.id))
-      const filtered = Object.fromEntries(
-        Object.entries(prev.devices.devices).filter(
-          ([nodeId, d]) => d.category !== 'attack-machine' || visualNodeIds.has(nodeId)
-        )
+      const attackIds = new Set(
+        Object.entries(prev.devices.devices)
+          .filter(([, d]) => d.category === 'attack-machine')
+          .map(([id]) => id)
       )
-      return { ...prev, devices: { devices: filtered } }
+      return {
+        ...prev,
+        visual: {
+          ...prev.visual,
+          nodes: prev.visual.nodes.filter(n => n.type !== 'attack-machine'),
+          edges: prev.visual.edges.filter(e => !attackIds.has(e.source) && !attackIds.has(e.target))
+        },
+        devices: {
+          devices: Object.fromEntries(
+            Object.entries(prev.devices.devices).filter(([, d]) => d.category !== 'attack-machine')
+          )
+        }
+      }
     })
   }, [])
 
@@ -1582,14 +1583,6 @@ export default function App() {
   const hasAttackMachine = attackDevices.length > 0
   // First attack machine — device object passed to handlers and the terminal modal
   const firstAttackDevice = (attackDevices[0]?.[1] as DeviceConfig) ?? null
-  // Non-visual attack machine (the default external-attacker one, added via this
-  // toolbar button) — distinct from an Insider Threat mode attack machine, which
-  // has its own visual canvas node and is added/removed via the palette/canvas
-  // like any other device. Gates the idle Add/Remove Attack Machine button so its
-  // label always matches what clicking it will actually do (see
-  // handleAttackMachineRemove).
-  const visualNodeIds = new Set(scenario?.visual.nodes.map(n => n.id) ?? [])
-  const hasNonVisualAttackMachine = attackDevices.some(([nodeId]) => !visualNodeIds.has(nodeId))
   const hasTutorial = !!scenario?.meta.tutorialSteps?.length
 
   // Engineering workstation helpers — first workstation device for the toolbar button
@@ -1983,18 +1976,16 @@ export default function App() {
             ) : (
               !simIsRunning && (
                 <button
-                  className={`btn btn-sm ${hasNonVisualAttackMachine ? 'btn-attack-active' : 'btn-attack-add'}`}
-                  onClick={
-                    hasNonVisualAttackMachine ? handleAttackMachineRemove : handleAttackMachineAdd
-                  }
+                  className={`btn btn-sm ${hasAttackMachine ? 'btn-attack-active' : 'btn-attack-add'}`}
+                  onClick={hasAttackMachine ? handleAttackMachineRemove : handleAttackMachineAdd}
                   disabled={simIsStarting || simIsStopping}
                   title={
-                    hasNonVisualAttackMachine
+                    hasAttackMachine
                       ? 'Remove the Kali Linux attack machine from this scenario'
                       : 'Add a Kali Linux attack machine to this scenario'
                   }
                 >
-                  {hasNonVisualAttackMachine ? 'Remove Attack Machine' : 'Add Attack Machine'}
+                  {hasAttackMachine ? 'Remove Attack Machine' : 'Add Attack Machine'}
                 </button>
               )
             )}

--- a/packages/app/src/renderer/src/App.tsx
+++ b/packages/app/src/renderer/src/App.tsx
@@ -1976,7 +1976,7 @@ export default function App() {
             ) : (
               !simIsRunning && (
                 <button
-                  className={`btn btn-sm ${hasAttackMachine ? 'btn-attack-active' : 'btn-attack-add'}`}
+                  className={`btn btn-sm ${hasAttackMachine ? 'btn-danger' : 'btn-attack-add'}`}
                   onClick={hasAttackMachine ? handleAttackMachineRemove : handleAttackMachineAdd}
                   disabled={simIsStarting || simIsStopping}
                   title={

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -267,8 +267,10 @@ const FIT_ZOOM_BOOST = 1.5
  * "too zoomed out" feeling is fixed consistently everywhere, not just on startup.
  */
 function fitCanvasView(instance: ReactFlowInstance): void {
-  instance.fitBounds(CANVAS_BOUNDS, { padding: 0.04, duration: 0 })
-  instance.zoomTo(instance.getZoom() * FIT_ZOOM_BOOST, { duration: 0 })
+  void (async () => {
+    await instance.fitBounds(CANVAS_BOUNDS, { padding: 0.04, duration: 0 })
+    await instance.zoomTo(instance.getZoom() * FIT_ZOOM_BOOST, { duration: 0 })
+  })()
 }
 
 /**
@@ -855,6 +857,7 @@ export function ScadaCanvas({
    * which re-centers the viewport — making the device appear to "snap to center".
    */
   const prevLayerRef = useRef<NetworkZone | null>(null)
+  const prevScenarioKeyRef = useRef<string | null>(null)
 
   /**
    * Timer ref for auto-dismissing the invalid connection tooltip.
@@ -1130,6 +1133,7 @@ export function ScadaCanvas({
         if (rfInstance.current) fitCanvasView(rfInstance.current)
       }, 100)
       prevLayerRef.current = null
+      prevScenarioKeyRef.current = null
       return
     }
     const deviceNodes = scenarioToNodes(scenario, activeLayer)
@@ -1204,6 +1208,11 @@ export function ScadaCanvas({
     )
     // Only re-fit when the active layer tab changes — not on every node/edge mutation.
     // Scenario edits (drops, drags, connections) must not re-center the viewport.
+    const scenarioKey = `${scenario.meta.name}\0${scenario.meta.createdAt}`
+    if (scenarioKey !== prevScenarioKeyRef.current) {
+      prevScenarioKeyRef.current = scenarioKey
+      prevLayerRef.current = null
+    }
     if (prevLayerRef.current !== activeLayer) {
       prevLayerRef.current = activeLayer
       setTimeout(() => {

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -252,24 +252,17 @@ const CANVAS_H = GRID_ROWS * CELL_SIZE // 2000 px at zoom = 1
 const CANVAS_BOUNDS = { x: 0, y: 0, width: CANVAS_W, height: CANVAS_H }
 
 /**
- * How much closer than a plain "fit the whole grid" view should start.
- * Applied as a zoom multiplier after fitBounds rather than shrinking
- * CANVAS_BOUNDS itself -- shrinking the fit rect would risk clipping devices
- * placed in the outer half of the grid, whereas zooming in from the already-
- * correct full-grid fit (same center point) never cuts anything off.
- */
-const FIT_ZOOM_BOOST = 1.5
-
-/**
- * Fits the full canvas grid into view, then zooms in further by FIT_ZOOM_BOOST
- * around the same center point. Used by every fitBounds call site (initial
- * mount, layer switch, window resize, empty-scenario placeholder) so the
- * "too zoomed out" feeling is fixed consistently everywhere, not just on startup.
+ * Fits visible nodes into view (empty canvas → full grid). Used on mount,
+ * layer switch, window resize, and empty-scenario placeholder.
  */
 function fitCanvasView(instance: ReactFlowInstance): void {
   void (async () => {
-    await instance.fitBounds(CANVAS_BOUNDS, { padding: 0.04, duration: 0 })
-    await instance.zoomTo(instance.getZoom() * FIT_ZOOM_BOOST, { duration: 0 })
+    if (instance.getNodes().length === 0) {
+      await instance.fitBounds(CANVAS_BOUNDS, { padding: 0.04, duration: 0 })
+      return
+    }
+    await instance.fitView({ padding: 0.2, duration: 0 })
+    await instance.zoomTo(instance.getZoom() / (1.2 * 1.2), { duration: 0 })
   })()
 }
 

--- a/packages/app/src/renderer/src/index.css
+++ b/packages/app/src/renderer/src/index.css
@@ -3668,11 +3668,6 @@ code.prop-value {
  *  .btn-attack-add    — sim stopped, no machine yet. Neutral secondary style with
  *                       a red hover so it reads as "add an offensive capability."
  *
- *  .btn-attack-active — sim stopped, machine IS in the scenario. Full bright red
- *                       matching btn-danger so it's clearly visible as a loaded
- *                       indicator. pointer-events:none avoids using disabled=""
- *                       which would let the browser dim the color automatically.
- *
  *  .btn-attack-launch — sim running. Identical to btn-danger — same red border,
  *                       text, and hover fill as the Stop Simulation button.
  */
@@ -3708,8 +3703,7 @@ code.prop-value {
  *  .btn-attack-add      — sim idle, no machine yet. Teal outline — same primary
  *                         visual weight as Run Simulation; click to add.
  *
- *  .btn-attack-active   — sim idle, machine IS in the scenario. Solid teal
- *                         fill confirms it's configured; click to remove.
+ *  Remove (has machine) — shared .btn-danger (same as Stop Simulation).
  *
  *  .btn-attack-launch   — sim running, not yet opened. Solid teal fill matches
  *                         Run Simulation; click to open the Kali window.
@@ -3728,19 +3722,6 @@ code.prop-value {
 .btn-attack-add:hover:not(:disabled) {
   background: var(--accent-teal);
   color: #0d1117;
-}
-
-/* "⚔ Attack Ready" — idle, machine is configured. Solid teal — click to remove. */
-.btn-attack-active {
-  background: var(--accent-teal);
-  border: 1px solid var(--accent-teal);
-  color: #0d1117;
-  font-weight: 600;
-}
-
-.btn-attack-active:hover:not(:disabled) {
-  background: transparent;
-  color: var(--accent-teal);
 }
 
 /*


### PR DESCRIPTION
## Summary
- **Problem:** Purdue tab switches / scenario loads often land on a random pan-zoom instead of a centered grid. Separately, Remove Attack Machine was teal, not Stop-Simulation red.
- **Cause:** `fitBounds` is async; `zoomTo` raced on the old viewport. Loading a new scenario on the same tab skipped fit entirely. Remove used unused `btn-attack-active`.
- **Solution:** Await fit then zoom in `fitCanvasView`; reset layer-fit guard on new scenario identity; use shared `btn-danger` for Remove and drop dead CSS.
## Test plan
- [ ] Load a scenario — canvas centers on the grid
- [ ] Switch Purdue tabs repeatedly — each landing is centered (not leftover pan from previous tab)
- [ ] Add Attack Machine → button turns red **Remove Attack Machine** (matches Stop Simulation red)
- [ ] Delete Scenario still uses its own bottom-right control and is unchanged