### PR TITLE
feat: real IIoT/MQTT support (iiot-sensor + iot-gateway)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,6 +56,13 @@ jobs:
           # Modbus TCP, re-exposes as a real synchrophasor stream on port 4712.
           - image: otforge-pmu
             context: containers/pmu
+          # IIoT/MQTT — iiot-sensor is a standalone MQTT publisher (paho-mqtt);
+          # iot-gateway hosts a real Mosquitto broker plus a Python sidecar that
+          # bridges wired Modbus field devices onto the same broker.
+          - image: otforge-iiot-sensor
+            context: containers/iiot-sensor
+          - image: otforge-iot-gateway
+            context: containers/iot-gateway
           - image: otforge-firewall
             context: containers/firewall
           - image: otforge-switch

--- a/containers/iiot-sensor/Dockerfile
+++ b/containers/iiot-sensor/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.12-alpine
+
+WORKDIR /app
+
+# paho-mqtt 2.x — the standard Python MQTT client library, same "use a real
+# library when one exists" choice this project already makes for Modbus
+# (pymodbus) and OPC UA (asyncua), rather than hand-rolling MQTT wire framing
+# the way containers/ethernetip or containers/pmu hand-roll protocols that
+# have no comparably standard small client library.
+RUN pip install --no-cache-dir "paho-mqtt==2.1.0"
+
+COPY server.py .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+# Defaults — all overridable via docker-compose environment:
+ENV DEVICE_ID=iiot-1 \
+    DEVICE_CATEGORY=iiot-sensor \
+    MQTT_BROKER_IP="" \
+    MQTT_BROKER_PORT=1883 \
+    SENSOR_KIND=temperature \
+    SENSOR_WAVEFORM=sine \
+    SENSOR_MIN_VALUE=0 \
+    SENSOR_MAX_VALUE=100 \
+    SENSOR_UNITS="" \
+    SENSOR_NOISE_PERCENT=5 \
+    SENSOR_SAMPLE_RATE_MS=1000 \
+    SENSOR_TAG_NAME=""
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/containers/iiot-sensor/entrypoint.sh
+++ b/containers/iiot-sensor/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+echo "[ics-iiot-sensor] Device=${DEVICE_ID}  category=${DEVICE_CATEGORY}  broker=${MQTT_BROKER_IP:-<unset>}:${MQTT_BROKER_PORT}"
+
+exec python3 /app/server.py

