### PR TITLE
fix: never create a duplicate container for hmi/historian devices

### DIFF
--- a/packages/orchestrator/src/__tests__/compose-generator.test.ts
+++ b/packages/orchestrator/src/__tests__/compose-generator.test.ts
@@ -278,13 +278,29 @@ describe('network attachment', () => {
   })
 
   it('attaches a control-zone device to control-net', () => {
+    // 'hmi'/'historian' categories never get their own container (see the guard
+    // in compose-generator.ts's device loop) -- 'application-server' is used
+    // here instead as an equally control-zone-appropriate category that does.
     const scenario = makeScenario(
-      [['hmi-1', { category: 'hmi', ipAddress: '10.200.20.10' }]],
+      [['app-1', { category: 'application-server', ipAddress: '10.200.20.10' }]],
       [{ zone: 'control', subnet: '10.200.20.0/24', gateway: '10.200.20.1' }]
     )
     const compose = gen(scenario)
-    expect(compose.services['hmi-1'].networks).toHaveProperty('control-net')
-    expect(compose.services['hmi-1'].networks['control-net'].ipv4_address).toBe('10.200.20.10')
+    expect(compose.services['app-1'].networks).toHaveProperty('control-net')
+    expect(compose.services['app-1'].networks['control-net'].ipv4_address).toBe('10.200.20.10')
+  })
+
+  it('never creates a container for hmi/historian devices — the fixed fuxa/influxdb services already cover that role', () => {
+    const scenario = makeScenario([
+      ['hmi-1', { category: 'hmi', ipAddress: '10.200.20.10' }],
+      ['historian-1', { category: 'historian', ipAddress: '10.200.20.11' }]
+    ])
+    const compose = gen(scenario)
+    expect(compose.services['hmi-1']).toBeUndefined()
+    expect(compose.services['historian-1']).toBeUndefined()
+    // The fixed infrastructure services are still present and unaffected.
+    expect(compose.services['fuxa']).toBeDefined()
+    expect(compose.services['influxdb']).toBeDefined()
   })
 
   it('falls back to ot-net when the device IP does not match any defined segment', () => {

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -628,6 +628,22 @@ export function generateCompose(
   }
 
   for (const [nodeId, device] of Object.entries(scenario.devices.devices)) {
+    // 'hmi' and 'historian' devices.devices entries never get their own container.
+    // Every simulation already includes a real, fully-wired FUXA ('fuxa' service,
+    // port 1881 published for the Electron hmi:open window) and InfluxDB
+    // ('influxdb' service, wired into Grafana's datasource) unconditionally, in
+    // the fixed-infrastructure block below -- those are the ONLY HMI/historian
+    // instance the rest of the app ever looks at (hardcoded localhost:1881 /
+    // fixed control-net IP). A canvas node with one of these categories exists
+    // purely to represent that role visually on the topology diagram; if the
+    // scenario JSON also gives it a devices.devices entry (rather than the
+    // visual-only pattern documented in ScadaCanvas.tsx's resolveVisualOnlyDevice),
+    // creating a second container here would just be an unreachable, unconfigured
+    // duplicate wasting its full RAM budget for nothing. Found 2026-07-25 in
+    // ICS_Lab_01/OpenPLC_Lab (both fixed to the visual-only pattern in the same
+    // change) -- this guard prevents any future scenario from reintroducing it.
+    if (device.category === 'hmi' || device.category === 'historian') continue
+
     // Use a custom image if specified (for advanced scenarios), otherwise use the category default
     const image = device.dockerImage ?? DEVICE_IMAGES[device.category]
     const limits = DEVICE_LIMITS[device.category]

--- a/scenarios/ICS_Lab_01.otflab
+++ b/scenarios/ICS_Lab_01.otflab
@@ -548,22 +548,6 @@
           "none"
         ]
       },
-      "hmi-1": {
-        "nodeId": "hmi-1",
-        "category": "hmi",
-        "ipAddress": "10.200.20.10",
-        "protocols": [
-          "modbus-tcp"
-        ]
-      },
-      "historian-1": {
-        "nodeId": "historian-1",
-        "category": "historian",
-        "ipAddress": "10.200.20.11",
-        "protocols": [
-          "none"
-        ]
-      },
       "firewall-1": {
         "nodeId": "firewall-1",
         "category": "firewall",

--- a/scenarios/OpenPLC_Lab.otflab
+++ b/scenarios/OpenPLC_Lab.otflab
@@ -252,14 +252,6 @@
           "none"
         ]
       },
-      "hmi-1": {
-        "nodeId": "hmi-1",
-        "category": "hmi",
-        "ipAddress": "10.200.20.10",
-        "protocols": [
-          "modbus-tcp"
-        ]
-      },
       "workstation-1": {
         "nodeId": "workstation-1",
         "category": "engineering-workstation",


### PR DESCRIPTION
## Summary
- Every simulation already includes a real, fully-wired FUXA (`fuxa` service, port 1881 published for the Electron `hmi:open` window) and InfluxDB (`influxdb` service, wired into Grafana's datasource) unconditionally — these are the only HMI/historian instance the rest of the app ever looks at (both hardcoded, confirmed by reading `index.ts`'s `hmi:open` handler and `grafana-provisioning.ts`'s datasource config).
- A canvas node with category `hmi` or `historian` exists purely to represent that role visually on the topology diagram. Giving it a `devices.devices` entry (rather than the visual-only pattern `ScadaCanvas.tsx` already documents/uses elsewhere) made `compose-generator.ts` spin up a second, unreachable, unconfigured container wasting its full RAM budget for nothing.
- Found while computing exact RAM/disk usage for a bundled tutorial: `ICS_Lab_01` was running two independent FUXA containers and two independent InfluxDB containers simultaneously (512MB wasted, 2 extra containers). Checked all 9 bundled tutorials — only `ICS_Lab_01` and `OpenPLC_Lab` (the two oldest) had this; every scenario built since correctly used the visual-only pattern.
- `hmi` is still a normal draggable palette entry though, so nothing previously stopped a future scenario (including community-authored ones) from reintroducing this.

## Changes
- `compose-generator.ts`: unconditional `continue` for `category === 'hmi' || category === 'historian'` at the top of the device loop, before any IP claiming/env building — so this can never happen again regardless of scenario JSON contents.
- `ICS_Lab_01.otflab` / `OpenPLC_Lab.otflab`: removed the redundant `devices.devices` entries for `hmi-1`/`historian-1`, matching every other tutorial's convention. Their `visual.nodes`/`visual.edges` entries are untouched — the canvas still shows the same topology diagram.

## Test plan
- [x] `tsc --noEmit` clean, `vitest run` — 223/223 passing (updated one test that asserted `hmi-1` got its own container; added a new test asserting `hmi`/`historian` never do, while the fixed `fuxa`/`influxdb` services remain present)
- [x] Ran the real compose generator against both edited scenarios: `ICS_Lab_01` dropped from 16→14 services / 5088MB→4576MB RAM cap; `OpenPLC_Lab` dropped its duplicate `hmi-1` container
- [x] Confirmed no edges/tutorial step text reference `hmi-1`/`historian-1` by container name in either scenario — only the now-untouched visual nodes/edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)