### PR TITLE
feat: built-in ControlLogix (enip-plc) via cpppo with edge-derived CIP tags

### DIFF
--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -397,6 +397,7 @@ const DEFAULT_PROTOCOLS: Record<DeviceCategory, Protocol[]> = {
   'safety-plc': ['modbus-tcp'], // SIS — same Modbus transport as standard PLC
   'dcs-controller': ['opc-ua'], // DCS prefers OPC-UA upward by convention
   'legacy-plc': ['s7comm'], // Siemens S7 — S7comm primary protocol (Phase 10)
+  'enip-plc': ['ethernet-ip'], // Logix-style CIP PLC (cpppo/scada)
   'iec104-rtu': ['iec-104'], // IEC 60870-5-104 RTU (Phase 10)
   'process-unit': ['modbus-tcp'], // physics process sim — Modbus TCP server (Phase 11)
   // 'sensor' always runs the real otforge-bacnet container (see DEVICE_IMAGES in
@@ -448,6 +449,7 @@ const CATEGORY_LABELS: Record<DeviceCategory, string> = {
   'safety-plc': 'Safety PLC',
   'dcs-controller': 'DCS Ctrl',
   'legacy-plc': 'S7 PLC', // Phase 10
+  'enip-plc': 'ControlLogix',
   'iec104-rtu': 'IEC 104', // Phase 10
   'process-unit': 'Process Unit', // Phase 11
   sensor: 'Sensor',

--- a/packages/app/src/renderer/src/canvas/connectionRules.ts
+++ b/packages/app/src/renderer/src/canvas/connectionRules.ts
@@ -79,6 +79,7 @@ export const VALID_CONNECTIONS: Partial<
     plc: ['modbus-tcp', 'ethernet-ip'], // peer-to-peer PLC network
     'safety-plc': ['ethernet-ip', 'modbus-tcp'], // PLC shares data with adjacent SIS
     'legacy-plc': ['s7comm', 'modbus-tcp'], // PLC → Siemens S7 peer (Phase 10)
+    'enip-plc': ['ethernet-ip'], // PLC → Logix CIP peer
     'iec104-rtu': ['modbus-tcp', 'modbus-rtu'], // PLC → IEC 104 RTU (Phase 10)
     'process-unit': ['modbus-tcp', 'modbus-rtu'], // PLC polls process simulation (Phase 11)
     hmi: ['modbus-tcp', 'opc-ua'],
@@ -144,6 +145,20 @@ export const VALID_CONNECTIONS: Partial<
   // I/O — see containers/ethernetip/server.py) — the adapter itself never
   // initiates a connection, it only responds to its scanning PLC.
   'ethernetip-adapter': {
+    switch: ['none'],
+    router: ['none'],
+    firewall: ['none'],
+    'ids-ips': ['none']
+  },
+
+  // ── EtherNet/IP Logix PLC (cpppo/scada) — CIP scanner / tag endpoint ─────
+  'enip-plc': {
+    'smart-controller': ['ethernet-ip'], // pumps/valves → edge-derived BOOL tags
+    'smart-sensor': ['ethernet-ip'],
+    'ethernetip-adapter': ['ethernet-ip'], // remote I/O
+    plc: ['ethernet-ip'], // peer OpenPLC / ENIP3-style link
+    hmi: ['ethernet-ip'],
+    'engineering-workstation': ['none', 'ethernet-ip'],
     switch: ['none'],
     router: ['none'],
     firewall: ['none'],
@@ -228,6 +243,7 @@ export const VALID_CONNECTIONS: Partial<
     'safety-plc': ['modbus-tcp', 'opc-ua'], // HMI shows SIS status (read-only)
     'dcs-controller': ['opc-ua', 'modbus-tcp'],
     'legacy-plc': ['s7comm', 'opc-ua'], // HMI reads Siemens S7 via S7comm or OPC-UA (Phase 10)
+    'enip-plc': ['ethernet-ip'], // HMI reads Logix CIP tags
     'iec104-rtu': ['iec-104'], // HMI reads IEC 104 RTU (Phase 10)
     'process-unit': ['modbus-tcp'], // HMI reads process simulation PVs (Phase 11)
     'scada-server': ['opc-ua', 'none'], // HMI pulls display data from SCADA server
@@ -405,6 +421,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['dnp3'],
     'safety-plc': ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'],
     'dcs-controller': ['modbus-tcp', 'modbus-rtu', 'ethernet-ip'],
+    'enip-plc': ['ethernet-ip'], // draw field → Logix (tags also work Logix → field)
     'legacy-plc': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
     'iec104-rtu': ['modbus-rtu', 'modbus-tcp'],
     'process-unit': ['modbus-tcp', 'none'], // P&ID: pump/valve/actuator attached to vessel
@@ -425,6 +442,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['dnp3', 'iec61850'],
     'safety-plc': ['modbus-tcp', 'modbus-rtu'],
     'dcs-controller': ['modbus-tcp', 'modbus-rtu', 'opc-ua'],
+    'enip-plc': ['ethernet-ip'],
     'legacy-plc': ['s7comm', 'modbus-tcp', 'modbus-rtu'],
     'iec104-rtu': ['modbus-rtu', 'modbus-tcp'],
     historian: ['opc-ua', 'modbus-tcp', 'dnp3'],
@@ -525,6 +543,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'], // Ethernet to IED configuration tool
     'iec61850-ied': ['none', 'iec61850'], // MMS engineering client (e.g. libiec61850 tools)
     'ethernetip-adapter': ['none', 'ethernet-ip'], // EtherNet/IP config tool (e.g. RSLinx/RSLogix-style client)
+    'enip-plc': ['none', 'ethernet-ip'], // Studio 5000 / RSLinx-style CIP client
     'profinet-device': ['none', 'profinet'], // PROFINET DCP config tool (e.g. Siemens PST-style station naming/IP tool)
     sensor: ['none', 'bacnet'], // BAS engineering client (e.g. bacpypes3 tools)
     'safety-plc': ['none'], // SIS engineering console (TriStation, Safety Builder)
@@ -617,6 +636,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'],
     'iec61850-ied': ['none'],
     'ethernetip-adapter': ['none'],
+    'enip-plc': ['none'],
     'profinet-device': ['none'],
     'ip-camera': ['none'],
     'safety-plc': ['none'],
@@ -657,6 +677,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'],
     'iec61850-ied': ['none'],
     'ethernetip-adapter': ['none'],
+    'enip-plc': ['none'],
     'profinet-device': ['none'],
     'ip-camera': ['none'],
     'safety-plc': ['none'],
@@ -697,6 +718,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'],
     'iec61850-ied': ['none'],
     'ethernetip-adapter': ['none'],
+    'enip-plc': ['none'],
     'profinet-device': ['none'],
     'ip-camera': ['none'],
     'safety-plc': ['none'],
@@ -737,6 +759,7 @@ export const VALID_CONNECTIONS: Partial<
     ied: ['none'],
     'iec61850-ied': ['none'],
     'ethernetip-adapter': ['none'],
+    'enip-plc': ['none'],
     'profinet-device': ['none'],
     'ip-camera': ['none'],
     'safety-plc': ['none'],
@@ -814,6 +837,8 @@ export const VALID_CONNECTIONS: Partial<
     // Unauthenticated Set_Attribute_Single write to the adapter's Output Assembly —
     // the same write path a legitimate scanning PLC uses, but from an unauthorized host.
     'ethernetip-adapter': ['ethernet-ip', 'none'],
+    // CIP Write Tag / List Identity against Logix-style endpoints (cpppo/scada).
+    'enip-plc': ['ethernet-ip', 'none'],
     // Unauthenticated DCP Set — rename the station or reassign its IP with zero
     // credentials, the same way a legitimate engineering tool would configure it.
     'profinet-device': ['profinet', 'none'],
@@ -997,6 +1022,7 @@ const CATEGORY_NAMES: Record<DeviceCategory, string> = {
   'safety-plc': 'Safety PLC / SIS',
   'dcs-controller': 'DCS Controller',
   'legacy-plc': 'Siemens S7 PLC', // Phase 10
+  'enip-plc': 'ControlLogix 1756-L61',
   'iec104-rtu': 'IEC 104 RTU', // Phase 10
   'process-unit': 'Process Unit', // Phase 11
   sensor: 'Sensor',
@@ -1076,6 +1102,7 @@ const DEVICE_CABLE_CAPABILITIES: Record<DeviceCategory, Set<CableType>> = {
   // DCS Controller: larger system, fiber uplinks to DCS node bus are common
   'dcs-controller': new Set(['rs485', 'rs232', 'cat5e', 'cat6', 'mmf', 'smf', 'ac']),
   'legacy-plc': new Set(['rs485', 'rs232', 'cat5e', 'cat6', 'ac']), // Siemens S7 — same ports
+  'enip-plc': new Set(['cat5e', 'cat6', 'cat6a', 'mmf', 'smf', 'ac']), // Logix CIP — Ethernet only
   'iec104-rtu': new Set(['rs485', 'rs232', 'cat5e', 'cat6', 'ac']), // IEC 104 RTU — same ports
   'process-unit': new Set(['cat5e', 'cat6', 'ac']), // process sim panel — Ethernet + mains
 

--- a/packages/app/src/renderer/src/icons/DeviceIcons.tsx
+++ b/packages/app/src/renderer/src/icons/DeviceIcons.tsx
@@ -936,6 +936,7 @@ const ICON_MAP: Record<DeviceCategory, () => JSX.Element> = {
   'safety-plc': SafetyPlcSvg, // IEC 61511 Safety PLC / SIS — Triconex, Siemens Safety
   'dcs-controller': DcsControllerSvg, // Distributed Control System — DeltaV, Experion, 800xA
   'legacy-plc': LegacyPlcSvg, // Siemens S7-300/400/1200/1500 via S7comm (Phase 10)
+  'enip-plc': LegacyPlcSvg, // Logix-style CIP PLC via cpppo/scada
   'iec104-rtu': Iec104RtuSvg, // IEC 60870-5-104 RTU via conpot emulation (Phase 10)
   'process-unit': ProcessUnitSvg, // physics-simulated process unit (Phase 11)
   sensor: SensorSvg,

--- a/packages/app/src/renderer/src/palette/DevicePalette.tsx
+++ b/packages/app/src/renderer/src/palette/DevicePalette.tsx
@@ -117,6 +117,7 @@ const PALETTE: PaletteSection[] = [
     layers: ['ot'],
     items: [
       { category: 'legacy-plc', label: 'Siemens S7 PLC' },
+      { category: 'enip-plc', label: 'ControlLogix 1756-L61' }, // cpppo/scada CIP
       { category: 'iec104-rtu', label: 'IEC 104 RTU' }
     ]
   },

--- a/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
+++ b/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
@@ -50,6 +50,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   ied: 'Intelligent Electronic Device (DNP3)',
   'iec61850-ied': 'IEC 61850 IED (MMS) — substation automation',
   'ethernetip-adapter': 'EtherNet/IP Adapter (CIP) — remote I/O',
+  'enip-plc': 'ControlLogix 1756-L61 — EtherNet/IP CIP PLC (cpppo)',
   'profinet-device': 'PROFINET Device (DCP) — discovery/naming only',
   'ip-camera': 'IP Camera — weak default SSH credentials',
   hmi: 'Human Machine Interface',

--- a/packages/orchestrator/src/__tests__/compose-generator.test.ts
+++ b/packages/orchestrator/src/__tests__/compose-generator.test.ts
@@ -43,6 +43,7 @@ interface ParsedService {
   ports?: string[]
   volumes?: string[]
   entrypoint?: string[]
+  command?: string[]
   deploy: { resources: { limits: { memory: string; cpus: string } } }
 }
 
@@ -822,6 +823,25 @@ describe('environment variable injection', () => {
       .find(v => v.startsWith('INITIAL_PROGRAM_B64='))
       ?.slice('INITIAL_PROGRAM_B64='.length)
     expect(Buffer.from(b64!, 'base64').toString()).toContain('pump_1_run AT %QX0.0')
+  })
+})
+
+describe('enip-plc — cpppo coil tags', () => {
+  it('injects cpppo command tags from pump/valve edges', () => {
+    const scenario = makeScenario([
+      ['logix-1', { category: 'enip-plc', ipAddress: '10.200.10.12' }],
+      [
+        'pump-1',
+        { category: 'smart-controller', ipAddress: '10.200.10.11', controller: { kind: 'pump' } }
+      ]
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'logix-1', target: 'pump-1', data: { protocol: 'ethernet-ip' } }
+    ]
+    const svc = gen(scenario).services['logix-1']
+    expect(svc.image).toBe('cpppo/scada')
+    expect(svc.entrypoint).toEqual(['python', '-m', 'cpppo.server.enip'])
+    expect(svc.command).toEqual(['--address=0.0.0.0:44818', 'pump_1_run=BOOL'])
   })
 })
 

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -31,7 +31,7 @@
 import yaml from 'js-yaml'
 import type { OTForgeScenario, DeviceCategory, NetworkZone } from '@otforge/schema'
 import { ZONE_DEFAULTS } from './network-config'
-import { buildAutoPlcProgram } from './plc-program-gen'
+import { buildAutoPlcProgram, buildEnipTagArgs } from './plc-program-gen'
 
 /**
  * Maps each DeviceCategory to its Docker image reference on GHCR.
@@ -59,6 +59,7 @@ const DEVICE_IMAGES: Record<DeviceCategory, string> = {
   'profinet-device': 'ghcr.io/iburres/otforge-profinet:latest',
   // Phase 10: Conpot legacy device emulation (S7comm + IEC 104)
   'legacy-plc': 'ghcr.io/iburres/otforge-conpot:latest',
+  'enip-plc': 'cpppo/scada', // Logix CIP via cpppo enip_server
   'iec104-rtu': 'ghcr.io/iburres/otforge-conpot:latest',
   // Phase 11: Physics-simulated process unit (water tank, pipeline, generator, generic)
   'process-unit': 'ghcr.io/iburres/otforge-process:latest',
@@ -150,6 +151,7 @@ const DEVICE_LIMITS: Record<DeviceCategory, { memory: number; cpus: string }> = 
   'ethernetip-adapter': { memory: 64, cpus: '0.25' }, // hand-rolled asyncio ENIP/CIP server on Alpine
   'profinet-device': { memory: 64, cpus: '0.25' }, // hand-rolled raw-socket DCP server on Alpine
   'legacy-plc': { memory: 80, cpus: '0.25' }, // pure-Python S7comm on Alpine (Phase 10)
+  'enip-plc': { memory: 128, cpus: '0.25' }, // cpppo/scada Logix CIP endpoint
   'iec104-rtu': { memory: 80, cpus: '0.25' }, // pure-Python IEC 104 on Alpine (Phase 10)
   'process-unit': { memory: 96, cpus: '0.25' }, // pymodbus + physics loop on Alpine (Phase 11)
   'safety-plc': { memory: 128, cpus: '0.5' }, // Safety PLC / SIS — same budget as process PLC
@@ -219,6 +221,8 @@ interface ComposeService {
    * bypassing the need for an image rebuild when routing config changes.
    */
   entrypoint?: string[]
+  /** Overrides Dockerfile CMD. Used for cpppo ENIP tag declarations at boot. */
+  command?: string[]
   /** Per-network IP assignments. Omitted when network_mode is set. */
   networks?: Record<string, { ipv4_address: string }>
   environment: string[] | undefined
@@ -637,6 +641,16 @@ export function generateCompose(
         if (device.safetyPlc.safeState) sisEnv.push(`SIS_SAFE_STATE=${device.safetyPlc.safeState}`)
         services[serviceName].environment = sisEnv
       }
+    }
+
+    // cpppo Logix CIP: edge coil map → BOOL tags on the enip_server command line.
+    if (device.category === 'enip-plc') {
+      const port = device.ethernetip?.port ?? 44818
+      services[serviceName].entrypoint = ['python', '-m', 'cpppo.server.enip']
+      services[serviceName].command = [
+        `--address=0.0.0.0:${port}`,
+        ...buildEnipTagArgs(scenario, device.nodeId)
+      ]
     }
 
     // Controller-specific env vars — injected for smart-controller devices only.

--- a/packages/orchestrator/src/plc-program-gen.ts
+++ b/packages/orchestrator/src/plc-program-gen.ts
@@ -101,6 +101,15 @@ function linkedToProcessUnit(scenario: OTForgeScenario, plcId: string): boolean 
   return false
 }
 
+/** Same coil map as auto-ST, as cpppo `enip_server` tag specs (`name=BOOL`). */
+export function buildEnipTagArgs(scenario: OTForgeScenario, plcId: string): string[] {
+  let bindings = inferPlcCoilBindings(scenario, plcId)
+  if (bindings.length === 0) {
+    bindings = [{ coilIndex: 0, peerId: plcId, varName: 'spare_0' }]
+  }
+  return bindings.map(b => `${b.varName}=BOOL`)
+}
+
 /** Minimal ST + variable map. Author plcProgram.source must win at the call site. */
 export function buildAutoPlcProgram(scenario: OTForgeScenario, plcId: string): PLCProgramConfig {
   let bindings = inferPlcCoilBindings(scenario, plcId)

--- a/packages/schema/src/icslab.ts
+++ b/packages/schema/src/icslab.ts
@@ -80,6 +80,7 @@ export type DeviceCategory =
   | 'safety-plc' // Safety Instrumented System / Safety PLC (IEC 61511) — Triconex, Siemens Safety
   | 'dcs-controller' // Distributed Control System controller — Honeywell, Emerson DeltaV, ABB 800xA
   | 'legacy-plc' // Siemens S7-300/400/1200/1500 via S7comm (Phase 10)
+  | 'enip-plc' // Logix-style EtherNet/IP CIP PLC via cpppo/scada (ControlLogix fingerprint)
   | 'iec104-rtu' // IEC 60870-5-104 RTU via conpot emulation (Phase 10)
   | 'process-unit' // Physics-simulated process unit: water tank, pipeline, generator (Phase 11)
   | 'sensor'


### PR DESCRIPTION
## Summary

Adds a built-in **ControlLogix 1756-L61**-style device (`enip-plc`) under OT → **Legacy / Protocol**, backed by the public `cpppo/scada` image. Canvas edges to pumps/valves drive cpppo `name=BOOL` tags at compose time, so students can use **real** EtherNet/IP tooling against a Logix-like endpoint (List Identity, read/write tags).

Stock **`ethernetip-adapter`** stays as remote I/O (`otforge-ethernetip`). This does not replace that path; it adds a scanner/PLC-shaped CIP target for ENIP labs.

Happy to land this here as an **experimental learning resource**. If you’d rather keep Hub/`cpppo` out of core, the same device can live as a **data pack on my fork** and stay optional for instructors who want it.

## Educational value

- Practice **List Identity** and CIP tag **read/write** with the same class of commands used on real Logix (cpppo / pycomm3 / similar), not a fake protocol skin.
- Pair with the existing adapter for a simple **scanner ↔ I/O** story (see sample ENIP3 lab).
- Edge→tag naming mirrors the OpenPLC auto-coil idea: wire a pump, get a recognizable BOOL tag—less “magic register number,” more “what am I talking to?”

## Shortcomings (honest)

- **Not a real ControlLogix.** Fingerprint/behavior is cpppo’s Logix-style server, not Rockwell firmware or full CIP object model.
- Tags are **edge-inferred BOOL only** at boot; no ladder, no AOI/UDT story, no physics sync (process-sim stays Modbus).
- Image is **Docker Hub `cpppo/scada`** (pull/ARM quirks possible); not a first-party OTForge build.
- Connection rules are intentionally lean (field/HMI/EWS/infra/attack)—historian/SCADA CIP clients not wired yet.

## Future work (if this earns a seat)

- First-party thin image (or documented override) for ARM / offline labs
- Richer tag types / explicit tag editor in Properties
- Optional historian/SCADA CIP edges when a lab needs them
- Tighter ENIP attack modules (Write Tag / List Identity demos) against `enip-plc`

## Test plan

- [ ] Palette: OT → Legacy / Protocol shows **ControlLogix 1756-L61**; Primary Control still has EtherNet/IP adapter
- [ ] Wire Logix → pump (`ethernet-ip`); generate compose → service uses `cpppo/scada`, `python -m cpppo.server.enip`, command includes `…_run=BOOL`
- [ ] From Kali/lab host: List Identity + read/write that tag against the Logix container IP:44818
- [ ] Adapter-only scenario: no cpppo entrypoint/command override
- [ ] `npm test -w @otforge/orchestrator -- -t enip-plc`