### PR TITLE
fix: add otforge-pmu to the docker.yml build matrix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,6 +52,10 @@ jobs:
             context: containers/camera
           - image: otforge-dcs
             context: containers/dcs
+          # Real IEEE C37.118 PMU — polls a wired generator process-unit over
+          # Modbus TCP, re-exposes as a real synchrophasor stream on port 4712.
+          - image: otforge-pmu
+            context: containers/pmu
           - image: otforge-firewall
             context: containers/firewall
           - image: otforge-switch


### PR DESCRIPTION
## Summary
- PR #64 added `containers/pmu/` but never added a matching entry to `docker.yml`'s `build-images` matrix, so merging it triggered a Build and Push run that succeeded (green) without ever actually building or publishing `otforge-pmu`.
- Confirmed by checking the post-merge run's actual built-image list, not just its pass/fail status — the PMU device would fail to pull its image in any real scenario.
- Added the missing matrix entry, same shape as the neighboring `otforge-dcs` entry.

## Test plan
- [x] Validated the YAML parses correctly (`yaml.safe_load`).
- [x] Will confirm `otforge-pmu` actually appears in the Build and Push run once merged.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>