### PR TITLE
feat: real M-out-of-N safety voting logic for safety-plc devices

### DIFF
--- a/containers/openplc/entrypoint.sh
+++ b/containers/openplc/entrypoint.sh
@@ -25,6 +25,19 @@
 #                          the physics simulator (%IW100 = LEVEL_PV) and drives its
 #                          actuators (%QX100.0-3 = pump/valve commands). Injected by
 #                          compose-generator.ts when a PLC↔process-unit edge exists.
+#   SIS_MBCONFIG_B64     — (Optional, safety-plc only) Base64-encoded, fully-built
+#                          mbconfig.cfg content for M-out-of-N safety voting — one
+#                          Modbus TCP master device per redundant sensor wired
+#                          directly to this safety-plc on the canvas, each reporting
+#                          at %IW100, %IW101, %IW102... in wiring order. Takes
+#                          precedence over PROCESS_SIM_IP if both are somehow set
+#                          (not a real scenario compose-generator.ts produces today —
+#                          see plc-program-gen.ts's buildSafetyVotingProgram for the
+#                          matching ST logic that reads these registers). Unlike
+#                          PROCESS_SIM_IP's single-device case, this file is built
+#                          entirely in TypeScript (compose-generator.ts) rather than
+#                          templated here in bash, so it's unit-testable the same way
+#                          INITIAL_PROGRAM_B64 already is.
 
 set -e
 
@@ -138,10 +151,20 @@ fi
 #   Coils_Start=0, Coils_Size=4  → bool_output[100][0..3] = %QX100.0..100.3
 #   Holding_Registers_Read_Start=0, Size=1 → int_input[100] = %IW100
 #
-# If PROCESS_SIM_IP is NOT set, write a zero-device stub to silence the warning.
-# webserver.py regenerates this file whenever slaves are added via the UI, so
-# the pre-created stub is always safe.
-if [ -n "${PROCESS_SIM_IP}" ]; then
+# If SIS_MBCONFIG_B64 is set (safety-plc with 1+ redundant sensors wired on
+# the canvas — see compose-generator.ts), it already IS the complete file
+# content, built and unit-tested in TypeScript; just decode and write it,
+# matching the INITIAL_PROGRAM_B64 decode pattern above. Checked first so it
+# takes precedence over PROCESS_SIM_IP in the (not currently scenario-
+# generated) case both are somehow set.
+#
+# Otherwise, if PROCESS_SIM_IP is NOT set, write a zero-device stub to
+# silence the warning. webserver.py regenerates this file whenever slaves
+# are added via the UI, so the pre-created stub is always safe.
+if [ -n "${SIS_MBCONFIG_B64}" ]; then
+  echo "${SIS_MBCONFIG_B64}" | base64 -d > /opt/openplc/webserver/mbconfig.cfg
+  echo "[ics-openplc] mbconfig.cfg → safety voting config decoded from SIS_MBCONFIG_B64"
+elif [ -n "${PROCESS_SIM_IP}" ]; then
   cat > /opt/openplc/webserver/mbconfig.cfg << EOF
 Num_Devices = "1"
 Polling_Period = "100"

--- a/packages/orchestrator/src/__tests__/compose-generator.test.ts
+++ b/packages/orchestrator/src/__tests__/compose-generator.test.ts
@@ -901,6 +901,161 @@ describe('dcs-controller — real device', () => {
   })
 })
 
