### PR TITLE
docs: labs come from the scenarios folder, not Canvas

### DIFF
--- a/docs/student-setup.html
+++ b/docs/student-setup.html
@@ -402,7 +402,7 @@ git clone https://github.com/iburres/otforge.git .</code></pre>
     </tbody>
   </table>
 
-  <p>This folder is created automatically when you clone the repository. When your instructor releases a lab file through Canvas, save it here.</p>
+  <p>This folder is created automatically when you clone the repository, and your instructor's lab files are already in it. When a new or updated lab is released, you get it automatically the next time you update OTForge (see <strong>Getting Updates</strong> below) &mdash; there's nothing to download or copy in by hand.</p>
 
   <hr>
 

--- a/docs/student-setup.md
+++ b/docs/student-setup.md
@@ -126,7 +126,7 @@ Your lab files (`.otflab`) go in:
 | Windows | `C:\OTForge\scenarios\` |
 | macOS | `~/OTForge/scenarios/` |
 
-This folder is created automatically when you clone the repository. When your instructor releases a lab file through Canvas, save it here.
+This folder is created automatically when you clone the repository, and your instructor's lab files are already in it. When a new or updated lab is released, you get it automatically the next time you update OTForge (see **Getting Updates** below) — there's nothing to download or copy in by hand.
 
 ---
 


### PR DESCRIPTION
Students now access labs directly from the repo `scenarios/` folder; the instructor no longer uploads `.otflab` files to Canvas. The student setup guide still told students their instructor "releases a lab file through Canvas" and to save it in by hand — that's stale.

Updates the **Scenarios Folder** step (in `student-setup.md` and its HTML) to say the lab files ship with the repo and arrive automatically via **Update OTForge**, so there's nothing to download or copy manually.

SCADA "canvas" UI references elsewhere in the docs and scenario files are the drag-drop editor, unrelated, and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)