--- a/containers/iiot-sensor/server.py
+++ b/containers/iiot-sensor/server.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+server.py — IIoT wireless sensor node for the ICS Simulator (real MQTT publisher).
+
+Generates a synthetic process value using the exact same waveform math already
+proven in containers/modbus/server.py's _sensor_value_at() (sine/random/
+sawtooth/square/constant, per SensorConfig — packages/schema/src/icslab.ts),
+then publishes it as a real MQTT PUBLISH packet to the wired iot-gateway's
+broker. Reimplemented standalone rather than imported/shared, matching the
+convention every device container in this project follows: each is an
+independently self-contained image with no shared Python module between them.
+
+Unlike smart-sensor (a Modbus TCP server a PLC polls), an IIoT sensor node
+never gets polled — it pushes its own readings on its own schedule, the
+actual behavior WirelessHART/ISA100.11a/MQTT-publisher field devices exhibit
+in a real plant, and the reason connectionRules.ts deliberately keeps this
+category from connecting directly to PLCs/historians: it only ever talks to
+its gateway.
+
+Topic: otforge/<DEVICE_ID>/value (or SENSOR_TAG_NAME if set, mirroring
+SensorConfig.tagName's role as a FUXA tag override — same "author can name
+this if they care to" convention).
+
+Payload (JSON, QoS 0, matching this project's "no authentication, no extra
+protocol machinery beyond what's needed to teach the concept" posture for
+every real protocol built so far):
+    {"value": <float>, "unit": "<string>", "timestamp": "<ISO8601>"}
+
+Environment variables:
+    DEVICE_ID             — node identifier string, used in logging and the
+                             default MQTT topic
+    DEVICE_CATEGORY        — logged at startup for Docker Compose traceability
+    MQTT_BROKER_IP         — Docker network IP of the wired iot-gateway
+                             (compose-generator.ts injects this from canvas
+                             edges — see MQTT_BROKER_IP in compose-generator.ts).
+                             Empty/unset means the sensor was placed but not
+                             wired to a gateway yet; the process logs a clear
+                             warning and idles rather than crash-looping.
+    MQTT_BROKER_PORT       — broker TCP port (default 1883, the IANA-assigned
+                             standard MQTT port)
+    SENSOR_KIND            — mirrors SensorConfig.kind (informational/logging)
+    SENSOR_WAVEFORM        — sine | random | sawtooth | square | constant
+    SENSOR_MIN_VALUE       — bottom of the simulated engineering range
+    SENSOR_MAX_VALUE       — top of the simulated engineering range
+    SENSOR_UNITS           — engineering units string included in the payload
+    SENSOR_NOISE_PERCENT   — Gaussian noise added on top of the waveform, as a
+                             percentage of the full range (0 = clean)
+    SENSOR_SAMPLE_RATE_MS  — publish interval in milliseconds (default 1000)
+    SENSOR_TAG_NAME        — optional MQTT topic override (mirrors
+                             SensorConfig.tagName); falls back to DEVICE_ID
+
+Protocol reference: MQTT Version 3.1.1 (OASIS Standard).
+Library version: paho-mqtt 2.1.0 (client mode).
+"""
+
+import json
+import logging
+import math
+import os
+import random
+import time
+from datetime import datetime, timezone
+
+import paho.mqtt.client as mqtt
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("ics-iiot-sensor")
+
+DEVICE_ID = os.getenv("DEVICE_ID", "iiot-1")
+CATEGORY = os.getenv("DEVICE_CATEGORY", "iiot-sensor")
+
+BROKER_IP = os.getenv("MQTT_BROKER_IP", "").strip()
+BROKER_PORT = int(os.getenv("MQTT_BROKER_PORT", "1883"))
+
+SENSOR_KIND = os.getenv("SENSOR_KIND", "temperature")
+SENSOR_WAVEFORM = os.getenv("SENSOR_WAVEFORM", "sine")
+SENSOR_MIN_VALUE = float(os.getenv("SENSOR_MIN_VALUE", "0"))
+SENSOR_MAX_VALUE = float(os.getenv("SENSOR_MAX_VALUE", "100"))
+SENSOR_UNITS = os.getenv("SENSOR_UNITS", "")
+SENSOR_NOISE_PERCENT = float(os.getenv("SENSOR_NOISE_PERCENT", "5"))
+SENSOR_SAMPLE_RATE_MS = int(os.getenv("SENSOR_SAMPLE_RATE_MS", "1000"))
+
+TOPIC = f"otforge/{os.getenv('SENSOR_TAG_NAME', '').strip() or DEVICE_ID}/value"
+
+
+def sensor_value_at(t: float) -> float:
+    """
+    Computes the raw engineering value at elapsed time t (seconds), before
+    noise, per SENSOR_WAVEFORM — identical math to containers/modbus/
+    server.py's _sensor_value_at():
+      sine     — smooth oscillation between min and max, period 60 s
+      random   — white noise bounded by min/max (ignores t)
+      sawtooth — linear ramp 0->1 every 60 s then reset
+      square   — two-state, half-period 30 s
+      constant — fixed at (min + max) / 2
+    """
+    lo, hi = SENSOR_MIN_VALUE, SENSOR_MAX_VALUE
+    mid, span = (lo + hi) / 2.0, (hi - lo) / 2.0
+    period = 60.0
+
+    if SENSOR_WAVEFORM == "sine":
+        return mid + span * math.sin(2 * math.pi * t / period)
+    if SENSOR_WAVEFORM == "random":
+        return random.uniform(lo, hi)
+    if SENSOR_WAVEFORM == "sawtooth":
+        return lo + (hi - lo) * ((t % period) / period)
+    if SENSOR_WAVEFORM == "square":
+        return hi if (t % period) < period / 2 else lo
+    return mid  # constant
+
+
+def main() -> None:
+    log.info(
+        "IIoT sensor starting -- id=%s  category=%s  kind=%s  waveform=%s  "
+        "range=[%.2f, %.2f]  rate=%dms  topic=%s",
+        DEVICE_ID, CATEGORY, SENSOR_KIND, SENSOR_WAVEFORM,
+        SENSOR_MIN_VALUE, SENSOR_MAX_VALUE, SENSOR_SAMPLE_RATE_MS, TOPIC,
+    )
+
+    if not BROKER_IP:
+        log.warning(
+            "No MQTT_BROKER_IP configured -- this sensor was placed but not "
+            "wired to an iot-gateway. Idling (no publishes) rather than "
+            "crash-looping; wire an edge to a gateway and restart."
+        )
+        while True:
+            time.sleep(3600)
+
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=DEVICE_ID)
+
+    def on_connect(_client, _userdata, _flags, reason_code, _properties=None):
+        if reason_code == 0:
+            log.info("Connected to broker %s:%d", BROKER_IP, BROKER_PORT)
+        else:
+            log.warning("Connect failed: %s", reason_code)
+
+    def on_disconnect(_client, _userdata, _flags, reason_code, _properties=None):
+        log.warning("Disconnected from broker (reason=%s) -- paho will auto-reconnect", reason_code)
+
+    client.on_connect = on_connect
+    client.on_disconnect = on_disconnect
+
+    # No authentication configured — matches every other real protocol server
+    # in this project (Modbus, DNP3, BACnet, EtherNet/IP, PROFINET, C37.118):
+    # the teaching point is the protocol's own lack of built-in security, not
+    # a simulator shortcut. A future MQTT attack tutorial can exploit this
+    # exactly like the existing tutorials exploit their own protocols' lack
+    # of authentication.
+    client.connect_async(BROKER_IP, BROKER_PORT, keepalive=30)
+    client.loop_start()
+
+    dt = SENSOR_SAMPLE_RATE_MS / 1000.0
+    full_range = SENSOR_MAX_VALUE - SENSOR_MIN_VALUE
+    t = 0.0
+    tick = 0
+    try:
+        while True:
+            time.sleep(dt)
+            t += dt
+            value = sensor_value_at(t)
+            if SENSOR_NOISE_PERCENT > 0:
+                value += random.gauss(0.0, full_range * SENSOR_NOISE_PERCENT / 100.0)
+            value = max(SENSOR_MIN_VALUE, min(SENSOR_MAX_VALUE, value))
+
+            payload = json.dumps({
+                "value": round(value, 3),
+                "unit": SENSOR_UNITS,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            })
+            client.publish(TOPIC, payload, qos=0)
+
+            tick += 1
+            if tick % 30 == 0:
+                log.info("[%s] t=%.0fs value=%.3f%s", TOPIC, t, value,
+                          f" {SENSOR_UNITS}" if SENSOR_UNITS else "")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        client.loop_stop()
+        client.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/containers/iot-gateway/Dockerfile
+++ b/containers/iot-gateway/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.12-alpine
+
+# Real Mosquitto broker (Alpine's own community package — the exact same
+# software a real IIoT gateway product would embed) plus pymodbus (client
+# mode, same version pin as containers/dcs) and paho-mqtt (client mode) for
+# the Python sidecar that bridges Modbus field devices onto the broker.
+# This is not a new container SHAPE for this project — it mirrors OpenPLC's
+# own container, which also runs a compiled runtime (matiec/openplc binary)
+# alongside a Python webserver process — just a different pair of processes.
+RUN apk add --no-cache mosquitto
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir "pymodbus==3.7.4" "paho-mqtt==2.1.0"
+
+COPY mosquitto.conf /etc/mosquitto/mosquitto.conf
+COPY sidecar.py .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+# Defaults — all overridable via docker-compose environment:
+ENV DEVICE_ID=gateway-1 \
+    DEVICE_CATEGORY=iot-gateway \
+    MQTT_PORT=1883 \
+    GATEWAY_FIELD_DEVICES=""
+
+# Standard MQTT port.
+EXPOSE 1883
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/containers/iot-gateway/entrypoint.sh
+++ b/containers/iot-gateway/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+echo "[ics-iot-gateway] Device=${DEVICE_ID}  category=${DEVICE_CATEGORY}  mqtt_port=${MQTT_PORT}"
+
+# Mosquitto runs backgrounded; the Python sidecar execs as the foreground
+# (PID 1) process so the container's lifecycle ties to the sidecar's health.
+# Same backgrounded-process-plus-foreground-exec shape already used in
+# containers/attack-base/entrypoint.sh's plc_init poller. Both processes'
+# stdout share this container's stdout stream (mosquitto.conf sets
+# log_dest stdout), so `docker logs` shows real broker activity interleaved
+# with the sidecar's own log lines.
+echo "[ics-iot-gateway] Starting Mosquitto broker on 0.0.0.0:${MQTT_PORT} (anonymous access)..."
+mosquitto -c /etc/mosquitto/mosquitto.conf &
+
+# Give the broker a moment to bind its listening socket before the sidecar's
+# first connection attempt — avoids a guaranteed-fail first try on every
+# container start (the sidecar's own paho-mqtt client will still retry/
+# reconnect on its own after this, this just avoids the noisy first failure).
+sleep 1
+
+exec python3 /app/sidecar.py

--- a/containers/iot-gateway/mosquitto.conf
+++ b/containers/iot-gateway/mosquitto.conf
@@ -1,0 +1,19 @@
+# mosquitto.conf — real Mosquitto broker configuration for the ICS Simulator
+# iot-gateway device.
+#
+# allow_anonymous true / no password_file / no ACL file: matches every other
+# real protocol server in this project (Modbus, DNP3, BACnet, EtherNet/IP,
+# PROFINET, C37.118) — no authentication by design, since the teaching point
+# throughout this platform is each protocol's own default security posture,
+# not a simulator shortcut. A future MQTT attack tutorial can exploit this
+# exactly like the existing tutorials exploit their own protocols.
+listener 1883 0.0.0.0
+allow_anonymous true
+
+# Log to stdout so `docker logs` shows real broker activity (connects,
+# subscribes, publishes at notice level) — same observability convention
+# every container in this project follows.
+log_dest stdout
+log_type error
+log_type warning
+log_type notice

--- a/containers/iot-gateway/sidecar.py
+++ b/containers/iot-gateway/sidecar.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+sidecar.py — Modbus-to-MQTT bridge for the ICS Simulator iot-gateway device.
+
+Runs alongside a real Mosquitto broker (started by entrypoint.sh, listening
+on localhost:MQTT_PORT) in the same container. This process has two jobs:
+
+  1. Polls the Modbus field devices (smart-sensor/smart-controller) wired to
+     this gateway on the canvas, exactly the same "field I/O in" role
+     containers/dcs/server.py already plays — same fresh-connection-per-
+     cycle polling style, same Coil0/HoldingReg0 read shape.
+  2. Republishes each field device's values as MQTT PUBLISH packets onto the
+     SAME broker that any wired iiot-sensor nodes are already publishing
+     directly to — unifying Modbus-only field devices and native MQTT
+     publishers under one consistent topic scheme (otforge/<nodeId>/value)
+     on one broker, one place for a student to inspect the whole picture.
+
+This is the "aggregation and re-exposure over a different real protocol"
+pattern already established by the DCS controller (Modbus-in, OPC-UA-out)
+and the PMU (Modbus-in, C37.118-out), applied here as Modbus-in, MQTT-out —
+except this device ALSO hosts the broker its own MQTT-out side publishes to,
+which is also where directly-wired iiot-sensor nodes publish. No write-down
+to field devices (read-only upward, deliberately) — same scope cut DCS made
+and for the same reason: this is the aggregation/visibility layer, not a
+second control path.
+
+Topic: otforge/<fieldDeviceNodeId>/value — same scheme containers/iiot-
+sensor/server.py uses for its own direct publishes, so both sources appear
+consistently under one topic namespace.
+
+Payload (JSON): {"value": <float>, "source": "modbus-bridge", "timestamp": "<ISO8601>"}
+
+Environment variables:
+    DEVICE_ID              — node identifier string, used in logging
+    DEVICE_CATEGORY        — logged at startup for Docker Compose traceability
+    MQTT_PORT              — local broker port this sidecar publishes to
+                             (default 1883 — must match mosquitto.conf's
+                             listener, which the same MQTT_PORT env var
+                             also configures via entrypoint.sh)
+    GATEWAY_FIELD_DEVICES  — comma-separated "nodeId|ip" pairs, one per
+                             field device wired to this gateway on the
+                             canvas (compose-generator.ts derives this from
+                             canvas edges — see connectionRules.ts's
+                             iot-gateway.smart-sensor/smart-controller
+                             entries). Empty/unset means the gateway was
+                             placed but not wired to any field devices yet;
+                             the sidecar still starts cleanly and the
+                             broker remains available for directly-wired
+                             iiot-sensor publishers.
+
+Protocol references: Modbus Application Protocol Specification (field I/O
+polling), MQTT Version 3.1.1 (OASIS Standard).
+Library versions: pymodbus 3.7.4 (client mode, same pin as containers/dcs),
+paho-mqtt 2.1.0 (client mode, same pin as containers/iiot-sensor).
+"""
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+import paho.mqtt.client as mqtt
+from pymodbus.client import AsyncModbusTcpClient
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("ics-iot-gateway")
+
+DEVICE_ID = os.getenv("DEVICE_ID", "gateway-1")
+CATEGORY = os.getenv("DEVICE_CATEGORY", "iot-gateway")
+MQTT_PORT = int(os.getenv("MQTT_PORT", "1883"))
+
+MODBUS_PORT = 502
+# Field devices in this simulator are seeded at Modbus unit id 1 by default,
+# same assumption containers/dcs/server.py already makes for the same reason.
+FIELD_DEVICE_UNIT_ID = 1
+
+POLL_INTERVAL_SECONDS = 2
+POLL_TIMEOUT_SECONDS = 3
+
+
+def parse_field_devices(raw: str) -> list[tuple[str, str]]:
+    """
+    Parses GATEWAY_FIELD_DEVICES ("nodeId|ip,nodeId|ip,...") into a list of
+    (nodeId, ip) tuples. Malformed entries are logged and skipped rather
+    than raising — one bad entry must not take down the whole gateway.
+    Identical parsing shape to containers/dcs/server.py's parse_field_devices().
+    """
+    devices: list[tuple[str, str]] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        parts = entry.split("|")
+        if len(parts) != 2:
+            log.warning("Skipping malformed GATEWAY_FIELD_DEVICES entry: %r", entry)
+            continue
+        node_id, ip = parts[0].strip(), parts[1].strip()
+        if node_id and ip:
+            devices.append((node_id, ip))
+    return devices
+
+
+async def poll_field_device(node_id: str, ip: str) -> float | None:
+    """
+    Opens a fresh Modbus TCP client connection to one field device, reads
+    Holding Register 0 (FC03), then closes the connection. Same fresh-
+    connection-per-cycle approach as containers/dcs/server.py's
+    poll_field_device() and for the same reason: simpler, more robust
+    recovery than a persistent per-device client.
+    """
+    client = AsyncModbusTcpClient(ip, port=MODBUS_PORT, timeout=POLL_TIMEOUT_SECONDS)
+    value: float | None = None
+    try:
+        await client.connect()
+        if not client.connected:
+            log.warning("%s (%s): connection failed", node_id, ip)
+            return None
+        hr_result = await client.read_holding_registers(0, count=1, slave=FIELD_DEVICE_UNIT_ID)
+        if not hr_result.isError():
+            value = float(hr_result.registers[0])
+    except Exception as exc:  # noqa: BLE001 — one field device's failure must not crash the poll loop
+        log.warning("%s (%s): poll error — %s", node_id, ip, exc)
+    finally:
+        client.close()
+    return value
+
+
+async def poll_loop(field_devices: list[tuple[str, str]], mqtt_client: mqtt.Client) -> None:
+    """
+    Background task — polls every field device every POLL_INTERVAL_SECONDS
+    and republishes each successfully-read value onto the local broker.
+    Each field device's poll+publish is wrapped in its own try/except, same
+    isolation reasoning as containers/dcs/server.py's poll_loop().
+    """
+    if not field_devices:
+        log.info("No field devices configured — bridging nothing, broker still available for iiot-sensor publishers.")
+        return
+
+    while True:
+        for node_id, ip in field_devices:
+            try:
+                value = await poll_field_device(node_id, ip)
+                if value is not None:
+                    payload = json.dumps({
+                        "value": value,
+                        "source": "modbus-bridge",
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    })
+                    mqtt_client.publish(f"otforge/{node_id}/value", payload, qos=0)
+            except Exception as exc:  # noqa: BLE001 — one field device's publish failing must not end polling for the rest
+                log.warning("%s: bridge error — %s", node_id, exc)
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+
+
+async def main() -> None:
+    field_devices = parse_field_devices(os.getenv("GATEWAY_FIELD_DEVICES", ""))
+    log.info(
+        "IoT gateway starting -- id=%s  category=%s  mqtt_port=%d  field_devices=%s",
+        DEVICE_ID, CATEGORY, MQTT_PORT,
+        ", ".join(f"{n}@{ip}" for n, ip in field_devices) or "(none)",
+    )
+
+    mqtt_client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=f"{DEVICE_ID}-sidecar")
+
+    def on_connect(_client, _userdata, _flags, reason_code, _properties=None):
+        if reason_code == 0:
+            log.info("Sidecar connected to local broker on 127.0.0.1:%d", MQTT_PORT)
+        else:
+            log.warning("Sidecar connect to local broker failed: %s", reason_code)
+
+    mqtt_client.on_connect = on_connect
+    mqtt_client.connect_async("127.0.0.1", MQTT_PORT, keepalive=30)
+    mqtt_client.loop_start()
+
+    await poll_loop(field_devices, mqtt_client)
+    await asyncio.Future()  # run until cancelled (only reached if field_devices was empty)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
+++ b/packages/app/src/renderer/src/properties/PropertiesPanel.tsx
@@ -548,7 +548,10 @@ export function PropertiesPanel({
             )}
 
             {/* ── Smart sensor config (kind chosen in dropdown) ───────────────────── */}