+describe('safety-plc — M-out-of-N voting logic', () => {
+  function pressureSensor(
+    id: string,
+    ip: string,
+    maxValue = 250,
+    modbusRegister = 0
+  ): [string, DeviceOverrides] {
+    return [
+      id,
+      {
+        category: 'smart-sensor',
+        ipAddress: ip,
+        sensor: {
+          kind: 'pressure',
+          waveform: 'sine',
+          minValue: 0,
+          maxValue,
+          units: 'psi',
+          noisePercent: 3,
+          modbusRegister
+        }
+      }
+    ]
+  }
+
+  it('injects SIS_MBCONFIG_B64 with one device block per wired sensor', () => {
+    const scenario = makeScenario([
+      [
+        'sis-1',
+        { category: 'safety-plc', ipAddress: '10.200.10.10', safetyPlc: { votingConfig: '2oo3' } }
+      ],
+      pressureSensor('p1', '10.200.10.21'),
+      pressureSensor('p2', '10.200.10.22'),
+      pressureSensor('p3', '10.200.10.23')
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'sis-1', target: 'p1', data: { protocol: 'modbus-tcp' } },
+      { id: 'e2', source: 'sis-1', target: 'p2', data: { protocol: 'modbus-tcp' } },
+      { id: 'e3', source: 'sis-1', target: 'p3', data: { protocol: 'modbus-tcp' } }
+    ]
+    const env = gen(scenario).services['sis-1'].environment ?? []
+    const b64 = env.find(v => v.startsWith('SIS_MBCONFIG_B64='))?.slice('SIS_MBCONFIG_B64='.length)
+    expect(b64).toBeDefined()
+    const mbconfig = Buffer.from(b64!, 'base64').toString()
+    expect(mbconfig).toContain('Num_Devices = "3"')
+    expect(mbconfig).toContain('device0.address = "10.200.10.21"')
+    expect(mbconfig).toContain('device1.address = "10.200.10.22"')
+    expect(mbconfig).toContain('device2.address = "10.200.10.23"')
+    // Read-only voting inputs — no coil writes back to the sensors.
+    expect(mbconfig).toContain('device0.Coils_Size = "0"')
+    expect(mbconfig).toContain('device0.Holding_Registers_Read_Size = "1"')
+  })
+
+  it('generates real 2-out-of-3 voting ST logic, not a scaffold', () => {
+    const scenario = makeScenario([
+      [
+        'sis-1',
+        { category: 'safety-plc', ipAddress: '10.200.10.10', safetyPlc: { votingConfig: '2oo3' } }
+      ],
+      pressureSensor('p1', '10.200.10.21', 250),
+      pressureSensor('p2', '10.200.10.22', 250),
+      pressureSensor('p3', '10.200.10.23', 250)
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'sis-1', target: 'p1', data: { protocol: 'modbus-tcp' } },
+      { id: 'e2', source: 'sis-1', target: 'p2', data: { protocol: 'modbus-tcp' } },
+      { id: 'e3', source: 'sis-1', target: 'p3', data: { protocol: 'modbus-tcp' } }
+    ]
+    const env = gen(scenario).services['sis-1'].environment ?? []
+    const b64 = env
+      .find(v => v.startsWith('INITIAL_PROGRAM_B64='))
+      ?.slice('INITIAL_PROGRAM_B64='.length)
+    const st = Buffer.from(b64!, 'base64').toString()
+    expect(st).toContain('sensor_0 AT %IW100 : INT')
+    expect(st).toContain('sensor_1 AT %IW101 : INT')
+    expect(st).toContain('sensor_2 AT %IW102 : INT')
+    // 80% of maxValue 250 = 200 psi, x10 fixed-point on the wire = 2000.
+    expect(st).toContain('IF sensor_0 > 2000 THEN vote_count := vote_count + 1;')
+    expect(st).toContain('IF vote_count >= 2 THEN')
+    expect(st).toContain('trip_relay := FALSE;')
+  })
+
+  it('clamps the vote threshold to the actual wired sensor count when fewer are connected than declared', () => {
+    const scenario = makeScenario([
+      [
+        'sis-1',
+        { category: 'safety-plc', ipAddress: '10.200.10.10', safetyPlc: { votingConfig: '2oo3' } }
+      ],
+      pressureSensor('p1', '10.200.10.21')
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'sis-1', target: 'p1', data: { protocol: 'modbus-tcp' } }
+    ]
+    const env = gen(scenario).services['sis-1'].environment ?? []
+    const b64 = env
+      .find(v => v.startsWith('INITIAL_PROGRAM_B64='))
+      ?.slice('INITIAL_PROGRAM_B64='.length)
+    const st = Buffer.from(b64!, 'base64').toString()
+    // votingConfig declares 2oo3, but only 1 sensor is wired — clamp to 1oo1.
+    expect(st).toContain('IF vote_count >= 1 THEN')
+    expect(st).not.toContain('sensor_1')
+
+    const mbB64 = env
+      .find(v => v.startsWith('SIS_MBCONFIG_B64='))
+      ?.slice('SIS_MBCONFIG_B64='.length)
+    expect(Buffer.from(mbB64!, 'base64').toString()).toContain('Num_Devices = "1"')
+  })
+
+  it('falls back to the generic spare-coil scaffold when no sensors are wired', () => {
+    const compose = gen(
+      makeScenario([
+        [
+          'sis-1',
+          { category: 'safety-plc', ipAddress: '10.200.10.10', safetyPlc: { votingConfig: '2oo3' } }
+        ]
+      ])
+    )
+    const env = compose.services['sis-1'].environment ?? []
+    expect(env.some(v => v.startsWith('SIS_MBCONFIG_B64'))).toBe(false)
+    const b64 = env
+      .find(v => v.startsWith('INITIAL_PROGRAM_B64='))
+      ?.slice('INITIAL_PROGRAM_B64='.length)
+    expect(Buffer.from(b64!, 'base64').toString()).toContain('spare_0')
+  })
+
+  it('still injects SIS_MBCONFIG_B64 for a wired safety-plc even when it has an authored plcProgram', () => {
+    // Matches ICS_Lab_04.otflab's actual sis-1: authored passthrough program,
+    // one pressure sensor wired. The authored ST wins for INITIAL_PROGRAM_B64
+    // (unaffected), but the sensor is still polled since wiring and program
+    // choice are independent concerns.
+    const authoredSt = Buffer.from('PROGRAM main\nEND_PROGRAM\n', 'utf8').toString('base64')
+    const scenario = makeScenario([
+      [
+        'sis-1',
+        {
+          category: 'safety-plc',
+          ipAddress: '10.200.10.10',
+          safetyPlc: { votingConfig: '2oo3' },
+          plcProgram: { language: 'st', source: authoredSt, variables: [] }
+        }
+      ],
+      pressureSensor('p1', '10.200.10.21')
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'sis-1', target: 'p1', data: { protocol: 'modbus-tcp' } }
+    ]
+    const env = gen(scenario).services['sis-1'].environment ?? []
+    const programB64 = env
+      .find(v => v.startsWith('INITIAL_PROGRAM_B64='))
+      ?.slice('INITIAL_PROGRAM_B64='.length)
+    expect(programB64).toBe(authoredSt)
+    expect(env.some(v => v.startsWith('SIS_MBCONFIG_B64'))).toBe(true)
+  })
+})
+
 // ── DNS device env vars ───────────────────────────────────────────────────────
 
 describe('DNS device environment variable injection', () => {

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -31,7 +31,11 @@
 import yaml from 'js-yaml'
 import type { OTForgeScenario, DeviceCategory, NetworkZone } from '@otforge/schema'
 import { ZONE_DEFAULTS } from './network-config'
-import { buildAutoPlcProgram } from './plc-program-gen'
+import {
+  buildAutoPlcProgram,
+  buildSafetyVotingProgram,
+  inferSisSensorNodeIds
+} from './plc-program-gen'
 
 /**
  * Maps each DeviceCategory to its Docker image reference on GHCR.
@@ -636,6 +640,61 @@ export function generateCompose(
         }
         if (device.safetyPlc.safeState) sisEnv.push(`SIS_SAFE_STATE=${device.safetyPlc.safeState}`)
         services[serviceName].environment = sisEnv
+      }
+
+      // Real M-out-of-N voting: when a safety-plc is directly wired to 1+
+      // smart-sensor devices, build a full mbconfig.cfg (base64) so OpenPLC's
+      // Modbus-master engine polls each one — the same engine PROCESS_SIM_IP
+      // already drives above, just generalized to N devices instead of one.
+      // Built entirely here (not in entrypoint.sh) so it's unit-testable the
+      // same way INITIAL_PROGRAM_B64/DCS_FIELD_DEVICES already are. Injected
+      // whenever sensors are wired, independent of whether the ST program
+      // itself is auto-generated or authored — the polling is a consequence
+      // of the canvas wiring, not of the program-generation choice above.
+      if (device.category === 'safety-plc') {
+        const sensorNodeIds = inferSisSensorNodeIds(scenario, device.nodeId)
+        if (sensorNodeIds.length > 0) {
+          const deviceBlocks = sensorNodeIds
+            .map((sensorId, i) => {
+              const sensorIp =
+                claimedDeviceIps.get(sensorId) ??
+                resolveDeviceIp(
+                  scenario.devices.devices[sensorId].ipAddress,
+                  scenario,
+                  effectiveZones
+                )
+              return `device${i}.name = "${sanitizeServiceName(sensorId)}"
+device${i}.protocol = "TCP"
+device${i}.slave_id = "1"
+device${i}.address = "${sensorIp}"
+device${i}.IP_Port = "502"
+device${i}.RTU_Baud_Rate = "0"
+device${i}.RTU_Parity = "0"
+device${i}.RTU_Data_Bits = "0"
+device${i}.RTU_Stop_Bits = "0"
+device${i}.RTU_TX_Pause = "0"
+device${i}.Discrete_Inputs_Start = "0"
+device${i}.Discrete_Inputs_Size = "0"
+device${i}.Coils_Start = "0"
+device${i}.Coils_Size = "0"
+device${i}.Input_Registers_Start = "0"
+device${i}.Input_Registers_Size = "0"
+device${i}.Holding_Registers_Read_Start = "0"
+device${i}.Holding_Registers_Read_Size = "1"
+device${i}.Holding_Registers_Start = "0"
+device${i}.Holding_Registers_Size = "0"`
+            })
+            .join('\n\n')
+          const mbconfig = `Num_Devices = "${sensorNodeIds.length}"
+Polling_Period = "100"
+Timeout = "1000"
+
+${deviceBlocks}
+`
+          const sisMbEnv: string[] = services[serviceName].environment ?? []
+          sisMbEnv.push(`SIS_MBCONFIG_B64=${Buffer.from(mbconfig, 'utf8').toString('base64')}`)
+          services[serviceName].environment = sisMbEnv
+        }
       }
     }
 
@@ -1759,10 +1818,21 @@ function buildDeviceEnv(
 
   // PLC program pre-load: authored plcProgram wins; otherwise edge-aware ST so
   // OpenPLC auto-starts (502 binds) with coils for connected pumps/valves.
+  // safety-plc devices wired directly to 1+ smart-sensor inputs get real
+  // M-out-of-N voting logic instead of the generic actuator-coil scaffold —
+  // see buildSafetyVotingProgram in plc-program-gen.ts. Positional (%IW100+i)
+  // addressing needs no IP resolution here; the matching mbconfig.cfg that
+  // actually polls those sensors is built separately, in the outer per-device
+  // loop where claimedDeviceIps/resolveDeviceIp are in scope (see
+  // SIS_MBCONFIG_B64 injection below).
   if (device.category === 'plc' || device.category === 'safety-plc') {
+    const sisSensorNodeIds =
+      device.category === 'safety-plc' ? inferSisSensorNodeIds(scenario, device.nodeId) : []
     const program = device.plcProgram?.source
       ? device.plcProgram
-      : buildAutoPlcProgram(scenario, device.nodeId)
+      : sisSensorNodeIds.length > 0
+        ? buildSafetyVotingProgram(scenario, sisSensorNodeIds, device.safetyPlc?.votingConfig)
+        : buildAutoPlcProgram(scenario, device.nodeId)
     env.push(`INITIAL_PROGRAM_B64=${program.source}`)
     env.push(`PLC_VAR_COUNT=${program.variables?.length ?? 0}`)
   }

--- a/packages/orchestrator/src/plc-program-gen.ts
+++ b/packages/orchestrator/src/plc-program-gen.ts
@@ -1,9 +1,16 @@
 /**
  * Edge-aware OpenPLC ST for PLCs with no authored plcProgram.
  * Coils from coilSource edges + PLC↔pump/valve links; spare coil if none (502 binds).
+ * Also: M-out-of-N safety voting ST for safety-plc devices wired directly to
+ * redundant smart-sensor inputs (see buildSafetyVotingProgram below).
  */
 
-import type { CanvasEdge, OTForgeScenario, PLCProgramConfig } from '@otforge/schema'
+import type {
+  CanvasEdge,
+  OTForgeScenario,
+  PLCProgramConfig,
+  SafetyPlcConfig
+} from '@otforge/schema'
 
 const ACTUATOR = new Set(['pump', 'valve', 'vfd', 'actuator'])
 
@@ -99,6 +106,125 @@ function linkedToProcessUnit(scenario: OTForgeScenario, plcId: string): boolean 
     if (e.data.coilSource?.nodeId === plcId || e.source === plcId || e.target === plcId) return true
   }
   return false
+}
+
+// ── Safety/SIS M-out-of-N voting ─────────────────────────────────────────────
+
+/**
+ * Direct safety-plc↔smart-sensor edges, in edge-iteration order. Unlike
+ * inferPlcCoilBindings' actuator side, there's no coilSource-equivalent to
+ * resolve here — a safety-plc directly wired to a smart-sensor unambiguously
+ * means that sensor feeds the safety vote, so a plain edge scan is enough.
+ */
+export function inferSisSensorNodeIds(scenario: OTForgeScenario, plcId: string): string[] {
+  const ids: string[] = []
+  for (const edge of scenario.visual.edges) {
+    const peer = otherEnd(edge, plcId)
+    if (peer && scenario.devices.devices[peer]?.category === 'smart-sensor') ids.push(peer)
+  }
+  return ids
+}
+
+/**
+ * Parses "MooN" voting config (e.g. "2oo3") into { m, n }, clamping m to the
+ * number of sensors actually wired if fewer are connected than the config
+ * declares. This is also the physically-correct real-world behavior for a
+ * partially-installed SIS — a vote can never require more inputs than exist.
+ * Falls back to requiring all wired sensors to agree (effectively 1oo1 for a
+ * single sensor) when votingConfig is unset or doesn't parse.
+ */
+function parseVotingThreshold(
+  votingConfig: SafetyPlcConfig['votingConfig'] | undefined,
+  wiredCount: number
+): number {
+  const match = votingConfig?.match(/^(\d)oo(\d)$/)
+  const declaredM = match ? parseInt(match[1], 10) : wiredCount
+  return Math.max(1, Math.min(declaredM, wiredCount))
+}
+
+/**
+ * Real M-out-of-N safety voting ST — not a scaffold, actual comparator logic.
+ * Reads each wired sensor's polled Modbus value (populated at %IW100+i by
+ * OpenPLC's Modbus-master engine polling the devices listed in the
+ * SIS_MBCONFIG_B64-generated mbconfig.cfg — see compose-generator.ts), counts
+ * how many exceed the trip threshold, and only de-energizes trip_relay
+ * (Lab04 convention: TRUE=safe/armed, FALSE=tripped) when the vote count
+ * reaches the configured M.
+ *
+ * Threshold defaults to 80% of the wired sensors' own maxValue (they should
+ * share a range, being redundant copies of the same measurement) — a simple,
+ * adjustable convention, not a claimed-precise SIL calculation. An
+ * author-configurable explicit setpoint is a natural follow-up, intentionally
+ * out of scope here.
+ *
+ * Sensor values are x10 fixed-point on the wire (containers/modbus/server.py's
+ * SENSOR_MODBUS_REGISTER convention), so the threshold is scaled by 10 to
+ * compare directly against the raw register value.
+ */
+export function buildSafetyVotingProgram(
+  scenario: OTForgeScenario,
+  sensorNodeIds: string[],
+  votingConfig: SafetyPlcConfig['votingConfig'] | undefined
+): PLCProgramConfig {
+  const m = parseVotingThreshold(votingConfig, sensorNodeIds.length)
+
+  const maxValues = sensorNodeIds
+    .map(id => scenario.devices.devices[id]?.sensor?.maxValue)
+    .filter((v): v is number => typeof v === 'number')
+  const maxValue = maxValues.length > 0 ? Math.max(...maxValues) : 100
+  const thresholdRaw = Math.round(maxValue * 0.8 * 10)
+
+  const vars: string[] = []
+  const logic: string[] = ['  vote_count := 0;']
+  const variables: PLCProgramConfig['variables'] = []
+
+  sensorNodeIds.forEach((nodeId, i) => {
+    const varName = `sensor_${i}`
+    vars.push(`    ${varName} AT %IW${100 + i} : INT;`)
+    variables.push({
+      name: varName,
+      type: 'INT',
+      address: `%IW${100 + i}`,
+      protocol: 'modbus-tcp',
+      protocolAddress: String(scenario.devices.devices[nodeId]?.sensor?.modbusRegister ?? 0)
+    })
+    logic.push(`  IF ${varName} > ${thresholdRaw} THEN vote_count := vote_count + 1; END_IF;`)
+  })
+
+  vars.push('    trip_relay AT %QX0.0 : BOOL;')
+  logic.push(
+    '',
+    `  IF vote_count >= ${m} THEN`,
+    '    trip_relay := FALSE; (* tripped — vote threshold reached *)',
+    '  ELSE',
+    '    trip_relay := TRUE; (* safe/armed *)',
+    '  END_IF;'
+  )
+
+  const st = `(* auto-generated ${m}-out-of-${sensorNodeIds.length} safety voting — override via Save Program *)
+PROGRAM main
+  VAR
+${vars.join('\n')}
+  END_VAR
+  VAR
+    vote_count : INT;
+  END_VAR
+
+${logic.join('\n')}
+
+END_PROGRAM
+
+CONFIGURATION config0
+  TASK task0(INTERVAL := T#100ms, PRIORITY := 0);
+  PROGRAM inst0 WITH task0 : main;
+END_CONFIGURATION
+`
+
+  return {
+    language: 'st',
+    source: toB64(st),
+    variables
+  }
 }
 
 /** Minimal ST + variable map. Author plcProgram.source must win at the call site. */


