### PR TITLE
fix: never mutate node_modules from inside the running Electron process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ resources.pak
 # against a containers/*/server.py while testing.
 __pycache__/
 *.pyc
+# Sentinel written by the "Update OTForge" button to request a `npm update` on
+# the next launch (applied by scripts/apply-pending-update.mjs from `predev`).
+# Must stay untracked so it never trips the update handler's own dirty-tree guard.
+.otforge-pending-dep-update

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "packages/*"
   ],
   "scripts": {
-    "predev": "npm install --legacy-peer-deps --no-package-lock && node node_modules/electron/install.js",
+    "predev": "npm install --legacy-peer-deps --no-package-lock && node scripts/apply-pending-update.mjs && node scripts/ensure-electron.mjs",
     "dev": "npm run build:packages && npm run dev --workspace=packages/app",
     "build": "npm run build --workspace=packages/schema && npm run build --workspace=packages/app",
     "build:win": "npm run build:schema && npm run build:win --workspace=packages/app",

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -171,6 +171,18 @@ function getProjectRoot(): string {
 }
 
 /**
+ * Sentinel dropped at the project root by the 'app:update' handler to request a
+ * `npm update` on the next launch, and consumed by scripts/apply-pending-update.mjs
+ * from `predev`. The name must stay in sync with SENTINEL in that script.
+ *
+ * The indirection exists because npm cannot safely replace node_modules/electron
+ * while Electron is running — see the long comment in the 'app:update' handler.
+ *
+ * Gitignored, so it can never trip that same handler's dirty-working-tree guard.
+ */
+const PENDING_DEP_UPDATE_FILE = '.otforge-pending-dep-update'
+
+/**
  * Runs a command via spawn(), streaming stdout+stderr to onProgress line-by-line
  * (CR→LF split, ANSI escape codes stripped) — mirrors DockerClient's internal
  * `_composePull` streaming so `git pull`/`npm install` output renders the same
@@ -705,6 +717,14 @@ function registerIPCHandlers(): void {
    * themselves. When nothing changed, a native "already up to date" dialog is shown
    * instead and the app keeps running. Progress lines are streamed to the
    * renderer over 'app:updateProgress' throughout.
+   *
+   * Dependencies are deliberately NOT updated here — this handler only writes
+   * the PENDING_DEP_UPDATE_FILE sentinel, and scripts/apply-pending-update.mjs
+   * runs the real `npm update` from `predev` on the next launch. npm replaces
+   * packages by renaming them, and Windows will not rename a file that the
+   * running process holds open, so updating node_modules/electron from inside
+   * Electron fails with EBUSY and leaves the install unbootable. See the long
+   * comment at the scheduling call below for the full incident.
    */
   ipcMain.handle('app:update', async (_e, scenario?: OTForgeScenario): Promise<AppUpdateResult> => {
     if (!is.dev) {
@@ -744,23 +764,36 @@ function registerIPCHandlers(): void {
       const { stdout: afterHead } = await execAsync('git rev-parse HEAD', { cwd: projectRoot })
       const restartRequired = beforeHead.trim() !== afterHead.trim()
 
-      // `npm update`, not `npm install`. A plain install treats an already-
-      // installed version that still satisfies its declared range as "good
-      // enough" and won't touch it, even when a newer non-breaking patch has
-      // been published upstream — confirmed live: a student hit a stale,
-      // vulnerable transitive brace-expansion left behind by repeated
-      // `npm install` runs (had to `rm -rf node_modules` to actually clear
-      // it). `npm update` re-resolves every dependency against its declared
-      // range and upgrades to the newest version that still satisfies it,
-      // fixing exactly that case without deleting anything — important since
-      // this runs from inside the already-running app; a full node_modules
-      // wipe here would try to delete the currently-executing Electron
-      // binary out from under itself. Confirmed live: reproduced the exact
-      // stale-dependency state, ran `npm update` against it, and verified
-      // both `npm audit` (0 vulnerabilities) and a full `build:win` package
-      // (electron-builder run to completion) afterward.
-      send('Updating dependencies (npm update)...')
-      await runStreamedCommand('npm', ['update'], projectRoot, send)
+      // Dependency updates are SCHEDULED here, never performed here.
+      //
+      // This handler runs inside the live Electron process, which on Windows
+      // holds open file handles on node_modules/electron/dist/electron.exe and
+      // dist/resources/default_app.asar. npm replaces a package by renaming it,
+      // and Windows refuses to rename a file with open handles, so running
+      // `npm update` from here aborts with EBUSY (errno -4082) partway through.
+      //
+      // The abort is what makes it dangerous: it left the tree structurally
+      // drifted (electron nested under packages/app/node_modules instead of
+      // hoisted to the root, with its dist/ binary gone), and since this repo
+      // has no lockfile there was no recorded good state for npm to repair
+      // against. A plain `npm install` then reported success while leaving the
+      // app unable to start. It took a full node_modules wipe to recover, and
+      // it happened to a live classroom.
+      //
+      // An earlier revision of this code ran `npm update` here on the reasoning
+      // that, unlike `rm -rf node_modules`, it "doesn't delete anything." That
+      // is not true — re-resolution replaces package directories, including
+      // electron's. The verification that passed at the time did so only
+      // because re-resolution happened to be a no-op for electron that day.
+      //
+      // So: drop a sentinel and let scripts/apply-pending-update.mjs run the
+      // actual `npm update` from `predev` on the next launch, when Electron is
+      // not running and npm is free to replace whatever it likes.
+      send('Scheduling dependency update for next startup...')
+      await writeFile(
+        pathJoin(projectRoot, PENDING_DEP_UPDATE_FILE),
+        `${new Date().toISOString()}\n`
+      )
 
       // Tracks the container image pull outcome SEPARATELY from the overall
       // source update — see AppUpdateResult.imageRefresh in packages/schema/
@@ -817,17 +850,25 @@ function registerIPCHandlers(): void {
           message: 'Update downloaded — restart required',
           detail:
             "This update changed OTForge's own code, so it needs to restart to take effect.\n\n" +
-            'Click OK, then stop this process (Ctrl+C) and run `npm run dev` again.' +
+            'Click OK, then stop this process (Ctrl+C) and run `npm run dev` again. ' +
+            'Dependency updates will be applied automatically during that startup.' +
             imageRefreshNote,
           buttons: ['OK']
         })
         app.exit(0)
       } else {
+        // Source was already current, so nothing forces a restart right now.
+        // The dependency update is still queued and will be applied on the next
+        // normal startup — deliberately NOT forcing a restart for it, since
+        // upstream patch releases are routine and interrupting a class for one
+        // would be worse than applying it whenever the app next starts.
         await dialog.showMessageBox(mainWindow!, {
           type: 'info',
           title: 'OTForge',
-          message: 'OTForge is already up to date.',
-          detail: imageRefreshNote || undefined,
+          message: 'OTForge source is already up to date.',
+          detail:
+            'Dependency updates will be checked and applied the next time you start OTForge.' +
+            imageRefreshNote,
           buttons: ['OK']
         })
       }

--- a/scripts/apply-pending-update.mjs
+++ b/scripts/apply-pending-update.mjs
@@ -1,0 +1,104 @@
+/**
+ * apply-pending-update.mjs — runs a deferred `npm update` at startup, while
+ * Electron is NOT running.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The in-app "Update OTForge" button used to run `npm update` directly, from
+ * inside the live Electron process. That is unsafe on Windows for a reason
+ * that has nothing to do with npm being wrong: the running process holds open
+ * file handles on node_modules/electron/dist/electron.exe and
+ * dist/resources/default_app.asar, and Windows refuses to rename or replace a
+ * file with open handles. npm's package replacement is implemented as a
+ * rename, so it aborts with EBUSY (errno -4082) partway through.
+ *
+ * A partial abort is much worse than a clean failure. It left the tree
+ * structurally drifted: the electron shim was reinstalled but its dist/ folder
+ * was gone, and electron ended up nested under packages/app/node_modules
+ * instead of hoisted to the root. Both `predev` and electron-vite resolve
+ * electron from the root, so the app could no longer start at all -- and
+ * because this repo intentionally has no lockfile (see .gitignore), npm had no
+ * recorded good state to repair against. A plain `npm install` reported
+ * success while leaving the install broken; only a full node_modules wipe
+ * recovered it. This happened to a live classroom.
+ *
+ * THE FIX
+ * -------
+ * Dependency mutation and a running Electron process must never overlap. The
+ * update handler now only writes a sentinel file and tells the user to
+ * restart; this script consumes that sentinel from `predev`, at which point
+ * Electron is not running and npm is free to replace whatever it likes.
+ *
+ * Ordering matters in `predev`: this runs BEFORE ensure-electron.mjs, so if
+ * `npm update` does replace the electron package and drop its binary, the
+ * following ensure-electron step downloads it again in the same startup. That
+ * makes the previously fatal case routine and self-healing.
+ *
+ * The sentinel is deleted only after `npm update` succeeds. If the update
+ * fails (offline, registry down, proxy), the sentinel stays and the update is
+ * retried on the next launch rather than being silently skipped.
+ */
+
+import { existsSync, unlinkSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/**
+ * Must match PENDING_DEP_UPDATE_FILE in packages/app/src/main/index.ts.
+ * Untracked and gitignored, so it can never trip the update handler's own
+ * dirty-working-tree guard.
+ */
+const SENTINEL = join(projectRoot, '.otforge-pending-dep-update')
+
+if (!existsSync(SENTINEL)) {
+  // Normal startup: nothing was scheduled, so stay silent and stay fast.
+  process.exit(0)
+}
+
+console.log('[apply-pending-update] A dependency update was scheduled by "Update OTForge".')
+console.log('[apply-pending-update] Applying it now (npm update)...')
+
+// `npm update`, not `npm install`. A plain install treats an already-installed
+// version that still satisfies its declared range as good enough and won't
+// touch it, even when a newer non-breaking patch has been published upstream --
+// confirmed live: a student hit a stale, vulnerable transitive brace-expansion
+// left behind by repeated `npm install` runs. `npm update` re-resolves every
+// dependency against its declared range and upgrades to the newest version
+// that still satisfies it.
+//
+// Passed as ONE command string with `shell: true`, rather than a command plus
+// an args array. Both halves of that are forced:
+//
+//   - `shell: true` is required at all, because on Windows `npm` is a .cmd
+//     shim and Node has refused to spawn .cmd/.bat without a shell since the
+//     CVE-2024-27980 mitigation. Spawning "npm.cmd" directly fails outright.
+//   - Given a shell, the args must be inlined, because passing an args array
+//     alongside `shell: true` trips Node's DEP0190 deprecation (the args get
+//     concatenated rather than escaped) which is slated to become an error.
+//
+// Safe here because every token is a hardcoded literal -- no user, scenario,
+// or filesystem input reaches this string. Mirrors runStreamedCommand() in
+// packages/app/src/main/index.ts, which joins for the same reason.
+const result = spawnSync('npm update --legacy-peer-deps --no-package-lock', {
+  cwd: projectRoot,
+  stdio: 'inherit',
+  shell: true
+})
+
+if (result.status !== 0) {
+  console.error(
+    `\n[apply-pending-update] npm update failed (exit code ${result.status}).\n` +
+      '[apply-pending-update] Keeping the request queued - it will be retried next launch.\n' +
+      '[apply-pending-update] Continuing startup with the dependencies you already have.'
+  )
+  // Deliberately exit 0. A failed dependency refresh should not block the app
+  // from starting with a perfectly usable existing node_modules -- students in
+  // a lab with flaky wifi still need to run OTForge.
+  process.exit(0)
+}
+
+unlinkSync(SENTINEL)
+console.log('[apply-pending-update] Dependencies updated.')

--- a/scripts/ensure-electron.mjs
+++ b/scripts/ensure-electron.mjs
@@ -1,0 +1,126 @@
+/**
+ * ensure-electron.mjs — guarantees the Electron *binary* is present before
+ * `npm run dev` tries to launch it.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The `electron` npm package is only a thin shim. The real ~150 MB Electron
+ * runtime (electron.exe / Electron.app / the `electron` ELF binary, plus
+ * dist/resources/default_app.asar) is downloaded separately by the package's
+ * own `install.js` postinstall script. If that download never runs, or if the
+ * dist/ folder is removed afterwards, `npm run dev` fails at launch even
+ * though `npm install` reported success and node_modules looks complete.
+ *
+ * Two real failures made this script necessary:
+ *
+ *   1. `predev` used to hardcode `node node_modules/electron/install.js`.
+ *      This is an npm *workspaces* repo, so whether `electron` lands in the
+ *      root node_modules (hoisted) or in packages/app/node_modules (nested)
+ *      is an npm implementation detail that changes with peer-dependency
+ *      resolution, `legacy-peer-deps`, and any `overrides` block. When npm
+ *      nested it, the hardcoded root path threw MODULE_NOT_FOUND and every
+ *      `npm run dev` aborted. Never assume hoisting -- always resolve.
+ *
+ *   2. The in-app "Update OTForge" button ran `npm update` from inside the
+ *      *running* Electron process. On Windows the running process holds open
+ *      handles on electron.exe and default_app.asar, so npm's rename failed
+ *      with EBUSY (errno -4082) partway through replacing the package. That
+ *      left the shim installed but dist/ gone -- an install that looks valid
+ *      to npm but cannot start.
+ *
+ * Because this script re-downloads whatever is missing, a plain `npm run dev`
+ * now self-heals both states instead of requiring manual intervention.
+ *
+ * It is deliberately idempotent and cheap: when the binary is already present
+ * it exits immediately without touching the network, so it adds no measurable
+ * cost to normal startup.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/**
+ * Every location npm might legitimately place `electron` in this workspace,
+ * in the order we should prefer them. Root first (the hoisted case, which is
+ * what npm does most of the time), then the workspace package that actually
+ * declares electron as a devDependency (the nested case).
+ *
+ * Resolving by probing real paths rather than using require.resolve() avoids
+ * a subtle trap: electron's package.json may expose an "exports" map that
+ * blocks require.resolve('electron/package.json'), and require.resolve('electron')
+ * returns the JS shim's entry point rather than the package directory.
+ */
+const CANDIDATE_DIRS = [
+  join(projectRoot, 'node_modules', 'electron'),
+  join(projectRoot, 'packages', 'app', 'node_modules', 'electron')
+]
+
+/** Finds the installed electron package directory, or null if npm never installed it. */
+function findElectronDir() {
+  return CANDIDATE_DIRS.find((dir) => existsSync(join(dir, 'install.js'))) ?? null
+}
+
+/**
+ * Reports whether the actual runtime binary is present.
+ *
+ * install.js writes `path.txt` containing the platform-specific executable
+ * path *relative to dist/* (e.g. "electron.exe" on Windows, "Electron.app/
+ * Contents/MacOS/Electron" on macOS). Checking path.txt AND the file it names
+ * is the only cross-platform-correct test -- hardcoding "electron.exe" would
+ * silently pass on macOS and Linux where that file never exists.
+ *
+ * Both checks matter: a failed npm rename can leave path.txt behind after
+ * dist/ is gone, so the presence of path.txt alone proves nothing.
+ */
+function binaryPresent(electronDir) {
+  const pathTxt = join(electronDir, 'path.txt')
+  if (!existsSync(pathTxt)) return false
+
+  const relativeExe = readFileSync(pathTxt, 'utf8').trim()
+  if (!relativeExe) return false
+
+  return existsSync(join(electronDir, 'dist', relativeExe))
+}
+
+const electronDir = findElectronDir()
+
+if (!electronDir) {
+  console.error(
+    '[ensure-electron] Could not find the electron package in node_modules.\n' +
+      '[ensure-electron] Run `npm install --legacy-peer-deps --no-package-lock` first, then try again.'
+  )
+  process.exit(1)
+}
+
+if (binaryPresent(electronDir)) {
+  console.log('[ensure-electron] Electron binary already present - skipping download.')
+  process.exit(0)
+}
+
+console.log(`[ensure-electron] Electron binary missing in ${electronDir}`)
+console.log('[ensure-electron] Downloading it now (this can take a minute on first run)...')
+
+// Run install.js as its own process rather than importing it. It is written as
+// a side-effecting CommonJS script, and spawning keeps its stdout/stderr (the
+// download progress and any proxy/network errors) visible to the user, which
+// matters because this is the step most likely to fail on a locked-down campus
+// network.
+const result = spawnSync(process.execPath, [join(electronDir, 'install.js')], {
+  cwd: electronDir,
+  stdio: 'inherit'
+})
+
+if (result.status !== 0) {
+  console.error(
+    `\n[ensure-electron] Electron download failed (exit code ${result.status}).\n` +
+      '[ensure-electron] If you are behind a proxy or firewall, set ELECTRON_MIRROR or\n' +
+      '[ensure-electron] ELECTRON_GET_USE_PROXY, then run `npm run dev` again.'
+  )
+  process.exit(result.status ?? 1)
+}
+
+console.log('[ensure-electron] Electron binary installed.')


### PR DESCRIPTION
## Problem

The **Update OTForge** button ran `npm update` from *inside the live Electron process*. On Windows the running process holds open handles on `node_modules/electron/dist/electron.exe` and `dist/resources/default_app.asar`, and npm replaces packages by renaming them — so the update aborted with **EBUSY (errno -4082)** partway through.

The partial abort is what made it dangerous. It left the dependency tree structurally drifted: `electron` ended up nested under `packages/app/node_modules` instead of hoisted to the root, with its `dist/` binary gone. Both `predev` and `electron-vite` resolve `electron` from the root, so the app could no longer start at all. Because this repo intentionally has no lockfile, npm had no recorded good state to repair against — a plain `npm install` reported success while leaving the install unbootable, and only a full `node_modules` wipe recovered it. **This took down a live classroom**, and it was also why affected students stayed stuck on stale container images: the button that refreshes images crashed before ever reaching the image-pull step.

## Fix

Dependency mutation and a running Electron process must never overlap.

- **`app:update` now only *schedules* the update** — writes a `.otforge-pending-dep-update` sentinel instead of running npm itself.
- **`scripts/apply-pending-update.mjs`** consumes the sentinel from `predev`, when Electron is *not* running. On failure it keeps the sentinel queued for the next launch and still lets the app start on existing dependencies.
- **`scripts/ensure-electron.mjs`** resolves electron's real install location rather than assuming npm hoisted it (the old `predev` hardcoded `node node_modules/electron/install.js`, which threw `MODULE_NOT_FOUND` whenever npm nested electron instead — the second half of the same failure). Verifies the binary via `path.txt` cross-platform, re-downloads only when missing. Running *after* the pending update means a replaced electron package self-heals in the same startup.
- **`predev`** chains install → apply-pending → ensure-electron.
- Update dialog wording now states when dependency updates actually apply.

## Verification

- Sentinel absent → silent no-op; present → `npm update` runs and sentinel is cleared; `npm update` failing → sentinel retained for retry, startup continues on existing deps.
- Sentinel invisible to both `git status` and the update handler's dirty-tree guard.
- typecheck clean · lint clean (1 pre-existing warning) · 223/223 orchestrator tests · app launches.
- **Live-verified end-to-end**: clicked Update OTForge in the running app — no crash, image refresh ran, and it resolved the presenting symptom (Lab 04 attack scripts missing on Kali = stale `attack-base` image, not a repo gap).

## Follow-ups (separate PRs)

- ESLint 8 → 9 flat-config migration — the root fix for the dev-only `brace-expansion` audit findings (ESLint 8 is EOL). A `brace-expansion` `overrides` pin was tried and dropped here because it breaks ESLint 8's bundled minimatch 3.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)