-            {device.category === 'smart-sensor' && (
+            {/* iiot-sensor reuses the same SensorConfig shape/editor — it's a
+                standalone MQTT publisher rather than a Modbus field device,
+                but the waveform/kind/range fields it publishes are identical. */}
+            {(device.category === 'smart-sensor' || device.category === 'iiot-sensor') && (
               <SensorPanel
                 sensorConfig={device.sensor}
                 nodeId={device.nodeId}

--- a/packages/orchestrator/src/__tests__/compose-generator.test.ts
+++ b/packages/orchestrator/src/__tests__/compose-generator.test.ts
@@ -901,6 +901,117 @@ describe('dcs-controller — real device', () => {
   })
 })
 
+describe('iiot-sensor — MQTT publisher', () => {
+  it('gives iiot-sensor the otforge-iiot-sensor image — a real container, not the alpine stub', () => {
+    const compose = gen(
+      makeScenario([['sensor-1', { category: 'iiot-sensor', ipAddress: '10.200.10.30' }]])
+    )
+    expect(compose.services['sensor-1']).toBeDefined()
+    expect(compose.services['sensor-1'].image).toBe('ghcr.io/iburres/otforge-iiot-sensor:latest')
+  })
+
+  it('assigns the 64m/0.1 resource limit to iiot-sensor', () => {
+    const compose = gen(
+      makeScenario([['sensor-1', { category: 'iiot-sensor', ipAddress: '10.200.10.30' }]])
+    )
+    expect(compose.services['sensor-1'].deploy.resources.limits.memory).toBe('64m')
+    expect(compose.services['sensor-1'].deploy.resources.limits.cpus).toBe('0.1')
+  })
+
+  it('injects MQTT_BROKER_IP from a direct edge to an iot-gateway', () => {
+    const scenario = makeScenario([
+      ['sensor-1', { category: 'iiot-sensor', ipAddress: '10.200.10.30' }],
+      ['gateway-1', { category: 'iot-gateway', ipAddress: '10.200.10.31' }]
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'sensor-1', target: 'gateway-1', data: { protocol: 'mqtt' } }
+    ]
+    const env = gen(scenario).services['sensor-1'].environment ?? []
+    expect(env).toContain('MQTT_BROKER_IP=10.200.10.31')
+  })
+
+  it('omits MQTT_BROKER_IP entirely when the iiot-sensor has no connecting edges', () => {
+    const compose = gen(
+      makeScenario([['sensor-1', { category: 'iiot-sensor', ipAddress: '10.200.10.30' }]])
+    )
+    const env = compose.services['sensor-1'].environment ?? []
+    expect(env.some(v => v.startsWith('MQTT_BROKER_IP'))).toBe(false)
+  })
+})
+
+describe('iot-gateway — real MQTT broker + Modbus bridge', () => {
+  it('gives iot-gateway the otforge-iot-gateway image — a real container, not the alpine stub', () => {
+    const compose = gen(
+      makeScenario([['gateway-1', { category: 'iot-gateway', ipAddress: '10.200.10.31' }]])
+    )
+    expect(compose.services['gateway-1']).toBeDefined()
+    expect(compose.services['gateway-1'].image).toBe('ghcr.io/iburres/otforge-iot-gateway:latest')
+  })
+
+  it('assigns the 96m/0.2 resource limit to iot-gateway', () => {
+    const compose = gen(
+      makeScenario([['gateway-1', { category: 'iot-gateway', ipAddress: '10.200.10.31' }]])
+    )
+    expect(compose.services['gateway-1'].deploy.resources.limits.memory).toBe('96m')
+    expect(compose.services['gateway-1'].deploy.resources.limits.cpus).toBe('0.2')
+  })
+
+  it('injects GATEWAY_FIELD_DEVICES from a single edge to a smart-sensor', () => {
+    const scenario = makeScenario([
+      ['gateway-1', { category: 'iot-gateway', ipAddress: '10.200.10.31' }],
+      ['sensor-1', { category: 'smart-sensor', ipAddress: '10.200.10.12' }]
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'gateway-1', target: 'sensor-1', data: { protocol: 'modbus-tcp' } }
+    ]
+    const env = gen(scenario).services['gateway-1'].environment ?? []
+    expect(env).toContain('GATEWAY_FIELD_DEVICES=sensor-1|10.200.10.12')
+  })
+
+  it('injects GATEWAY_FIELD_DEVICES as a comma-separated list from multiple edges', () => {
+    const scenario = makeScenario([
+      ['gateway-1', { category: 'iot-gateway', ipAddress: '10.200.10.31' }],
+      [
+        'pump-1',
+        { category: 'smart-controller', ipAddress: '10.200.10.11', controller: { kind: 'pump' } }
+      ],
+      ['sensor-1', { category: 'smart-sensor', ipAddress: '10.200.10.12' }]
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'gateway-1', target: 'pump-1', data: { protocol: 'modbus-tcp' } },
+      { id: 'e2', source: 'sensor-1', target: 'gateway-1', data: { protocol: 'modbus-tcp' } }
+    ]
+    const env = gen(scenario).services['gateway-1'].environment ?? []
+    const fieldDevicesEnv = env.find(v => v.startsWith('GATEWAY_FIELD_DEVICES='))
+    expect(fieldDevicesEnv).toBeDefined()
+    const entries = fieldDevicesEnv!.slice('GATEWAY_FIELD_DEVICES='.length).split(',')
+    expect(entries).toEqual(
+      expect.arrayContaining(['pump-1|10.200.10.11', 'sensor-1|10.200.10.12'])
+    )
+    expect(entries).toHaveLength(2)
+  })
+
+  it('omits GATEWAY_FIELD_DEVICES entirely when the gateway has no connecting field-device edges', () => {
+    const compose = gen(
+      makeScenario([['gateway-1', { category: 'iot-gateway', ipAddress: '10.200.10.31' }]])
+    )
+    const env = compose.services['gateway-1'].environment ?? []
+    expect(env.some(v => v.startsWith('GATEWAY_FIELD_DEVICES'))).toBe(false)
+  })
+
+  it('does not pull an edge to an unrelated category (e.g. hmi) into the field-device list', () => {
+    const scenario = makeScenario([
+      ['gateway-1', { category: 'iot-gateway', ipAddress: '10.200.10.31' }],
+      ['hmi-1', { category: 'hmi', ipAddress: '10.200.20.10' }]
+    ])
+    scenario.visual.edges = [
+      { id: 'e1', source: 'gateway-1', target: 'hmi-1', data: { protocol: 'opc-ua' } }
+    ]
+    const env = gen(scenario).services['gateway-1'].environment ?? []
+    expect(env.some(v => v.startsWith('GATEWAY_FIELD_DEVICES'))).toBe(false)
+  })
+})
+
 describe('pmu — real IEEE C37.118 device', () => {
   function generatorUnit(id: string, ip: string): [string, DeviceOverrides] {
     return [

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -82,10 +82,10 @@ const DEVICE_IMAGES: Record<DeviceCategory, string> = {
   pmu: 'ghcr.io/iburres/otforge-pmu:latest',
   // BACnet/IP device — bacpypes3 Python server on Alpine (containers/bacnet)
   sensor: 'ghcr.io/iburres/otforge-bacnet:latest',
-  // STUB: IIoT sensor — MQTT publisher stub until otforge-iiot-sensor is built.
-  'iiot-sensor': 'ghcr.io/iburres/alpine:latest',
-  // STUB: IoT gateway — MQTT broker/bridge stub until otforge-iot-gateway is built.
-  'iot-gateway': 'ghcr.io/iburres/alpine:latest',
+  // Real IIoT sensor — standalone MQTT publisher, paho-mqtt client (containers/iiot-sensor).
+  'iiot-sensor': 'ghcr.io/iburres/otforge-iiot-sensor:latest',
+  // Real IoT gateway — real Mosquitto broker + Python Modbus-to-MQTT bridge sidecar (containers/iot-gateway).
+  'iot-gateway': 'ghcr.io/iburres/otforge-iot-gateway:latest',
   // Real Modbus TCP outstation — same pymodbus server image as rtu (containers/modbus).
   // server.py generates the configured waveform; FUXA cannot act as a Modbus server,
   // so this needs to be a real container, not a "no container, FUXA generates it" device.
@@ -522,6 +522,53 @@ export function generateCompose(
     }
   }
 
+  // ── IIoT sensor → gateway broker IP map ─────────────────────────────────────
+  // Scan canvas edges to find which iot-gateway (if any) each iiot-sensor is
+  // directly wired to — used below to inject MQTT_BROKER_IP so the sensor's
+  // paho-mqtt publisher knows where to connect at container startup (see
+  // containers/iiot-sensor/server.py). Single-target edge scan, same shape
+  // as pmuToGeneratorNodeId above — an iiot-sensor publishes to exactly one
+  // gateway, not a fan-out relationship.
+  const iiotSensorToGatewayNodeId = new Map<string, string>()
+  for (const edge of scenario.visual.edges) {
+    const srcDevice = scenario.devices.devices[edge.source]
+    const tgtDevice = scenario.devices.devices[edge.target]
+    if (!srcDevice || !tgtDevice) continue
+    if (srcDevice.category === 'iiot-sensor' && tgtDevice.category === 'iot-gateway') {
+      iiotSensorToGatewayNodeId.set(edge.source, edge.target)
+    } else if (tgtDevice.category === 'iiot-sensor' && srcDevice.category === 'iot-gateway') {
+      iiotSensorToGatewayNodeId.set(edge.target, edge.source)
+    }
+  }
+
+  // ── IoT gateway → Modbus field device map ───────────────────────────────────
+  // Scan canvas edges to find which smart-controller/smart-sensor field
+  // devices (if any) each iot-gateway is directly wired to — used below to
+  // inject GATEWAY_FIELD_DEVICES so the gateway's Python sidecar knows which
+  // field devices to poll over Modbus and bridge onto its own MQTT broker
+  // (see containers/iot-gateway/sidecar.py). Identical fan-in shape to
+  // dcsToFieldDeviceNodeIds above — reuses the same isFieldDevice() helper.
+  const gatewayToFieldDeviceNodeIds = new Map<string, string[]>()
+  for (const edge of scenario.visual.edges) {
+    const srcDevice = scenario.devices.devices[edge.source]
+    const tgtDevice = scenario.devices.devices[edge.target]
+    if (!srcDevice || !tgtDevice) continue
+    let gatewayNodeId: string | null = null
+    let fieldNodeId: string | null = null
+    if (srcDevice.category === 'iot-gateway' && isFieldDevice(tgtDevice.category)) {
+      gatewayNodeId = edge.source
+      fieldNodeId = edge.target
+    } else if (tgtDevice.category === 'iot-gateway' && isFieldDevice(srcDevice.category)) {
+      gatewayNodeId = edge.target
+      fieldNodeId = edge.source
+    }
+    if (gatewayNodeId && fieldNodeId) {
+      const existing = gatewayToFieldDeviceNodeIds.get(gatewayNodeId) ?? []
+      existing.push(fieldNodeId)
+      gatewayToFieldDeviceNodeIds.set(gatewayNodeId, existing)
+    }
+  }
+
   // ── IP deduplication ────────────────────────────────────────────────────────
   // Tracks host octets already assigned per Docker network so that stale or
   // duplicate IPs in the scenario JSON never produce an invalid compose file.
@@ -784,6 +831,28 @@ ${deviceBlocks}
       }
     }
 
+    // IIoT sensor — real MQTT publisher (containers/iiot-sensor). Injects
+    // MQTT_BROKER_IP when wired to an iot-gateway; sensor kind/waveform env
+    // vars are injected unconditionally below via the existing device.sensor
+    // block (reused as-is, same as smart-sensor). Omitted entirely when
+    // unwired — the container still starts cleanly and idles (see
+    // server.py's module docstring) rather than crash-looping.
+    if (device.category === 'iiot-sensor') {
+      const gatewayNodeId = iiotSensorToGatewayNodeId.get(nodeId)
+      if (gatewayNodeId) {
+        const gatewayIp =
+          claimedDeviceIps.get(gatewayNodeId) ??
+          resolveDeviceIp(
+            scenario.devices.devices[gatewayNodeId].ipAddress,
+            scenario,
+            effectiveZones
+          )
+        const iiotEnv: string[] = services[serviceName].environment ?? []
+        iiotEnv.push(`MQTT_BROKER_IP=${gatewayIp}`)
+        services[serviceName].environment = iiotEnv
+      }
+    }
+
     // Controller-specific env vars — injected for smart-controller devices only.
     // Visible in container logs / Properties Panel either way, but CONTROLLER_KIND and
     // the headline numeric fields (CONTROLLER_RATED_FLOW_LPM, CONTROLLER_MAX_FREQUENCY_HZ,
@@ -843,6 +912,32 @@ ${deviceBlocks}
         const dcsEnv: string[] = services[serviceName].environment ?? []
         dcsEnv.push(`DCS_FIELD_DEVICES=${fieldDeviceEntries.join(',')}`)
         services[serviceName].environment = dcsEnv
+      }
+    }
+
+    // IoT gateway — inject the field devices (smart-controller/smart-sensor)
+    // this gateway is directly wired to, so containers/iot-gateway/sidecar.py
+    // knows which Modbus TCP hosts to poll and bridge onto its own MQTT
+    // broker at startup. Omitted entirely when the gateway has no connecting
+    // field-device edges yet — the broker is still fully available for any
+    // directly-wired iiot-sensor publishers regardless (see sidecar.py's
+    // module docstring). Identical shape to the DCS_FIELD_DEVICES block above.
+    if (device.category === 'iot-gateway') {
+      const fieldDeviceNodeIds = gatewayToFieldDeviceNodeIds.get(nodeId) ?? []
+      if (fieldDeviceNodeIds.length > 0) {
+        const fieldDeviceEntries = fieldDeviceNodeIds.map(fieldNodeId => {
+          const fieldIp =
+            claimedDeviceIps.get(fieldNodeId) ??
+            resolveDeviceIp(
+              scenario.devices.devices[fieldNodeId].ipAddress,
+              scenario,
+              effectiveZones
+            )
+          return `${sanitizeServiceName(fieldNodeId)}|${fieldIp}`
+        })
+        const gatewayEnv: string[] = services[serviceName].environment ?? []
+        gatewayEnv.push(`GATEWAY_FIELD_DEVICES=${fieldDeviceEntries.join(',')}`)
+        services[serviceName].environment = gatewayEnv
       }
     }
 


### PR DESCRIPTION
## Summary
- Upgrades the two long-standing `iiot-sensor`/`iot-gateway` alpine stubs to real containers, closing the last unimplemented protocol in the `Protocol` enum.
- `iiot-sensor`: standalone `paho-mqtt` publisher pushing synthetic waveform readings (sine/random/sawtooth/square/constant, reusing `SensorConfig`) on its own schedule to its wired gateway's broker — never polled, unlike `smart-sensor`.
- `iot-gateway`: real Mosquitto broker (anonymous, matching every other protocol's default-insecure teaching posture in this project) plus a Python sidecar that polls wired Modbus field devices (`smart-controller`/`smart-sensor`) and republishes their values onto the same broker — unifying native MQTT publishes and Modbus-bridged values under one topic scheme (`otforge/<nodeId>/value`).
- Delivery stops at the MQTT layer by design — no historian/InfluxDB write path, matching Ian's scope call to keep this a self-contained protocol-survey unit.
- `compose-generator.ts`: swapped both images off the alpine stub, added `iiotSensorToGatewayNodeId` (single-target edge scan → `MQTT_BROKER_IP`) and `gatewayToFieldDeviceNodeIds` (fan-in edge scan → `GATEWAY_FIELD_DEVICES`), mirroring the existing PMU/DCS patterns exactly.
- `PropertiesPanel.tsx`: widened the existing `SensorPanel` condition to also cover `iiot-sensor`.
- `docker.yml`: added both new images to the `build-images` matrix (lesson learned from PR #65 — CI can go green without ever building a new image if this step is missed).
- New `compose-generator.test.ts` blocks mirroring the PMU/DCS test shapes (image assignment, resource limits, env injection single/multiple/omitted/unrelated-category-ignored).

## Test plan
- [x] `tsc --noEmit` clean in `packages/orchestrator` and `packages/app`
- [x] `vitest run` — 216/216 passing in `packages/orchestrator`
- [x] Built both images locally (`otforge-iiot-sensor`, `otforge-iot-gateway`)
- [x] Standalone `iot-gateway` with no field devices: broker starts, sidecar connects, idles cleanly
- [x] Standalone `iiot-sensor` wired to a gateway: real MQTT PUBLISH packets over the Docker network follow the configured waveform (sawtooth verified monotonically increasing)
- [x] `iot-gateway` wired to a real `smart-sensor` container: sidecar's Modbus poll picks up the real register value and republishes it as MQTT, verified by direct subscription
- [x] Full topology: `iiot-sensor` + a Modbus-bridged field device on the same gateway — a third-party subscriber sees both topics together
- [ ] CI: confirm both `otforge-iiot-sensor` and `otforge-iot-gateway` appear in the `build-images` job output on this PR, not just an overall green run

🤖 Generated with [Claude Code](https://claude.com/claude-code)