### PR DESCRIPTION
## Summary
- Generates actual ST voting logic (not a scaffold) for `safety-plc` devices wired directly to redundant `smart-sensor` inputs: builds a `mbconfig.cfg` polling each wired sensor and ST logic that trips the relay once the configured M-of-N vote threshold is reached.
- Voting `M` clamps to the number of sensors actually wired if fewer are connected than the declared `MooN` config — physically-correct degradation for a partially-installed SIS.
- Fixes a matiec (iec2c) compile bug found during live verification: located (`AT %...`) and non-located variable declarations can't share one `VAR` block. The internal `vote_count` accumulator now gets its own block.

## Test plan
- [x] `tsc --noEmit` clean in `packages/orchestrator` and `packages/app`
- [x] `vitest run` — 194/194 passing (5 new tests covering mbconfig generation, real ST content, M-clamping, zero-sensor fallback, and authored-program coexistence)
- [x] Live end-to-end verification: brought up a real 4-container stack (safety-plc + 3 pressure sensors) from a generated compose file, confirmed the OpenPLC binary compiles and runs, and walked sensor readings from 0-of-3 → 3-of-3 above threshold via direct register manipulation — `trip_relay` flipped to tripped exactly at 2-of-3 and stayed tripped at 3-of-3, matching the `2oo3` config under test.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>