### PR TITLE
fix(siem): ephemeral Loki storage + pin the image (fixes classroom outage)

### DIFF
--- a/containers/loki/Dockerfile
+++ b/containers/loki/Dockerfile
@@ -1,4 +1,12 @@
 # containers/loki/Dockerfile — Multi-platform mirror of grafana/loki.
 #
 # Official image supports linux/amd64 and linux/arm64.
-FROM grafana/loki:latest
+#
+# PINNED, not :latest. `grafana/loki:latest` is a rolling tag: a rebuild on
+# 2026-07-22 silently advanced it to 3.7.4 (after Lab 04 shipped), which — with
+# the old persisted loki-data volume — hung at /ready = 503 and broke the whole
+# Suricata/Zeek -> Grafana pipeline in class. Loki storage is now ephemeral
+# (see packages/orchestrator/src/compose-generator.ts), and this pin stops the
+# base image from drifting out from under the labs again. 3.7.4 is verified to
+# work cleanly. Bump this deliberately, not implicitly.
+FROM grafana/loki:3.7.4

--- a/packages/orchestrator/src/__tests__/compose-generator.test.ts
+++ b/packages/orchestrator/src/__tests__/compose-generator.test.ts
@@ -1824,9 +1824,19 @@ describe('fixed infrastructure services', () => {
     expect(compose.volumes).toHaveProperty('my-proj-suricata-logs')
     expect(compose.volumes).toHaveProperty('my-proj-zeek-logs')
     expect(compose.volumes).toHaveProperty('my-proj-influxdb-data')
-    expect(compose.volumes).toHaveProperty('my-proj-loki-data')
     expect(compose.volumes).toHaveProperty('my-proj-grafana-data')
     expect(compose.volumes).toHaveProperty('my-proj-fuxa-data')
+  })
+
+  it('does NOT create a persistent volume for Loki (storage is ephemeral by design)', () => {
+    // Loki storage is deliberately ephemeral: a persisted loki-data volume, once
+    // the rolling grafana/loki image drifted to 3.7.4, hung at /ready=503 because
+    // the new version could not recover the old WAL — silently breaking the whole
+    // Suricata/Zeek -> Grafana pipeline in class. A training SIEM starts clean each
+    // run, so Loki must have no named volume and no /loki mount. See compose-generator.ts.
+    const compose = gen(infraScenario, 'my-proj')
+    expect(compose.volumes).not.toHaveProperty('my-proj-loki-data')
+    expect(compose.services['loki'].volumes).toBeUndefined()
   })
 
   it('places infrastructure services on control-net (Level 3 — Control Center)', () => {

--- a/packages/orchestrator/src/compose-generator.ts
+++ b/packages/orchestrator/src/compose-generator.ts
@@ -1508,7 +1508,21 @@ ${deviceBlocks}
   // Loki ingests EVE JSON from Suricata and Zeek logs for querying in Grafana.
   // Port 3100 is published to the host so the Electron renderer can query the
   // Loki HTTP API directly for the native live-log panel (Phase 6).
-  volumes[`${projectName}-loki-data`] = {}
+  //
+  // Loki storage is DELIBERATELY EPHEMERAL — there is no named volume. Loki
+  // writes its WAL/index/chunks to /loki in the container's own writable layer,
+  // which is wiped every time the container is recreated (i.e. every Run
+  // Simulation). A persisted loki-data volume caused a hard-to-diagnose
+  // classroom outage: when the rolling `grafana/loki:latest` image drifted to
+  // 3.7.4 (rebuilt 2026-07-22, after Lab 04 shipped 07-17), 3.7.4 could not
+  // recover the WAL left in the old volume and hung at `/ready` = 503 forever,
+  // so Promtail could not push and every Suricata/Zeek alert silently failed to
+  // reach Grafana — presenting to students as "Suricata stopped working". A
+  // clean volume always works; the persisted one was the trap. A training SIEM
+  // has no reason to survive a restart — each run should start with a clean
+  // slate — so ephemeral storage removes the failure mode entirely. Both Lab 03
+  // and Lab 04 use this pipeline. See containers/loki/Dockerfile for the
+  // companion version pin that stops the underlying image drift.
   services['loki'] = {
     image: 'ghcr.io/iburres/loki:latest',
     pull_policy: 'if_not_present',
@@ -1521,7 +1535,8 @@ ${deviceBlocks}
     },
     environment: undefined,
     cap_add: undefined,
-    volumes: [`${projectName}-loki-data:/loki`],
+    // No volume mount — /loki is intentionally ephemeral (see comment above).
+    volumes: undefined,
     // Publish so the Electron main process can proxy Loki API queries
     ports: ['3100:3100'],
     // Healthcheck: recent grafana/loki images use a distroless base with no shell


### PR DESCRIPTION
Students reported "Suricata stopped working" in Lab 04 (same pipeline is in Lab 03). Suricata is fine — the break is downstream at **Loki**.

## Root cause

Loki is `grafana/loki:latest`, a rolling tag. A rebuild on **2026-07-22** (after Lab 04 shipped 07-17) advanced it to **3.7.4**. Combined with the persisted `loki-data` volume, 3.7.4 could not recover the WAL left by the older version and hung at `/ready` = **503 forever** — so Promtail could not push, Loki queries returned empty, and no Suricata/Zeek alert reached Grafana. Students saw an empty dashboard and blamed detection.

Confirmed by clean-room test: a wiped Loki volume always works; the persisted one across the version jump was the trap.

## Fix

- **Loki storage is now ephemeral** — no named volume; `/loki` lives in the container writable layer, wiped on every recreate (every Run Simulation). A training SIEM has no reason to survive a restart. Removes the failure mode for **Lab 03 and Lab 04 both**, and reaches students via the normal app update (compose-generator is app code) — no manual volume surgery.
- **Pin `grafana/loki:latest` → `grafana/loki:3.7.4`** to stop the rolling drift that triggered this.

## Verified live

Ephemeral Loki stays ready (~18-21 s) and the full `Suricata → eve.json → Promtail → Loki → Grafana` pipeline delivers the 9000002 alert across **3 consecutive Stop/Start cycles** — the exact scenario that broke the persisted volume. typecheck clean, lint clean, 224 orchestrator tests (added one asserting Loki has no persistent volume).

## Note

Existing broken students self-heal: after this merges and they Update OTForge, their next Run Simulation no longer mounts the stale volume. Merging also triggers the Loki image rebuild, now pinned to 3.7.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)