### PR TITLE
chore: add docker:clean script to prevent dangling-image buildup

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint:fix": "eslint \"packages/*/src/**/*.{ts,tsx}\" --fix",
     "typecheck": "npm run typecheck --workspace=packages/schema && npm run typecheck --workspace=packages/app",
     "format": "prettier --write \"packages/*/src/**/*.{ts,tsx,css,json}\"",
+    "docker:clean": "docker image prune -f && docker builder prune -f",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Adds `npm run docker:clean` (`docker image prune -f && docker builder prune -f`) — a one-command way to reclaim space from dangling `<none>` images and stale buildx cache.
- Root cause: rebuilding the same local image tag (`docker build -t ghcr.io/iburres/otforge-X:latest ...`) during iterative container development orphans the previous build as an untagged, unreferenced image. This has never been cleaned up anywhere in the repo's history — found 24 dangling images (some 19 months old) plus 21GB of stale build cache, ~57GB reclaimable total, already run once locally.
- Both operations are always safe: `docker image prune` only removes images with no tag and no container referencing them; `docker builder prune` only removes cache with 0 active users.

## Test plan
- [x] Ran `npm run docker:clean` locally — reclaimed ~35GB (images 63.6GB → 29GB, build cache 21.3GB → 0)
- [x] Confirmed `docker images -f dangling=true` is empty afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)