### PR TITLE
docs: simplify setup to `npm run dev` and lead updates with the Update OTForge button

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,10 @@ Real protocol packets flow on Docker virtual networks — scanner tools and expl
 ```bash
 git clone https://github.com/iburres/otforge.git
 cd otforge
-npm install
-node node_modules/electron/install.js   # macOS only — downloads the Electron binary
-npm run build:packages
 npm run dev
 ```
+
+`npm run dev` handles the rest on first run — it installs dependencies, downloads the Electron runtime, builds the packages, and launches the app. (On Windows, first allow scripts once with `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`.)
 
 Docker Desktop must be running before launching the app.
 
@@ -151,6 +150,12 @@ Docker Desktop must be running before launching the app.
 > **[View Student Setup Guide (browser)](https://iburres.github.io/otforge/student-setup.html)** &nbsp;|&nbsp; [Markdown source](docs/student-setup.md)
 
 ### Getting updates
+
+**Preferred — the in-app button.** With a lab loaded, click **Update OTForge** in the toolbar. It pulls the latest code, updates dependencies, and refreshes the Docker container images for the loaded scenario in one step. A plain `git pull` updates source only and does **not** refresh container images, so services or attack scripts added in a new lab can appear missing until the images are refreshed — the button handles both. Image refresh only runs when a scenario is loaded, so open a lab before clicking.
+
+If the update changes OTForge's own code it will ask you to restart: stop the app and run `npm run dev` again — any queued dependency update is applied automatically during that startup, while Electron is not running.
+
+**Code-only fallback:**
 
 **Windows (PowerShell in `C:\OTForge`):**
 ```powershell

--- a/docs/student-setup.html
+++ b/docs/student-setup.html
@@ -369,21 +369,16 @@ git clone https://github.com/iburres/otforge.git .</code></pre>
 <pre><code>Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser</code></pre>
   <p>Type <strong>Y</strong> when prompted.</p>
 
-  <p>Then install and launch:</p>
-<pre><code>npm install
-npm run build:packages
-npm run dev</code></pre>
+  <p>Then launch OTForge:</p>
+<pre><code>npm run dev</code></pre>
 
   <hr style="margin: 24px 0; border-style: dashed;">
 
   <p class="platform-label">macOS &mdash; Terminal (from <code>~/OTForge</code>)</p>
-<pre><code>npm install
-node node_modules/electron/install.js
-npm run build:packages
-npm run dev</code></pre>
+<pre><code>npm run dev</code></pre>
 
   <blockquote class="note">
-    <p>The <code>node node_modules/electron/install.js</code> step downloads the Electron desktop runtime (~90 MB). If the download fails or you see an Electron error later, run <code>.\fix-electron.ps1</code> (Windows) &mdash; it checks a local cache before downloading so it works on most campus networks.</p>
+    <p>That single command does everything on first run: it installs the app's dependencies, downloads the Electron desktop runtime (~90 MB), builds the packages, and launches OTForge. The first run takes a few minutes; later runs start quickly. If the Electron download is blocked by antivirus or a campus network, run <code>.\fix-electron.ps1</code> (Windows) &mdash; it checks a local cache before downloading.</p>
   </blockquote>
 
   <hr>
@@ -414,14 +409,18 @@ npm run dev</code></pre>
   <!-- ── Getting Updates ── -->
   <h2 id="updating">Getting Updates</h2>
 
-  <p>Run these two commands from your OTForge folder &mdash; same on Windows and macOS:</p>
-<pre><code>git pull
-npm run dev</code></pre>
-  <p><code>git pull</code> downloads the latest code. <code>npm run dev</code> rebuilds and relaunches automatically &mdash; nothing else needed.</p>
+  <p><strong>The easiest way is the in-app button.</strong> With OTForge open and a lab loaded, click <strong>Update OTForge</strong> in the toolbar. It pulls the latest code, updates dependencies, and refreshes the Docker container images for your lab &mdash; all in one step. Open a lab first: image refresh only happens when a scenario is loaded, so clicking it on an empty screen updates the code but not the containers.</p>
+
+  <p>When the update changes OTForge's own code, it will ask you to restart. Stop the app (close the window, or press <strong>Ctrl+C</strong> in the terminal) and run <code>npm run dev</code> again &mdash; any queued dependency updates are applied automatically during that startup.</p>
 
   <blockquote class="note">
-    <p><strong>If your instructor announces that new packages were added</strong>, run <code>.\get-updates.ps1</code> (Windows) or <code>bash get-updates.sh</code> (macOS) instead of <code>git pull</code>. This is rare &mdash; most updates are source-code only and need nothing more than <code>git pull</code>.</p>
+    <p><strong>Why the button matters:</strong> a plain <code>git pull</code> only updates source code. It does <strong>not</strong> refresh the Docker container images, so attack scripts or services added in a new lab can appear &ldquo;missing&rdquo; until the images are refreshed. The <strong>Update OTForge</strong> button handles both.</p>
   </blockquote>
+
+  <p><strong>Code-only refresh (fallback).</strong> If you just want the latest source without touching containers, run these from your OTForge folder &mdash; same on Windows and macOS:</p>
+<pre><code>git pull
+npm run dev</code></pre>
+  <p><code>git pull</code> downloads the latest code, and <code>npm run dev</code> installs any new dependencies, repairs the Electron runtime if needed, and relaunches the app.</p>
 
   <hr>
 
@@ -450,8 +449,8 @@ npm run dev</code></pre>
   <p>If none of the above work, restart your computer and relaunch Docker Desktop. A full reboot clears stuck WSL instances and stalled service states.</p>
 
   <h3><code>npm run dev</code> fails &mdash; Electron not installed (macOS)</h3>
-<pre><code>node node_modules/electron/install.js
-npm run dev</code></pre>
+  <p><code>npm run dev</code> repairs a missing Electron runtime automatically on startup, so running it again is usually enough:</p>
+<pre><code>npm run dev</code></pre>
 
   <h3><code>npm run dev</code> fails &mdash; Electron not installed (Windows)</h3>
   <p><code>npm run dev</code> already tries to fix this automatically, but if your antivirus or campus network blocks the direct download from GitHub, it can still fail. Run the included repair script from <code>C:\OTForge</code>:</p>
@@ -530,7 +529,7 @@ npm run dev</code></pre>
         <tr><td>Navigate to OTForge</td><td><code>cd C:\OTForge</code></td><td><code>cd ~/OTForge</code></td></tr>
         <tr><td>Launch OTForge</td><td><code>npm run dev</code></td><td><code>npm run dev</code></td></tr>
         <tr><td>Scenarios folder</td><td><code>C:\OTForge\scenarios\</code></td><td><code>~/OTForge/scenarios/</code></td></tr>
-        <tr><td>Get updates</td><td><code>git pull</code> then <code>npm run dev</code></td><td><code>git pull</code> then <code>npm run dev</code></td></tr>
+        <tr><td>Get updates</td><td><strong>Update OTForge</strong> button (lab loaded)</td><td><strong>Update OTForge</strong> button (lab loaded)</td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/student-setup.md
+++ b/docs/student-setup.md
@@ -97,10 +97,8 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
 Type **Y** when prompted.
 
-Then install and launch:
+Then launch OTForge:
 ```powershell
-npm install
-npm run build:packages
 npm run dev
 ```
 
@@ -108,11 +106,12 @@ npm run dev
 
 **macOS (Terminal — from `~/OTForge`):**
 ```bash
-npm install
 npm run dev
 ```
 
 ---
+
+That single command does everything: the first time you run it, it installs the app's dependencies, downloads the Electron runtime, builds the packages, and then launches OTForge. The first run takes a few minutes; later runs start quickly.
 
 OTForge will open. The first time you run a scenario and click **Start Simulation**, Docker will pull the required container images (~2–4 GB one-time download). This takes several minutes — subsequent launches are fast.
 
@@ -133,14 +132,20 @@ This folder is created automatically when you clone the repository. When your in
 
 ## Getting Updates
 
-Run these two commands from your OTForge folder — same on Windows and macOS:
+**The easiest way is the in-app button.** With OTForge open and a lab loaded, click **Update OTForge** in the toolbar. It pulls the latest code, updates dependencies, and refreshes the Docker container images for your lab — all in one step. Open a lab first: image refresh only happens when a scenario is loaded, so clicking it on an empty screen updates the code but not the containers.
+
+When the update changes OTForge's own code, it will ask you to restart. Stop the app (close the window, or press **Ctrl+C** in the terminal) and run `npm run dev` again — any queued dependency updates are applied automatically during that startup.
+
+> **Why the button matters:** a plain `git pull` only updates source code. It does **not** refresh the Docker container images, so attack scripts or services added in a new lab can appear "missing" until the images are refreshed. The **Update OTForge** button handles both.
+
+**Code-only refresh (fallback).** If you just want the latest source without touching containers, run these from your OTForge folder — same on Windows and macOS:
 
 ```
 git pull
 npm run dev
 ```
 
-That's it. `git pull` downloads the latest code and `npm run dev` installs any new dependencies and relaunches the app automatically.
+`git pull` downloads the latest code, and `npm run dev` installs any new dependencies, repairs the Electron runtime if needed, and relaunches the app.
 
 ---
 
@@ -167,10 +172,11 @@ If the spinner still does not clear:
 If none of the above work, restart your computer and relaunch Docker Desktop. A full reboot clears stuck WSL instances and stalled service states.
 
 ### `npm run dev` fails — Electron not installed
+`npm run dev` repairs a missing Electron runtime automatically on startup, so running it again is usually enough:
 ```
-npm install
 npm run dev
 ```
+If it still fails, your antivirus or campus network may be blocking the Electron download — see the next entry.
 
 ### `Error: Electron uninstall` (Windows)
 `npm run dev` already tries to fix this automatically, but if your antivirus or campus network blocks the direct download from GitHub, it can still fail. Run the included repair script from `C:\OTForge`:
@@ -231,7 +237,7 @@ New-NetFirewallRule `
 | Navigate to OTForge | `cd C:\OTForge` | `cd ~/OTForge` |
 | Launch OTForge | `npm run dev` | `npm run dev` |
 | Scenarios folder | `C:\OTForge\scenarios\` | `~/OTForge/scenarios/` |
-| Get updates | `git pull` then `npm run dev` | `git pull` then `npm run dev` |
+| Get updates | **Update OTForge** button (lab loaded) | **Update OTForge** button (lab loaded) |
 
 
 ---


### PR DESCRIPTION
Follow-up to #72. Now that `predev` installs dependencies, self-heals the Electron runtime (`scripts/ensure-electron.mjs`), and builds packages, the setup and update docs can be simplified and corrected.

## First-time setup

Collapsed to three lines on both the README Quick Start and the student setup guide:

```
git clone https://github.com/iburres/otforge.git
cd otforge
npm run dev
```

- Removed the redundant `npm install` / `node node_modules/electron/install.js` / `npm run build:packages` steps — `npm run dev` does all of it on first run.
- Dropped the `# macOS only` note on the Electron install step. It was wrong: on Windows a plain `npm install` does not fetch the Electron binary either, so the note would have left Windows students broken if they followed it literally.
- Preserved the Windows `Set-ExecutionPolicy` prerequisite in the student guide.

## Getting Updates

Now leads with the in-app **Update OTForge** button, which refreshes the Docker container images in addition to pulling source and updating dependencies. A plain `git pull` updates source only and leaves stale images — the exact reason Lab 04's attack scripts appeared "missing" on Kali. `git pull` + `npm run dev` is now documented as the code-only fallback rather than the primary path.

## Notes

- `docs/student-setup.html` was hand-edited to match `docs/student-setup.md` — there is no md→html build tooling in the repo.
- Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)