### PR TITLE
feat: real Active Directory Domain Controller (Samba4, LDAP/Kerberos/SMB)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,6 +63,10 @@ jobs:
             context: containers/iiot-sensor
           - image: otforge-iot-gateway
             context: containers/iot-gateway
+          # Real Samba4 Active Directory Domain Controller — LDAP (389/636),
+          # Kerberos (88), SMB (445), Enterprise Zone.
+          - image: otforge-dc
+            context: containers/dc
           - image: otforge-firewall
             context: containers/firewall
           - image: otforge-switch

--- a/containers/attack-base/Dockerfile
+++ b/containers/attack-base/Dockerfile
@@ -101,6 +101,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git vim nano \
     && rm -rf /var/lib/apt/lists/*
 
+# ── Layer 6b: Active Directory enumeration/collection tooling ────────────────
+# ldap3: real LDAP bind/search client for AD enumeration (impacket above
+# already covers Kerberoasting/AS-REP-roasting/secretsdump/pass-the-hash via
+# its example scripts). bloodhound: the BloodHound Python collector, produces
+# standard JSON collection files from a real AD environment (no BloodHound
+# GUI/Neo4j is bundled here -- students analyze the JSON output separately).
+RUN pip3 install --no-cache-dir --break-system-packages \
+    ldap3 \
+    bloodhound
+
 # ── Layer 7: Python ICS protocol libraries + noVNC WebSocket bridge ───────────
 # websockify bridges VNC port 5901 → WebSocket port 6080 (the Electron webview
 # connects to 6080 via noVNC). Installing via pip is more reliable than the

--- a/containers/dc/Dockerfile
+++ b/containers/dc/Dockerfile
@@ -1,0 +1,50 @@
+# containers/dc/Dockerfile
+#
+# Meridian Process Controls — real Active Directory Domain Controller for the
+# Enterprise Zone of the ICS Simulator topology.
+#
+# Runs a genuine Samba4 AD DC (not an emulator) provisioned at container start
+# via `samba-tool domain provision`, serving real LDAP (389/636), Kerberos (88),
+# and SMB (445). Deliberately a distinct internal namespace (MERIDIAN.LOCAL by
+# default) from the public-facing meridian-process.com DNS zone already served
+# by containers/dns-server/ — real organizations commonly split the two the
+# same way.
+#
+# This is a REALISTIC domain, not a deliberately vulnerable one: a small
+# OU/user/group structure is seeded so LDAP enumeration and BloodHound
+# collection have real data to work with, but no intentionally weak accounts,
+# Kerberoastable SPNs, or AS-REP-roastable flags are planted here — that
+# content belongs to a future attack tutorial, not this device's baseline.
+#
+# Environment variables (with defaults, see entrypoint.sh):
+#   AD_DOMAIN          — Fully-qualified AD realm  (default: MERIDIAN.LOCAL)
+#   AD_NETBIOS         — Short NetBIOS domain name (default: MERIDIAN)
+#   AD_ADMIN_PASSWORD  — Administrator account password (default: fixed known value)
+#   AD_USER_PASSWORD   — Password for every seeded employee account (default: a
+#                        different fixed known value, so students can't assume
+#                        the Administrator password by guessing a shared one)
+#
+# Image: alpine:3.20 + samba-dc (~19 MiB package)
+FROM alpine:3.20
+
+RUN apk add --no-cache samba-dc
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENV AD_DOMAIN=MERIDIAN.LOCAL \
+    AD_NETBIOS=MERIDIAN \
+    AD_ADMIN_PASSWORD=M3ridian!Admin \
+    AD_USER_PASSWORD=M3ridian!2026
+
+# LDAP (389), LDAPS (636), Kerberos (88, tcp+udp), SMB (445), Samba's own
+# internal DNS for the AD zone (53, tcp+udp) — all real AD DC service ports.
+EXPOSE 389/tcp
+EXPOSE 636/tcp
+EXPOSE 88/tcp
+EXPOSE 88/udp
+EXPOSE 445/tcp
+EXPOSE 53/tcp
+EXPOSE 53/udp
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/containers/dc/entrypoint.sh
+++ b/containers/dc/entrypoint.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# entrypoint.sh — real Samba4 Active Directory Domain Controller.
+#
+# On first start, provisions a brand-new AD forest/domain via `samba-tool
+# domain provision`, then seeds a small realistic OU/user/group structure
+# (no deliberately weak accounts — see Dockerfile header), then runs `samba`
+# in the foreground so every LDAP bind, Kerberos AS-REQ, and SMB session
+# Docker captures on stdout is visible to students via `docker logs -f`.
+#
+# Re-provisioning is skipped on container restart (sam.ldb already present)
+# so restarting the same container doesn't destroy/recreate the domain.
+#
+# Environment variables:
+#   AD_DOMAIN          Fully-qualified AD realm  (default: MERIDIAN.LOCAL)
+#   AD_NETBIOS         Short NetBIOS domain name (default: MERIDIAN)
+#   AD_ADMIN_PASSWORD  Administrator account password (default: fixed known value)
+#   AD_USER_PASSWORD   Password shared by every seeded employee account
+#                      (deliberately different from AD_ADMIN_PASSWORD so
+#                      students can't assume a single domain-wide password)
+#
+# NOTE on --option='posix:eadb=...': Samba's provision process sets an NT ACL
+# on the sysvol directory using filesystem extended attributes by default,
+# which fails with NT_STATUS_ACCESS_DENIED on Docker's overlay filesystem.
+# Redirecting extended-attribute storage to a tdb database file (rather than
+# real filesystem xattrs) is Samba's own documented workaround for exactly
+# this environment and is what makes AD DC provisioning work inside a
+# container at all.
+
+set -e
+
+AD_DOMAIN="${AD_DOMAIN:-MERIDIAN.LOCAL}"
+AD_NETBIOS="${AD_NETBIOS:-MERIDIAN}"
+AD_ADMIN_PASSWORD="${AD_ADMIN_PASSWORD:-M3ridian!Admin}"
+AD_USER_PASSWORD="${AD_USER_PASSWORD:-M3ridian!2026}"
+AD_LOG_LEVEL="${AD_LOG_LEVEL:-2}"
+# DEVICE_ID is the scenario nodeId, injected by compose-generator.ts's
+# buildDeviceEnv() for every device -- it matches the Docker Compose service
+# name/network alias other containers use to resolve this one. Setting the
+# container's own OS hostname to match (and passing the same value as
+# --host-name below) makes Samba self-register its AD DNS records under the
+# SAME name Docker's embedded DNS already resolves, instead of the random
+# container-ID hostname Samba would otherwise pick up automatically.
+DEVICE_ID="${DEVICE_ID:-dc-1}"
+hostname "${DEVICE_ID}" 2>/dev/null || true
+
+HOST_IP=$(hostname -i | awk '{print $1}')
+
+echo "[otforge-dc] ================================================"
+echo "[otforge-dc] Domain (realm):  ${AD_DOMAIN}"
+echo "[otforge-dc] NetBIOS domain:  ${AD_NETBIOS}"
+echo "[otforge-dc] Host IP:         ${HOST_IP}"
+echo "[otforge-dc] Administrator password: ${AD_ADMIN_PASSWORD}"
+echo "[otforge-dc] Seeded employee password (all accounts below): ${AD_USER_PASSWORD}"
+echo "[otforge-dc] ================================================"
+
+if [ ! -f /var/lib/samba/private/sam.ldb ]; then
+    echo "[otforge-dc] No existing domain found -- provisioning a new AD forest..."
+    rm -f /etc/samba/smb.conf
+
+    samba-tool domain provision \
+        --server-role=dc \
+        --use-rfc2307 \
+        --dns-backend=SAMBA_INTERNAL \
+        --realm="${AD_DOMAIN}" \
+        --domain="${AD_NETBIOS}" \
+        --adminpass="${AD_ADMIN_PASSWORD}" \
+        --host-ip="${HOST_IP}" \
+        --host-name="${DEVICE_ID}" \
+        --option="posix:eadb=/var/lib/samba/private/eadb.tdb" \
+        --option="log level=${AD_LOG_LEVEL}"
+
+    echo "[otforge-dc] Provisioning complete -- seeding realistic OU/user/group structure..."
+
+    # Three departments, matching this project's fictional company (Meridian
+    # Process Controls) -- a small, realistic org structure for LDAP
+    # enumeration and BloodHound collection exercises. No deliberately weak
+    # accounts, Kerberoastable SPNs, or AS-REP-roastable flags are set here.
+    samba-tool ou create OU=IT
+    samba-tool ou create OU=Engineering
+    samba-tool ou create OU=Operations
+
+    samba-tool group add IT-Staff --group-scope=Global
+    samba-tool group add Engineering-Staff --group-scope=Global
+    samba-tool group add Operations-Staff --group-scope=Global
+
+    samba-tool user create schen "${AD_USER_PASSWORD}" --given-name=Sarah --surname=Chen --userou=OU=IT
+    samba-tool user create mwebb "${AD_USER_PASSWORD}" --given-name=Marcus --surname=Webb --userou=OU=IT
+    samba-tool user create eortiz "${AD_USER_PASSWORD}" --given-name=Elena --surname=Ortiz --userou=OU=Engineering
+    samba-tool user create dkim "${AD_USER_PASSWORD}" --given-name=David --surname=Kim --userou=OU=Engineering
+    samba-tool user create pnair "${AD_USER_PASSWORD}" --given-name=Priya --surname=Nair --userou=OU=Operations
+    samba-tool user create tbaxter "${AD_USER_PASSWORD}" --given-name=Tom --surname=Baxter --userou=OU=Operations
+
+    samba-tool group addmembers IT-Staff schen,mwebb
+    samba-tool group addmembers Engineering-Staff eortiz,dkim
+    samba-tool group addmembers Operations-Staff pnair,tbaxter
+
+    echo "[otforge-dc] Seeded users: schen, mwebb (IT-Staff) / eortiz, dkim (Engineering-Staff) / pnair, tbaxter (Operations-Staff)"
+else
+    echo "[otforge-dc] Existing domain found -- skipping provisioning, starting as-is."
+fi
+
+echo "[otforge-dc] Starting Samba (LDAP 389/636, Kerberos 88, SMB 445, DNS 53)..."
+echo "[otforge-dc] Every bind/auth/query will appear below (docker logs -f):"
+echo ""
+
+# -i (interactive/foreground) so Docker captures stdout; --debuglevel makes
+# every LDAP bind, Kerberos ticket request, and SMB session visible.
+exec samba -i --debuglevel="${AD_LOG_LEVEL}"

--- a/packages/app/src/renderer/src/canvas/PipeEdge.tsx
+++ b/packages/app/src/renderer/src/canvas/PipeEdge.tsx
@@ -91,6 +91,9 @@ const PIPE_COLORS: Record<Protocol, string> = {
   mqtt: '#e87040', // MQTT — orange; IIoT sensor/gateway pub/sub
   profinet: '#00a0e3', // PROFINET — Siemens/PI brand blue
   c37118: '#db61a2', // IEEE C37.118 synchrophasor — matches the pmu device's palette color
+  ldap: '#a371f7', // LDAP — matches the domain-controller device's enterprise-zone palette color
+  kerberos: '#a371f7', // Kerberos — same AD family color as LDAP/SMB
+  smb: '#a371f7', // SMB — same AD family color as LDAP/Kerberos
   none: '#484f58'
 }
 

--- a/packages/app/src/renderer/src/canvas/ProtocolEdge.tsx
+++ b/packages/app/src/renderer/src/canvas/ProtocolEdge.tsx
@@ -111,6 +111,9 @@ const PROTOCOL_COLORS: Partial<Record<Protocol, string>> = {
   mqtt: '#e87040', // MQTT — orange; IIoT broker-based pub/sub
   profinet: '#00a0e3', // PROFINET — Siemens/PI brand blue
   c37118: '#db61a2', // IEEE C37.118 synchrophasor — matches the pmu device's palette color
+  ldap: '#a371f7', // LDAP — matches the domain-controller device's enterprise-zone palette color
+  kerberos: '#a371f7', // Kerberos — same AD family color as LDAP/SMB
+  smb: '#a371f7', // SMB — same AD family color as LDAP/Kerberos
   none: '#484f58'
 }
 

--- a/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
+++ b/packages/app/src/renderer/src/canvas/ScadaCanvas.tsx
@@ -95,6 +95,9 @@ const CONNECTION_OPTIONS: { protocol: Protocol; label: string; color: string }[]
   { protocol: 'ethernet-ip', label: 'EtherNet/IP', color: '#f85149' },
   { protocol: 'iec61850', label: 'IEC 61850', color: '#a371f7' },
   { protocol: 'mqtt', label: 'MQTT', color: '#e87040' },
+  { protocol: 'ldap', label: 'LDAP', color: '#a371f7' },
+  { protocol: 'kerberos', label: 'Kerberos', color: '#a371f7' },
+  { protocol: 'smb', label: 'SMB', color: '#a371f7' },
   { protocol: 'none', label: 'Unspecified / Ethernet', color: '#484f58' }
 ]
 

--- a/packages/app/src/renderer/src/canvas/connectionRules.ts
+++ b/packages/app/src/renderer/src/canvas/connectionRules.ts
@@ -987,8 +987,10 @@ export const VALID_CONNECTIONS: Partial<
     'engineering-workstation': ['none'],
     'application-server': ['none'],
     'database-server': ['none'],
-    // Enterprise zone targets — lateral movement and credential attacks
-    'domain-controller': ['none'],
+    // Enterprise zone targets — lateral movement and credential attacks.
+    // Real Samba4 AD DC: LDAP enumeration/bind, Kerberos AS-REQ (Kerberoasting/
+    // AS-REP-roasting via impacket's example scripts), SMB session/share access.
+    'domain-controller': ['ldap', 'kerberos', 'smb', 'none'],
     'web-server': ['none'],
     'business-server': ['none'],
     'enterprise-desktop': ['none'],

--- a/packages/orchestrator/src/__tests__/compose-generator.test.ts
+++ b/packages/orchestrator/src/__tests__/compose-generator.test.ts
@@ -1457,6 +1457,85 @@ describe('DNS device environment variable injection', () => {
   })
 })
 
+describe('domain-controller — real Samba4 AD device', () => {
+  it('gives domain-controller the otforge-dc image — a real container, not the alpine stub', () => {
+    const compose = gen(
+      makeScenario([['dc-1', { category: 'domain-controller', ipAddress: '10.200.40.10' }]])
+    )
+    expect(compose.services['dc-1']).toBeDefined()
+    expect(compose.services['dc-1'].image).toBe('ghcr.io/iburres/otforge-dc:latest')
+  })
+
+  it('assigns the 256m/0.5 resource limit to domain-controller', () => {
+    const compose = gen(
+      makeScenario([['dc-1', { category: 'domain-controller', ipAddress: '10.200.40.10' }]])
+    )
+    expect(compose.services['dc-1'].deploy.resources.limits.memory).toBe('256m')
+    expect(compose.services['dc-1'].deploy.resources.limits.cpus).toBe('0.5')
+  })
+
+  it('injects AD_DOMAIN when device.domainController.domainName is set', () => {
+    const compose = gen(
+      makeScenario([
+        [
+          'dc-1',
+          {
+            category: 'domain-controller',
+            ipAddress: '10.200.40.10',
+            domainController: { domainName: 'CONTOSO.LOCAL' }
+          }
+        ]
+      ])
+    )
+    const env = compose.services['dc-1'].environment ?? []
+    expect(env).toContain('AD_DOMAIN=CONTOSO.LOCAL')
+  })
+
+  it('injects AD_NETBIOS when device.domainController.netbiosName is set', () => {
+    const compose = gen(
+      makeScenario([
+        [
+          'dc-1',
+          {
+            category: 'domain-controller',
+            ipAddress: '10.200.40.10',
+            domainController: { netbiosName: 'CONTOSO' }
+          }
+        ]
+      ])
+    )
+    const env = compose.services['dc-1'].environment ?? []
+    expect(env).toContain('AD_NETBIOS=CONTOSO')
+  })
+
+  it('injects AD_ADMIN_PASSWORD when device.domainController.adminPassword is set', () => {
+    const compose = gen(
+      makeScenario([
+        [
+          'dc-1',
+          {
+            category: 'domain-controller',
+            ipAddress: '10.200.40.10',
+            domainController: { adminPassword: 'Test123!Passw0rd' }
+          }
+        ]
+      ])
+    )
+    const env = compose.services['dc-1'].environment ?? []
+    expect(env).toContain('AD_ADMIN_PASSWORD=Test123!Passw0rd')
+  })
+
+  it('omits AD_DOMAIN/AD_NETBIOS/AD_ADMIN_PASSWORD entirely when device.domainController is unset', () => {
+    const compose = gen(
+      makeScenario([['dc-1', { category: 'domain-controller', ipAddress: '10.200.40.10' }]])
+    )
+    const env = compose.services['dc-1'].environment ?? []
+    expect(env.some(v => v.startsWith('AD_DOMAIN'))).toBe(false)
+    expect(env.some(v => v.startsWith('AD_NETBIOS'))).toBe(false)
+    expect(env.some(v => v.startsWith('AD_ADMIN_PASSWORD'))).toBe(false)
+  })
+})
+
 // ── Process unit env vars (pipeline + generator) ──────────────────────────────
 
 describe('process unit environment variable injection', () => {

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -119,8 +119,9 @@ const DEVICE_IMAGES: Record<DeviceCategory, string> = {
   // STUB: Wireless AP — Alpine stub; real 802.11 simulation requires host Wi-Fi adapter.
   wap: 'ghcr.io/iburres/alpine:latest',
   // ── Enterprise Zone (Level 4) ───────────────────────────────────────────────
-  // STUB: Replace with otforge-dc (Samba AD domain controller) once published.
-  'domain-controller': 'ghcr.io/iburres/alpine:latest',
+  // Real Samba4 Active Directory Domain Controller — LDAP (389/636),
+  // Kerberos (88), SMB (445) (containers/dc).
+  'domain-controller': 'ghcr.io/iburres/otforge-dc:latest',
   // STUB: nginx:alpine serves HTTP. Replace with otforge-webserver once published.
   'web-server': 'nginx:alpine',
   // STUB: Replace with otforge-bizserver once published.
@@ -2002,6 +2003,24 @@ function buildDeviceEnv(
   // this override is only emitted when the scenario configures a different domain.
   if (device.mail?.domain) {
     env.push(`MAIL_DOMAIN=${device.mail.domain}`)
+  }
+
+  // Domain controller — inject AD realm/NetBIOS/admin-password overrides from
+  // the optional DomainControllerConfig. The container Dockerfile already
+  // sets AD_DOMAIN=MERIDIAN.LOCAL, AD_NETBIOS=MERIDIAN, and known default
+  // passwords; these overrides are only emitted when the scenario explicitly
+  // configures different values, keeping the Compose YAML clean (same
+  // convention as the DNS/mail blocks above).
+  if (device.domainController) {
+    if (device.domainController.domainName) {
+      env.push(`AD_DOMAIN=${device.domainController.domainName}`)
+    }
+    if (device.domainController.netbiosName) {
+      env.push(`AD_NETBIOS=${device.domainController.netbiosName}`)
+    }
+    if (device.domainController.adminPassword) {
+      env.push(`AD_ADMIN_PASSWORD=${device.domainController.adminPassword}`)
+    }
   }
 
   // PMU station identity — consumed by containers/pmu/server.py. Informational

--- a/packages/schema/src/icslab.ts
+++ b/packages/schema/src/icslab.ts
@@ -26,6 +26,9 @@ export type Protocol =
   | 'iec-104' // IEC 60870-5-104 telecontrol protocol (port 2404)
   | 'mqtt' // Message Queuing Telemetry Transport — IIoT sensors, cloud gateways, broker-based pub/sub
   | 'c37118' // IEEE C37.118 synchrophasor protocol — PMU/PDC wide-area grid monitoring (port 4712)
+  | 'ldap' // Lightweight Directory Access Protocol — Active Directory bind/search (port 389)
+  | 'kerberos' // Kerberos network authentication (AS-REQ/TGT, port 88) — Active Directory domain auth
+  | 'smb' // Server Message Block file/print sharing — Active Directory domain (port 445)
   | 'none'
 
 /**
@@ -537,6 +540,36 @@ export interface MailConfig {
 }
 
 /**
+ * Runtime configuration for an otforge-dc container.
+ *
+ * The container runs a real Samba4 Active Directory Domain Controller,
+ * provisioned at first start via `samba-tool domain provision` and serving
+ * real LDAP (389), Kerberos (88), and SMB (445) — a realistic small
+ * OU/user/group structure is seeded automatically, with no deliberately
+ * weak/vulnerable accounts (that content belongs to a future attack
+ * tutorial, not this device's baseline).
+ *
+ * Deliberately distinct from the public internet-facing meridian-process.com
+ * DNS zone (DnsConfig above) — real organizations commonly split their
+ * public site domain from their internal AD namespace the same way.
+ *
+ * All fields are optional — the container Dockerfile sets safe defaults:
+ *   AD_DOMAIN         = MERIDIAN.LOCAL
+ *   AD_NETBIOS        = MERIDIAN
+ *   AD_ADMIN_PASSWORD = a fixed default (visible in container docs/logs,
+ *                       matching this project's convention of every device
+ *                       shipping a knowable default credential)
+ */
+export interface DomainControllerConfig {
+  /** Fully-qualified AD domain/realm name (default: MERIDIAN.LOCAL). */
+  domainName?: string
+  /** Short NetBIOS domain name (default: MERIDIAN). */
+  netbiosName?: string
+  /** Administrator account password set during provisioning (default: a fixed known value). */
+  adminPassword?: string
+}
+
+/**
  * Safety Instrumented System configuration for safety-plc devices (IEC 61511).
  *
  * These fields are informational — they are injected as environment variables
@@ -832,6 +865,7 @@ export interface DeviceConfig {
   processUnit?: ProcessUnitConfig // Physics process simulation config (Phase 11)
   dns?: DnsConfig // DNS server config (dns-server devices, Phase 12)
   mail?: MailConfig // Mail server config (email-server devices)
+  domainController?: DomainControllerConfig // Samba4 AD config (domain-controller devices)
   plcProgram?: PLCProgramConfig
   safetyPlc?: SafetyPlcConfig // SIS config for safety-plc devices
   batch?: BatchConfig // ISA-88 recipe config for batch-controller devices


### PR DESCRIPTION
## Summary
- Upgrades `domain-controller` from an alpine stub to a real Samba4 Active Directory Domain Controller, closing the last item in the older Phase 15+ backlog (IT/Enterprise sector).
- `containers/dc/`: provisions a real AD forest via `samba-tool domain provision` at container start (Alpine + `samba-dc`, using the documented `posix:eadb` tdb workaround for Docker's overlay filesystem), then seeds a realistic small OU/user/group structure (IT/Engineering/Operations departments, 6 employees). No deliberately weak/vulnerable accounts this round — that content is deferred to a future AD attack tutorial, matching how the ISA-88 engine build (PR #63) preceded its own vulnerability-bearing attack tutorial (PR #66) in a separate PR.
- Serves real LDAP (389/636), Kerberos (88), and SMB (445) simultaneously.
- Schema: three new `Protocol` values — `ldap`/`kerberos`/`smb` — matching this codebase's existing per-port granularity (s7comm/iec-104 stay separate even though one container serves both). New `DomainControllerConfig` interface mirroring `DnsConfig`/`MailConfig`'s shape.
- `connectionRules.ts` + `ProtocolEdge.tsx`/`PipeEdge.tsx`/`ScadaCanvas.tsx`: widened the `attack-machine` → `domain-controller` edge to the three new protocols, added their edge colors/context-menu entries. Every other enterprise-zone device (`web-server`/`business-server`/`enterprise-desktop`) stays a stub this round.
- `compose-generator.ts`: real image mapping, `AD_DOMAIN`/`AD_NETBIOS`/`AD_ADMIN_PASSWORD` env injection from the optional `domainController` config (author-optional, container has sane defaults).
- `containers/attack-base/Dockerfile`: added `ldap3` and `bloodhound` (BloodHound Python collector) alongside the `python3-impacket` example scripts already installed, so enumeration/collection tooling is ready for a future attack tutorial without another container-change pass.
- `docker.yml`: added `otforge-dc` to the build matrix in this same PR (lesson learned from PR #65 — CI can go green without ever building a new image if this step is missed).

## Test plan
- [x] `tsc --noEmit` clean in `packages/schema`, `packages/orchestrator`, `packages/app`
- [x] `vitest run` — 222/222 passing in `packages/orchestrator` (new `domain-controller` describe block: image assignment, resource limits, env injection set/omitted)
- [x] Built `otforge-dc` locally; confirmed `samba-tool domain provision` succeeds inside the container and `samba -i` starts cleanly with all 6 seeded users/groups visible via `samba-tool user list`/`group list`
- [x] Fixed a real bug found during verification: Samba self-registered its AD DNS records under the container's random hostname instead of the Docker service name, breaking name resolution for any other container trying to reach it — fixed by setting the container's OS hostname and `--host-name` from `DEVICE_ID` at provision time
- [x] Real **LDAP**: authenticated LDAPS bind (`ldap3`) with full directory enumeration of all seeded users in their correct OUs; confirmed anonymous bind succeeds but anonymous search returns nothing and unencrypted simple bind is rejected — matches real AD's actual default security posture
- [x] Real **Kerberos**: `kinit` against the DC issues a genuine TGT for a seeded user
- [x] Real **SMB**: `smbclient` lists the DC's real default shares (`sysvol`, `netlogon`, `IPC$`); confirmed the DC correctly refuses legacy SMB1
- [x] Real credentialed RPC enumeration via `rpcclient` (`enumdomusers`) and impacket's `lookupsid.py` — both list all seeded accounts / resolve the real domain SID
- [ ] `bloodhound-python` (the LEGACY collector) hits a known `ldap3`-NTLM interop gap against Samba (documented upstream, not specific to this container) — noted for whoever builds the follow-up AD attack tutorial; impacket's own RPC-based tools work fine as the alternative path
- [ ] CI: confirm `otforge-dc` appears in the `build-images` job output on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)